### PR TITLE
Fix wrong protobuf cmake variable when cmake < 3.6.0

### DIFF
--- a/tools/converter/CMakeLists.txt
+++ b/tools/converter/CMakeLists.txt
@@ -30,6 +30,10 @@ endif()
 
 # -----------find protobuf lib-----------
 find_package(Protobuf REQUIRED)
+if (${CMAKE_VERSION} VERSION_LESS "3.6.0")
+    set(Protobuf_LIBRARIES ${PROTOBUF_LIBRARIES})
+    set(Protobuf_INCLUDE_DIRS ${PROTOBUF_INCLUDE_DIRS})
+endif()
 
 # -----------set path-----------
 set(SRC_PATH source)

--- a/tools/converter/source/caffe/CMakeLists.txt
+++ b/tools/converter/source/caffe/CMakeLists.txt
@@ -6,8 +6,12 @@ set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 11)
 
 find_package(Protobuf REQUIRED)
+if (${CMAKE_VERSION} VERSION_LESS "3.6.0")
+    set(Protobuf_LIBRARIES ${PROTOBUF_LIBRARIES})
+    set(Protobuf_INCLUDE_DIRS ${PROTOBUF_INCLUDE_DIRS})
+endif()
 
-include_directories(${PROTOBUF_INCLUDE_DIR})
+include_directories(${Protobuf_INCLUDE_DIRS})
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 

--- a/tools/converter/source/onnx/CMakeLists.txt
+++ b/tools/converter/source/onnx/CMakeLists.txt
@@ -6,8 +6,12 @@ set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 11)
 
 find_package(Protobuf REQUIRED)
+if (${CMAKE_VERSION} VERSION_LESS "3.6.0")
+    set(Protobuf_LIBRARIES ${PROTOBUF_LIBRARIES})
+    set(Protobuf_INCLUDE_DIRS ${PROTOBUF_INCLUDE_DIRS})
+endif()
 
-include_directories(${PROTOBUF_INCLUDE_DIR})
+include_directories(${Protobuf_INCLUDE_DIRS})
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 

--- a/tools/converter/source/tensorflow/CMakeLists.txt
+++ b/tools/converter/source/tensorflow/CMakeLists.txt
@@ -6,8 +6,12 @@ set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 11)
 
 find_package(Protobuf REQUIRED)
+if (${CMAKE_VERSION} VERSION_LESS "3.6.0")
+    set(Protobuf_LIBRARIES ${PROTOBUF_LIBRARIES})
+    set(Protobuf_INCLUDE_DIRS ${PROTOBUF_INCLUDE_DIRS})
+endif()
 
-include_directories(${PROTOBUF_INCLUDE_DIR})
+include_directories(${Protobuf_INCLUDE_DIRS})
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 


### PR DESCRIPTION
According to cmake doc, FindProtobuf.cmake defines `PROTOBUF_*` instead of `Protobuf_*` in cmake < 3.6, so cmake 3.5 users (including ubuntu 16.04 users which install cmake 3.5.1 by `apt install`) will get link errors like `/usr/bin/ld: source/onnx/libonnx.so: undefined reference to google::protobuf::RepeatedField<unsigned long>::unsafe_data() const'` and fail to build converter since `Protobuf_*` is empty.

What's more, it's more proper to use `Protobuf_INCLUDE_DIRS` instead of `Protobuf_INCLUDE_DIR` according to the doc, the latter one is expected to be set by the user and even doesn't exist in cmake 3.0, so I fixed it too.

Refer: [cmake 3.5 doc](https://cmake.org/cmake/help/v3.5/module/FindProtobuf.html)
[cmake 3.6 doc](https://cmake.org/cmake/help/v3.6/module/FindProtobuf.html)
[cmake 3.0 doc](https://cmake.org/cmake/help/v3.0/module/FindProtobuf.html)