### PR TITLE
Fix get_model.sh error

### DIFF
--- a/tools/script/get_model.sh
+++ b/tools/script/get_model.sh
@@ -34,6 +34,7 @@ get_caffe1() { # model_URL, model_path, prototxt_URL, prototxt_path, model, MNN_
 
 get_tensorflow_lite() {
   if [ ! -e $4 ]; then
+    mkdir -p build
     pushd build > /dev/null
     download $1 $2.tgz && tar -xzf $2.tgz $2
     succ=$?
@@ -44,6 +45,7 @@ get_tensorflow_lite() {
 
 get_portrait_lite() {
   if [ ! -e $4 ]; then
+    mkdir -p build
     pushd build > /dev/null
     download $1 $2
     succ=$?


### PR DESCRIPTION
Create `build` folder if needed.

```
./tools/script/get_model.sh: line 37: pushd: build: No such file or directory
downloading mobilenet_v2_1.0_224.tflite.tgz ...
./tools/script/get_model.sh: line 41: ./../build/MNNConvert: No such file or directory
downloading mobilenet_v2_1.0_224_quant.tflite.tgz ...
./tools/script/get_model.sh: line 41: ./../build/MNNConvert: No such file or directory
downloading deeplabv3_257_mv_gpu.tflite ...
./tools/script/get_model.sh: line 51: ./../build/MNNConvert: No such file or directory
./tools/script/get_model.sh: line 115: popd: directory stack empty
```