### PR TITLE
fix bug : memory not release in ImageProcess::Inside

### DIFF
--- a/source/cv/ImageProcess.cpp
+++ b/source/cv/ImageProcess.cpp
@@ -27,6 +27,8 @@ struct ImageProcess::Inside {
 };
 
 ImageProcess::~ImageProcess() {
+    mInside->cacheBuffer.release();
+    mInside->cacheBufferRGBA.release();
     delete mInside;
 }
 


### PR DESCRIPTION
ImageProcess class must release the memory applied by mInside in its  destructor.