### PR TITLE
feat: Add Transpose B support to Opencl MatMul

### DIFF
--- a/source/backend/opencl/execution/EltwiseExecution.cpp
+++ b/source/backend/opencl/execution/EltwiseExecution.cpp
@@ -60,8 +60,13 @@ ErrorCode EltwiseExecution::onResize(const std::vector<Tensor *> &inputs, const 
 
         auto &unit  = (i >= 2) ? mUnits[i - 1] : mUnits[i];
         int dimension = (i >= 2) ? inputs[i]->dimensions() : inputs[i + 1]->dimensions();
+        int nums = 1;
+        const auto& shape = (i >= 2) ? inputs[i]->shape() : inputs[i + 1]->shape();
+        for (auto axis_len:shape) {
+            nums*=axis_len;
+        }
         const Tensor* input0 = (i >= 2) ? outputs[0] : inputs[0];
-        if(dimension == 0) {
+        if(dimension == 0 || nums == 1) {
             auto input = (i >= 2) ? inputs[i] : inputs[i + 1];
             unit.kernel = runTime->buildKernel("binary", "binary_value", mBuildOptions);
             unit.kernel.setArg(0, openCLImage(input0));

--- a/source/backend/opencl/execution/MatmulExecution.hpp
+++ b/source/backend/opencl/execution/MatmulExecution.hpp
@@ -18,13 +18,15 @@ namespace OpenCL {
 
 class MatMulExecution : public Execution {
 public:
-    MatMulExecution(const std::vector<Tensor *> &inputs, const MNN::Op *op, Backend *backend);
+    MatMulExecution(const std::vector<Tensor *> &inputs, const MNN::Op *op, Backend *backend, bool transposeA, bool transposeB);
     virtual ~MatMulExecution() = default;
 
     virtual ErrorCode onExecute(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) override;
     virtual ErrorCode onResize(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) override;
 
 private:
+    bool mTransposeA;
+    bool mTransposeB;
     cl::Kernel mKernel;
     uint32_t mMaxWorkGroupSize;
     std::vector<int> mInput0Shape;

--- a/source/backend/opencl/execution/cl/binary.cl
+++ b/source/backend/opencl/execution/cl/binary.cl
@@ -70,8 +70,13 @@ __kernel void binary_1toM_channel_broadcast_on_1wh(__read_only image2d_t input0,
 
     FLOAT4 in0, in1;
     int2 pos0, pos1;
-
-    if (whInput0.x == 1) { // Tensor 0 width length 1
+    if (whInput0.x == 1 && whInput0.y == 1) {
+        pos0 = (int2)(0, 0);
+        FLOAT4 value = RI_F(input0, SAMPLER, pos0);
+        in0 = (FLOAT4)(value.x);
+        pos1 = (int2)(nhwc.w*whOutput.x+nhwc.z, nhwc.x*whOutput.y+nhwc.y);
+    }
+    else if (whInput0.x == 1) { // Tensor 0 width length 1
         pos0 = (int2)(0, nhwc.y);
         FLOAT4 value = RI_F(input0, SAMPLER, pos0);
         in0 = (FLOAT4)(value.x);
@@ -83,13 +88,8 @@ __kernel void binary_1toM_channel_broadcast_on_1wh(__read_only image2d_t input0,
         FLOAT4 value = RI_F(input0, SAMPLER, pos0);
         in0 = (FLOAT4)(value.x);
         pos1 = (whInput1.x != 1) ?
-            (int2)(nhwc.w*whOutput.x+nhwc.z, nhwc.x*whOutput.y+nhwc.y) :
-            (int2)(nhwc.w*whInput1.x, nhwc.x*whOutput.y+nhwc.y);
-    } else if (whInput0.x == 1 && whInput0.y == 1) {
-        pos0 = (int2)(0, 0);
-        FLOAT4 value = RI_F(input0, SAMPLER, pos0);
-        in0 = (FLOAT4)(value.x);
-        pos1 = (int2)(nhwc.w*whOutput.x+nhwc.z, nhwc.x*whOutput.y+nhwc.y);
+               (int2)(nhwc.w * whOutput.x + nhwc.z, nhwc.x * whOutput.y + nhwc.y) :
+               (int2)(nhwc.w * whInput1.x, nhwc.x * whOutput.y + nhwc.y);
     }
     in1 = RI_F(input1, SAMPLER, pos1);
     WI_F(output, pos, OPERATOR);


### PR DESCRIPTION
1. Add Transpose B support to Opencl MatMul
2. Fix binary operator when the second operand is scalar, but its dimension is not 0, e.g, 1x1x1x1.

说明：
1. Opencl里边的MatMul不支持transpose B操作，pytorch导入ONNX的FC 层会有transpose B，用opencl backend会导致计算不对。
2. binary 算子里边，如果第二个操作数是一个数，按理说应该调用binary_value这个opencl kernel，但是有的时候这个标量维度是1，结果导致去调用其他kernel，发生错误。
3. binary 算子里边，出现了if A ... else if B... else if A && B，这个11月的一个PR里也有，但是尚未patch上。
