### PR TITLE
Fix missing memory header in ubuntu 16.04

### DIFF
--- a/demo/exec/pictureRecognition.cpp
+++ b/demo/exec/pictureRecognition.cpp
@@ -17,6 +17,7 @@
 #include <vector>
 #include "AutoTime.hpp"
 #include "FreeImage.h"
+#include <memory>
 using namespace MNN;
 using namespace MNN::CV;
 

--- a/demo/exec/pictureRotate.cpp
+++ b/demo/exec/pictureRotate.cpp
@@ -15,6 +15,8 @@
 #include <vector>
 #include "AutoTime.hpp"
 #include "FreeImage.h"
+#include <memory>
+
 using namespace MNN;
 using namespace MNN::CV;
 


### PR DESCRIPTION
add #include <memory> in the demo/exec/pictureRecognition.cpp and demo/exec/pictureRotate.cpp. Ubuntu 16.04 without this header in both files, the system will show errors like " error: ‘shared_ptr’ is not a member of ‘std’ std::shared_ptr<ImageProcess> pretreat(ImageProcess::create(config));" .