### PR TITLE
fix Tensor getDimensionType bug

### DIFF
--- a/source/core/Tensor.cpp
+++ b/source/core/Tensor.cpp
@@ -187,6 +187,9 @@ Tensor::DimensionType Tensor::getDimensionType() const {
     if (mDescribe->dimensionFormat == MNN_DATA_FORMAT_NHWC) {
         return Tensor::TENSORFLOW;
     }
+    else if(mDescribe->dimensionFormat == MNN_DATA_FORMAT_NC4HW4) {
+        return Tensor::CAFFE_C4;
+    }
     return Tensor::CAFFE;
 }
 


### PR DESCRIPTION
This func returns wrong result when the tensor's dimensiontype was MNN_DATA_FORMAT_NC4HW4