### PR TITLE
BugFix: converter optimizer forget to copy 「outputName」

### DIFF
--- a/tools/converter/source/optimizer/PostConverter.cpp
+++ b/tools/converter/source/optimizer/PostConverter.cpp
@@ -141,6 +141,7 @@ std::unique_ptr<MNN::NetT> optimizeNet(std::unique_ptr<MNN::NetT>& originNet, bo
         auto outputs = program->outputs();
         newNet->sourceType = originNet->sourceType;
         newNet->bizCode = originNet->bizCode;
+        newNet->outputName = originNet->outputName;
         Variable::save(outputs, newNet.get());
     }
 


### PR DESCRIPTION
Problem Inference:
1. The json file from DumpMNN2json will not include outputName info
2. Inference model.mnn will not enable to get multi-outputs
3. Inference model.mnn perhaps get wrong output.