### PR TITLE
Express _Split support NetSource_CAFFE format input

### DIFF
--- a/include/MNN/expr/NeuralNetWorkOp.hpp
+++ b/include/MNN/expr/NeuralNetWorkOp.hpp
@@ -11,6 +11,7 @@ namespace Express {
 enum PaddingMode {CAFFE, VALID, SAME};
 enum PoolingMode {MAXPOOL, AVEPOOL};
 enum PadValueMode {CONSTANT, REFLECT, SYMMETRIC};
+enum NetSourceMode {CAFFE_MODE, TENSORFLOW_MODE, TFLITE_MODE, ONNX_MODE};
 MNN_PUBLIC VARP _Input(INTS shape = {}, Dimensionformat data_format = NC4HW4, halide_type_t dtype = halide_type_of<float>()) ;
 MNN_PUBLIC VARP _Clone(VARP source, bool deepCopy = false);
 
@@ -49,7 +50,7 @@ MNN_PUBLIC VARP _PRelu(VARP x, std::vector<float> &&slopes);
 MNN_PUBLIC VARP _Softmax(VARP logits, int axis = -1);
 MNN_PUBLIC VARP _Softplus(VARP features);
 MNN_PUBLIC VARP _Softsign(VARP features);
-MNN_PUBLIC std::vector<VARP> _Split(VARP value, INTS size_splits, int axis = 0);
+MNN_PUBLIC std::vector<VARP> _Split(VARP value, INTS size_splits, NetSourceMode source = TENSORFLOW_MODE, int axis = 0);
 MNN_PUBLIC VARP _Slice(VARP x, VARP starts, VARP sizes);
 MNN_PUBLIC VARP _StridedSlice(VARP x, VARP begin, VARP end, VARP strided, halide_type_t type,
                                       int32_t beginMask, int32_t endMask, int32_t ellipsisMask,

--- a/test/expr/ReplaceTest.cpp
+++ b/test/expr/ReplaceTest.cpp
@@ -160,7 +160,7 @@ public:
             return false;
         }
         auto d0 = _Const(7.f, {1, 3, 1, 1}, NHWC);
-        auto d = _Split(d0, {1, 1, 1}, 1)[0];
+        auto d = _Split(d0, {1, 1, 1}, NetSourceMode::TENSORFLOW_MODE, 1)[0];
         Variable::replace(c3, d);
         r3 = b1->readMap<float>();
         if (29.0f != r3[0]) {

--- a/test/op/SplitTest.cpp
+++ b/test/op/SplitTest.cpp
@@ -21,15 +21,15 @@ public:
         const float input_data[] = {1.0 , 2.0, 5.0, 6.0, 3.0, 4.0, 7.0, 8.0};
         auto inputPtr          = input->writeMap<float>();
         memcpy(inputPtr, input_data, 8 * sizeof(float));
-        auto outputs = _Split(input, {1, 3}, 1);
+        auto outputs = _Split(input, {1, 3}, NetSourceMode::TENSORFLOW_MODE, 1);
         const std::vector<float> expectedOutput0 = {1.0 , 3.0};
         auto gotOutput0 = outputs[0]->readMap<float>();
         if (!checkVector<float>(gotOutput0, expectedOutput0.data(), 2, 0.0001)) {
             MNN_ERROR("SplitTest test failed!\n");
             return false;
         }
-	const std::vector<int> expectedDim0 = {2, 1};
-	auto gotDim0 = outputs[0]->getInfo()->dim;
+        const std::vector<int> expectedDim0 = {2, 1};
+        auto gotDim0 = outputs[0]->getInfo()->dim;
         if (!checkVector<int>(gotDim0.data(), expectedDim0.data(), 2, 0)) {
             MNN_ERROR("SplitTest test failed!\n");
             return false;
@@ -49,4 +49,44 @@ public:
         return true;
     }
 };
+class SplitC4Test : public MNNTestCase {
+public:
+    virtual ~SplitC4Test() = default;
+    virtual bool run() {
+        auto input = _Input({1, 4, 1, 2}, NCHW);
+        input->setName("input");
+        // set input data
+        const float input_data[] = {1.0 , 2.0, 5.0, 6.0, 3.0, 4.0, 7.0, 8.0};
+        auto inputPtr          = input->writeMap<float>();
+        memcpy(inputPtr, input_data, 8 * sizeof(float));
+        auto outputs = _Split(_Convert(input, NC4HW4), {1}, NetSourceMode::CAFFE_MODE, 1);
+        const std::vector<float> expectedOutput0 = {1.0 , 2.0};
+        auto gotOutput0 = _Convert(outputs[0], NCHW)->readMap<float>();
+        if (!checkVector<float>(gotOutput0, expectedOutput0.data(), 2, 0.0001)) {
+            MNN_ERROR("SplitTest test failed!\n");
+            return false;
+        }
+        const std::vector<int> expectedDim0 = {1, 1, 1, 2};
+        auto gotDim0 = outputs[0]->getInfo()->dim;
+        if (!checkVector<int>(gotDim0.data(), expectedDim0.data(), 4, 0)) {
+            MNN_ERROR("SplitTest test failed!\n");
+            return false;
+        }
+        const std::vector<float> expectedOutput1 = {5.0, 6.0, 3.0, 4.0, 7.0, 8.0};
+        auto gotOutput1 = _Convert(outputs[1], NCHW)->readMap<float>();
+        if (!checkVector<float>(gotOutput1, expectedOutput1.data(), 6, 0.0001)) {
+            MNN_ERROR("SplitTest test failed!\n");
+            return false;
+        }
+        const std::vector<int> expectedDim1 = {1, 3, 1, 2};
+        auto gotDim1 = outputs[1]->getInfo()->dim;
+        if (!checkVector<int>(gotDim1.data(), expectedDim1.data(), 4, 0)) {
+            MNN_ERROR("SplitTest test failed!\n");
+            return false;
+        }
+        return true;
+    }
+};
+
 MNNTestSuiteRegister(SplitTest, "op/split");
+MNNTestSuiteRegister(SplitC4Test, "op/splitC4");

--- a/tools/train/source/demo/nnGradTest.cpp
+++ b/tools/train/source/demo/nnGradTest.cpp
@@ -135,8 +135,8 @@ public:
             targetValue        = _Concat({targetValue1, targetValue2}, 1);
             predictValue       = _Concat({predictValue1, predictValue2}, 1);
 
-            auto slicetarget  = _Split(targetValue, {2}, 2);
-            auto slicePredict = _Split(predictValue, {2}, 2);
+            auto slicetarget  = _Split(targetValue, {2}, TENSORFLOW_MODE, 2);
+            auto slicePredict = _Split(predictValue, {2}, TENSORFLOW_MODE, 2);
             targetValue       = slicetarget[0];
             predictValue      = slicePredict[0];
             targetValue       = _Convert(targetValue, NCHW);

--- a/tools/train/source/grad/ConcatGrad.cpp
+++ b/tools/train/source/grad/ConcatGrad.cpp
@@ -29,7 +29,7 @@ public:
             auto input = expr->inputs()[i];
             points[i]  = input->getInfo()->dim[axis];
         }
-        res = _Split(backwardOutput[0], points, axis);
+        res = _Split(backwardOutput[0], points, TENSORFLOW_MODE, axis);
         return res;
     }
 };

--- a/tools/train/source/module/NN.cpp
+++ b/tools/train/source/module/NN.cpp
@@ -452,15 +452,15 @@ public:
         mSplitInput = {iC0, iC1};
 
         MNN_PRINT("Octave: %d, %d -> %d - %d, %d-%d\n", option.channel[0], option.channel[1], iC0, iC1, oC0, oC1);
-        auto splitBias = _Split(bias * _Scalar<float>(0.5f), {oC0, oC1}, 0);
+        auto splitBias = _Split(bias * _Scalar<float>(0.5f), {oC0, oC1}, TENSORFLOW_MODE, 0);
         mLBias         = splitBias[0];
         mHBias         = splitBias[1];
         mLBias.fix(VARP::TRAINABLE);
         mHBias.fix(VARP::TRAINABLE);
 
-        auto splitWeight = _Split(weight, {oC0, oC1}, 0);
-        auto lw          = _Split(splitWeight[0], {iC0, iC1}, 1);
-        auto hw          = _Split(splitWeight[1], {iC0, iC1}, 1);
+        auto splitWeight = _Split(weight, {oC0, oC1}, TENSORFLOW_MODE, 0);
+        auto lw          = _Split(splitWeight[0], {iC0, iC1}, TENSORFLOW_MODE, 1);
+        auto hw          = _Split(splitWeight[1], {iC0, iC1}, TENSORFLOW_MODE, 1);
         mLLW             = lw[0];
         mLHW             = lw[1];
         mHLW             = hw[0];
@@ -481,7 +481,7 @@ public:
     }
     virtual std::vector<Express::VARP> onForward(const std::vector<Express::VARP>& inputs) override {
         auto input      = _Convert(inputs[0], NC4HW4);
-        auto inputSplit = _Split(input, mSplitInput, 1);
+        auto inputSplit = _Split(input, mSplitInput, TENSORFLOW_MODE, 1);
         auto XL         = inputSplit[0];
         auto XH         = inputSplit[1];
         if (input->getInfo()->dim[3] < 2) {


### PR DESCRIPTION
Express `_Split` support `NetSource_TENSORFLOW` format by default. And does not support `NetSource_CAFFE` input format. So add support for It. 