### PR TITLE
[android demo]fix permission bug for first start after install

### DIFF
--- a/demo/android/app/src/main/java/com/taobao/android/mnndemo/PortraitActivity.java
+++ b/demo/android/app/src/main/java/com/taobao/android/mnndemo/PortraitActivity.java
@@ -1,7 +1,6 @@
 package com.taobao.android.mnndemo;
 
 import android.Manifest;
-import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
@@ -21,7 +20,6 @@ import android.view.Window;
 import android.view.WindowManager;
 import android.widget.CompoundButton;
 import android.widget.Switch;
-import android.widget.Toast;
 
 import com.taobao.android.mnn.MNNForwardType;
 import com.taobao.android.mnn.MNNImageProcess;
@@ -221,19 +219,6 @@ public class PortraitActivity extends AppCompatActivity {
         } finally {
             if (canvas != null) {
                 mDrawSurfaceHolder.unlockCanvasAndPost(canvas);
-            }
-        }
-    }
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-
-        if (10 == requestCode) {
-            if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-
-            } else {
-                Toast.makeText(this, "没有获得必要的权限", Toast.LENGTH_SHORT).show();
             }
         }
     }

--- a/demo/android/app/src/main/java/com/taobao/android/mnndemo/VideoActivity.java
+++ b/demo/android/app/src/main/java/com/taobao/android/mnndemo/VideoActivity.java
@@ -207,7 +207,7 @@ public class VideoActivity extends AppCompatActivity implements AdapterView.OnIt
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             if (checkSelfPermission(Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
-                requestPermissions(new String[]{Manifest.permission.CAMERA}, 10);
+                requestPermissions(new String[]{Manifest.permission.CAMERA}, 100);
             } else {
                 handlePreViewCallBack();
             }


### PR DESCRIPTION
Tested on MI8（小米8）

The previous android demo code generated apk just crash for the first time of start after installation. 

Now it run ok for every time opening the apk.

Also remove redundant permission related function.