### PR TITLE
修改converter中新添加层的命名规则

### DIFF
--- a/express/source/Expr.cpp
+++ b/express/source/Expr.cpp
@@ -634,9 +634,8 @@ void Variable::save(const std::vector<VARP>& vars, NetT* dest) {
         for (int i = 0; i < op->inputIndexes.size(); ++i) {
             op->inputIndexes[i] = varIndex[expr.first->inputs()[i]->expr()];
         }
-        // int outputIndex = (int)dest->tensorName.size();
         if (op->name.empty()) {
-            op->name = EnumNameOpType(op->type) + numberToString(index); // numberToString(outputIndex);
+            op->name = EnumNameOpType(op->type) + numberToString(index);
         }
         op->outputIndexes.resize(expr.first->outputSize());
         auto exprOutputs = expr.first->outputs();

--- a/express/source/Expr.cpp
+++ b/express/source/Expr.cpp
@@ -634,9 +634,9 @@ void Variable::save(const std::vector<VARP>& vars, NetT* dest) {
         for (int i = 0; i < op->inputIndexes.size(); ++i) {
             op->inputIndexes[i] = varIndex[expr.first->inputs()[i]->expr()];
         }
-        int outputIndex = (int)dest->tensorName.size();
+        // int outputIndex = (int)dest->tensorName.size();
         if (op->name.empty()) {
-            op->name = EnumNameOpType(op->type) + numberToString(outputIndex);
+            op->name = EnumNameOpType(op->type) + numberToString(index); // numberToString(outputIndex);
         }
         op->outputIndexes.resize(expr.first->outputSize());
         auto exprOutputs = expr.first->outputs();


### PR DESCRIPTION
当op为替换层时（例如，ONNX/CAFFE的InnerProduct层替换为卷积层时），express/source/Expr.cpp文件的line 638 判断当前层的op->name是否被命名，如未命名需要给op->name命名。原始的命名规则为层类型（op->type）加当前网络的层数/output数（由 dest->tensorName.resize(executeOrder.size()) 得到）。层类型和层数都是固定值，如果出现多个相同类型的层（例如，dnn这种由多个全连接层组成的网络）时，所有相同类型未命名层的名字将是相同的。

这会影响到转换后mnn网络的使用：我在使用量化工具量化DNN网络时，由于所有卷积层的命名相同（有全连接层替换得到），工具里面负责统计网络层次信息的map变量中，所有的卷积层会共享一个key-value对。这就造成权值统计结果被最后一层卷积值覆盖，并导致权值统计结果的错误。导致错误的位置在calibration.cpp文件，Calibration类的_initMaps()方法，line163和line176：

```
以Calibration::_initMaps()中line163前后的代码为例:
MNN::TensorCallBackWithInfo before =[&](const std::vector<MNN::Tensor*>& nTensors, const MNN::OperatorInfo* info) {
        _opInfo[info->name()].first = nTensors; // 由于网络中一部分层次的名字相同，nTensors会被相同层次的最后一层覆盖
        if (Helper::gNeedFeatureOp.find(info->type()) != Helper::gNeedFeatureOp.end()) {
            for (auto t : nTensors) {
                if (_featureInfo.find(t) == _featureInfo.end()) {
                    _featureInfo[t] = std::shared_ptr<TensorStatistic>(
                        new TensorStatistic(t, _featureQuantizeMethod, info->name() + "__input"));
                }
            }
        }
        return false;
    };
```

在Expr.cpp文件中，我修改命名规则：层次的命名规则按照 层次类型+当前层编号 命名，可以避免命名相同的问题。