### PR TITLE
Build flatc only, bringing speedup and avoiding errors

### DIFF
--- a/schema/generate.ps1
+++ b/schema/generate.ps1
@@ -22,7 +22,7 @@ if (-Not (Test-Path $FLATC -PathType Leaf)) {
 
   # build
   cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release ..
-  nmake
+  cmake --build . --target flatc
 
   # dir recover
   popd

--- a/schema/generate.sh
+++ b/schema/generate.sh
@@ -19,7 +19,7 @@ if [ ! -e $FLATC ]; then
   cd tmp && rm -rf *
 
   # build
-  env -i bash -l -c "cmake .. && make -j4"
+  env -i bash -l -c "cmake .. && cmake --build . --target flatc -- -j4"
 
   # dir recover
   popd > /dev/null

--- a/tools/converter/generate_schema.ps1
+++ b/tools/converter/generate_schema.ps1
@@ -20,7 +20,7 @@ if (-Not (Test-Path $FLATC -PathType Leaf)) {
 
   # build
   cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release ..
-  nmake
+  cmake --build . --target flatc
 
   # dir recover
   popd

--- a/tools/converter/generate_schema.sh
+++ b/tools/converter/generate_schema.sh
@@ -17,7 +17,7 @@ if [ ! -e $FLATC ]; then
   cd tmp && rm -rf *
 
   # build
-  env -i bash -l -c "cmake .. && make -j4"
+  env -i bash -l -c "cmake .. && cmake --build . --target flatc -- -j4"
 
   # dir recover
   popd > /dev/null


### PR DESCRIPTION
flatbuffers tests fail to compile on gcc 9.1.0

It brings speedup and avoids confusing error messages to build flatc only.