### PR TITLE
modify binary_same_channel_broadcast function to support whInput0.x =…

### DIFF
--- a/source/backend/opencl/execution/cl/binary.cl
+++ b/source/backend/opencl/execution/cl/binary.cl
@@ -12,7 +12,11 @@ __kernel void binary_same_channel_broadcast(__read_only image2d_t input0, __read
     FLOAT4 in0, in1;
     int2 pos0, pos1;
 
-    if (whInput0.x == 1) { // Tensor 0 width length 1
+    if (whInput0.x == 1 && whInput0.y == 1) {
+        pos0 = (int2)(nhwc.w*whInput0.x, 0);
+        in0 = RI_F(input0, SAMPLER, pos0);
+        pos1 = (int2)(nhwc.w*whOutput.x+nhwc.z, nhwc.x*whOutput.y+nhwc.y);
+    } else if (whInput0.x == 1) { // Tensor 0 width length 1
         pos0 = (int2)(nhwc.w*whInput0.x, nhwc.x*whOutput.y+nhwc.y);
         in0 = RI_F(input0, SAMPLER, pos0);
         pos1 = (whInput1.y != 1) ?
@@ -24,10 +28,6 @@ __kernel void binary_same_channel_broadcast(__read_only image2d_t input0, __read
         pos1 = (whInput1.x != 1) ?
             (int2)(nhwc.w*whOutput.x+nhwc.z, nhwc.x*whOutput.y+nhwc.y) :
             (int2)(nhwc.w*whInput1.x, nhwc.x*whOutput.y+nhwc.y);
-    } else if (whInput0.x == 1 && whInput0.y == 1) {
-        pos0 = (int2)(nhwc.w*whInput0.x, 0);
-        in0 = RI_F(input0, SAMPLER, pos0);
-        pos1 = (int2)(nhwc.w*whOutput.x+nhwc.z, nhwc.x*whOutput.y+nhwc.y);
     }
     in1 = RI_F(input1, SAMPLER, pos1);
     WI_F(output, pos, OPERATOR);


### PR DESCRIPTION
…= 1 && whInput0.y == 1

这段代码应该无法执行到(whInput0.x == 1 && whInput0.y == 1)的处理分支，所以调整一下分支的前后顺序
