### PR TITLE
Use bash instead of /bin/sh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,7 +372,7 @@ endif()
 
 # schema generator
 add_custom_target( MNN_SCHEMA ALL
-    COMMAND /bin/sh ${CMAKE_SOURCE_DIR}/schema/generate.sh -lazy
+    COMMAND bash ${CMAKE_SOURCE_DIR}/schema/generate.sh -lazy
 )
 add_dependencies(MNN MNN_SCHEMA)
 


### PR DESCRIPTION
1. /bin/sh can be a weaker shell, and doesn't have `pushd` and `popd` (This error has been validated on ubuntu 16.04) [link](https://stackoverflow.com/questions/5193048/bin-sh-pushd-not-found)
2. bash is not always at /bin/bash