### PR TITLE
converter的防空判断

### DIFF
--- a/tools/converter/source/optimizer/merge/ConvBiasAdd.cpp
+++ b/tools/converter/source/optimizer/merge/ConvBiasAdd.cpp
@@ -25,6 +25,9 @@ static auto gRegister = []() {
         }
         auto inputs = expr->inputs();
         auto inputExpr = inputs[0]->expr().first;
+        if (inputExpr->get() == nullptr){
+            return false;
+        }
         if (inputExpr->get()->main_type() != OpParameter_Convolution2D || inputExpr->outputs().size() != 1) {
             return false;
         }


### PR DESCRIPTION
在进行模型转换的时候,有个模型无法转换成功.跟进去发现,是对空指针进行操作.所以增加了一个防空判断.