### PR TITLE
avoid protobuf error

### DIFF
--- a/tools/converter/CMakeLists.txt
+++ b/tools/converter/CMakeLists.txt
@@ -99,4 +99,4 @@ else()
     target_link_libraries(MNNConvert tensorflow caffe onnx tflite)
 endif()
 
-target_link_libraries(MNNConvert mnn_bizcode optimizer COMMON_LIB ${Protobuf_LIBRARY})
+target_link_libraries(MNNConvert mnn_bizcode optimizer COMMON_LIB ${Protobuf_LIBRARY} pthread)


### PR DESCRIPTION
With latest protobuf 3.9.1, MNNConvert would throw the errors if not compiled with pthread

```
[libprotobuf FATAL google/protobuf/generated_message_util.cc:783] CHECK failed: (scc->visit_status.load(std::memory_order_relaxed)) == (SCCInfoBase::kRunning): 

terminate called after throwing an instance of 'google::protobuf::FatalException'
  what():  CHECK failed: (scc->visit_status.load(std::memory_order_relaxed)) == (SCCInfoBase::kRunning): 
```

