### PR TITLE
fix memory header missing when compiling multiPose.cpp on ubuntu16.04

### DIFF
--- a/demo/exec/multiPose.cpp
+++ b/demo/exec/multiPose.cpp
@@ -9,6 +9,7 @@
 #include <math.h>
 #include <fstream>
 #include <iostream>
+#include <memory>
 
 #include "FreeImage.h"
 #include "ImageProcess.hpp"


### PR DESCRIPTION
When compiled using GCC 5.4 on the Ubuntu 16.04 platform, the error `‘shared_ptr’ is not a member of ‘std’` will be reported if `memory` is not included.