### PR TITLE
Fix paths when embedding converter into another projects

### DIFF
--- a/tools/converter/CMakeLists.txt
+++ b/tools/converter/CMakeLists.txt
@@ -36,7 +36,7 @@ if (${CMAKE_VERSION} VERSION_LESS "3.6.0")
 endif()
 
 # -----------set path-----------
-set(SRC_PATH source)
+set(SRC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/source)
 set(IR_PATH ${SRC_PATH}/IR)
 set(COMMON_PATH ${SRC_PATH}/common)
 set(CAFFE_PATH ${SRC_PATH}/caffe)

--- a/tools/converter/source/MNN/CMakeLists.txt
+++ b/tools/converter/source/MNN/CMakeLists.txt
@@ -5,9 +5,9 @@ project(mnn_bizcode)
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 11)
 
-include_directories(${CMAKE_SOURCE_DIR}/source/IR)
-include_directories(${CMAKE_SOURCE_DIR}/source/include)
+include_directories(${SRC_PATH}/IR)
+include_directories(${SRC_PATH}/include)
 
-file(GLOB MNN_SRC ${CMAKE_SOURCE_DIR}/source/MNN/*)
+file(GLOB MNN_SRC ${SRC_PATH}/MNN/*)
 
 add_library(mnn_bizcode SHARED ${MNN_SRC})

--- a/tools/converter/source/caffe/CMakeLists.txt
+++ b/tools/converter/source/caffe/CMakeLists.txt
@@ -19,10 +19,10 @@ protobuf_generate_cpp(CAFFE_PROTO_SRCS CAFFE_PROTO_HDRS
     caffe.proto
 )
 
-include_directories(${CMAKE_SOURCE_DIR}/source/IR)
-include_directories(${CMAKE_SOURCE_DIR}/source/include)
+include_directories(${SRC_PATH}/IR)
+include_directories(${SRC_PATH}/include)
 
-file(GLOB CAFFE_SRC ${CMAKE_SOURCE_DIR}/source/caffe/*)
+file(GLOB CAFFE_SRC ${SRC_PATH}/caffe/*)
 
 add_library(caffe SHARED ${CAFFE_SRC} ${CAFFE_PROTO_SRCS})
 target_link_libraries(caffe ${Protobuf_LIBRARIES})

--- a/tools/converter/source/onnx/CMakeLists.txt
+++ b/tools/converter/source/onnx/CMakeLists.txt
@@ -22,9 +22,9 @@ protobuf_generate_cpp(ONNX_PROTO_SRCS ONNX_PROTO_HDRS
     # onnx-operators-ml.proto
 )
 
-include_directories(${CMAKE_SOURCE_DIR}/source/IR)
-include_directories(${CMAKE_SOURCE_DIR}/source/include)
+include_directories(${SRC_PATH}/IR)
+include_directories(${SRC_PATH}/include)
 
-file(GLOB ONNX_SRC ${CMAKE_SOURCE_DIR}/source/onnx/*)
+file(GLOB ONNX_SRC ${SRC_PATH}/onnx/*)
 add_library(onnx SHARED ${ONNX_SRC} ${ONNX_PROTO_SRCS})
 target_link_libraries(onnx ${Protobuf_LIBRARIES})

--- a/tools/converter/source/optimizer/CMakeLists.txt
+++ b/tools/converter/source/optimizer/CMakeLists.txt
@@ -5,9 +5,9 @@ project(optimizer)
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 11)
 
-include_directories(${CMAKE_SOURCE_DIR}/source/IR)
-include_directories(${CMAKE_SOURCE_DIR}/source/include)
+include_directories(${SRC_PATH}/IR)
+include_directories(${SRC_PATH}/include)
 
-file(GLOB OPTIMIZER_SRC ${CMAKE_SOURCE_DIR}/source/optimizer/*)
+file(GLOB OPTIMIZER_SRC ${SRC_PATH}/optimizer/*)
 
 add_library(optimizer SHARED ${OPTIMIZER_SRC})

--- a/tools/converter/source/tensorflow/CMakeLists.txt
+++ b/tools/converter/source/tensorflow/CMakeLists.txt
@@ -28,10 +28,10 @@ protobuf_generate_cpp(TENSORFLOW_PROTO_SRCS TENSORFLOW_PROTO_HDRS
     versions.proto
 )
 
-include_directories(${CMAKE_SOURCE_DIR}/source/IR)
-include_directories(${CMAKE_SOURCE_DIR}/source/include)
+include_directories(${SRC_PATH}/IR)
+include_directories(${SRC_PATH}/include)
 
-file(GLOB TENSORFLOW_SRC ${CMAKE_SOURCE_DIR}/source/tensorflow/*)
+file(GLOB TENSORFLOW_SRC ${SRC_PATH}/tensorflow/*)
 
 add_library(tensorflow SHARED ${TENSORFLOW_SRC} ${TENSORFLOW_PROTO_SRCS})
 target_link_libraries(tensorflow ${Protobuf_LIBRARIES})

--- a/tools/converter/source/tflite/CMakeLists.txt
+++ b/tools/converter/source/tflite/CMakeLists.txt
@@ -5,10 +5,10 @@ project(tflite)
 set(CMAKE_CXX_STANDARD 11)
 
 
-set(TFLITE_SRC_PATH ${CMAKE_SOURCE_DIR}/source/tflite)
+set(TFLITE_SRC_PATH ${SRC_PATH}/tflite)
 
-include_directories(${CMAKE_SOURCE_DIR}/source/IR)
-include_directories(${CMAKE_SOURCE_DIR}/source/include)
+include_directories(${SRC_PATH}/IR)
+include_directories(${SRC_PATH}/include)
 include_directories(${TFLITE_SRC_PATH}/schema)
 include_directories(${TFLITE_SRC_PATH})
 


### PR DESCRIPTION
I expect to embed the converter into my own project by cmake add_subdirectory, some paths have to be fixed.