### PR TITLE
fix mnn_bizcode source dir path

### DIFF
--- a/tools/converter/CMakeLists.txt
+++ b/tools/converter/CMakeLists.txt
@@ -43,7 +43,7 @@ set(CAFFE_PATH ${SRC_PATH}/caffe)
 set(TENSORFLOW_PATH ${SRC_PATH}/tensorflow)
 set(ONNX_PATH ${SRC_PATH}/onnx)
 set(TFLITE_PATH ${SRC_PATH}/tflite)
-set(MNN_PATH ${SRC_PATH}/mnn)
+set(MNN_PATH ${SRC_PATH}/MNN)
 set(OPTIMIZER_PATH ${SRC_PATH}/optimizer)
 set(INCLUDE_PATH ${SRC_PATH}/include)
 

--- a/tools/converter/source/MNN/CMakeLists.txt
+++ b/tools/converter/source/MNN/CMakeLists.txt
@@ -8,6 +8,6 @@ set(CMAKE_CXX_STANDARD 11)
 include_directories(${CMAKE_SOURCE_DIR}/source/IR)
 include_directories(${CMAKE_SOURCE_DIR}/source/include)
 
-file(GLOB MNN_SRC ${CMAKE_SOURCE_DIR}/source/mnn/*)
+file(GLOB MNN_SRC ${CMAKE_SOURCE_DIR}/source/MNN/*)
 
 add_library(mnn_bizcode SHARED ${MNN_SRC})


### PR DESCRIPTION
fix compilation errors as below when executing ./tools/script/get_model.sh:

CMake Error at CMakeLists.txt:59 (add_subdirectory):
  add_subdirectory given source "source/mnn" which is not an existing
  directory

You have called ADD_LIBRARY for library mnn_bizcode without any source files. This typically indicates a problem with your CMakeLists.txt file
-- Configuring done
CMake Error: CMake can not determine linker language for target: mnn_bizcode
CMake Error: Cannot determine link language for target "mnn_bizcode".