### PR TITLE
Don't increase reference count when extracting a block from a non-splitable freelist

### DIFF
--- a/source/core/BufferAllocator.cpp
+++ b/source/core/BufferAllocator.cpp
@@ -167,7 +167,7 @@ void* BufferAllocator::getFromFreeList(FREELIST* list, size_t size, bool permite
 
     // update parent use count
     void* pointer = x->second->pointer;
-    if (nullptr != x->second->parent) {
+    if (permiteSplit && nullptr != x->second->parent) {
         x->second->parent->useCount += 1;
     }
 


### PR DESCRIPTION
... since returning a block to a non-mergeable free list does not decrement this count.

Looks like a bug for me that could lead to the leak of free memory blocks. Please verify if this is really so. Found when looking for a different memory bug.