### PR TITLE
fix inputCount=0 of convolution layer in benchmark mode

### DIFF
--- a/tools/converter/source/optimizer/PostTreatUtils.cpp
+++ b/tools/converter/source/optimizer/PostTreatUtils.cpp
@@ -842,6 +842,7 @@ void PostTreatUtils::turnInnerProduct2Convolution() {
         convP->common->strideY     = 1;
         convP->common->group       = 1;
         convP->common->outputCount = originInner->outputCount;
+        convP->common->inputCount  = originInner->weightSize / originInner->outputCount;
         convP->common->padX        = 0;
         convP->common->padY        = 0;
         convP->common->padMode     = MNN::PadMode_CAFFE;
@@ -1020,6 +1021,7 @@ void PostTreatUtils::turnGroupConvolution() {
             newConvolutionT->common->strideY     = common->strideY;
             newConvolutionT->common->group       = 1;
             newConvolutionT->common->padMode     = common->padMode;
+            newConvolutionT->common->inputCount  = srcCount / common->group;
             newConvolutionT->common->outputCount = common->outputCount / common->group;
             newConvolutionT->common->padX        = common->padX;
             newConvolutionT->common->padY        = common->padY;


### PR DESCRIPTION
When converting the fully connection layer to convolution layer or slicing the group convolution layer in benchmark mode (`MNNConverter --benchmarkModel`), the input count of the convolution layer would be zero and thus can't run with benchmark.out.

Add inputCount would solve the issue.