### PR TITLE
CMAKE_SOURCE_DIR -> CMAKE_CURRENT_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,7 +375,7 @@ endif()
 
 # schema generator
 add_custom_target( MNN_SCHEMA ALL
-    COMMAND bash ${CMAKE_SOURCE_DIR}/schema/generate.sh -lazy
+    COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/schema/generate.sh -lazy
 )
 add_dependencies(MNN MNN_SCHEMA)
 


### PR DESCRIPTION
`CMAKE_SOURCE_DIR` makes build fail when mnn is in a subdirectory, and there is no need to use `CMAKE_SOURCE_DIR` rather than `CMAKE_CURRENT_SOURCE_DIR`