### PR TITLE
Fix pydot error

### DIFF
--- a/pymnn/pip_package/MNNTools/mnnvisual.py
+++ b/pymnn/pip_package/MNNTools/mnnvisual.py
@@ -95,7 +95,7 @@ def mnn_to_dot(mnn_file):
     for idx in range(ts_num):
         ts_name = net.TensorName(idx)
         name = "tensor_" + str(idx)
-        label = ts_name
+        label = ts_name.decode()
         if isinstance(label, bytes):
             label = label.decode()
         if label == '':


### PR DESCRIPTION
mnnvisual used to throw error due to pydot unable to handle bytestrings, I added `decode()` to solve this issue.