### PR TITLE
TFLITE PRelu support and fixing vulkan validation errors

### DIFF
--- a/source/backend/vulkan/backend/VulkanBackend.cpp
+++ b/source/backend/vulkan/backend/VulkanBackend.cpp
@@ -367,7 +367,10 @@ const VulkanTensor* VulkanBackend::findTensor(uint64_t deviceId) const {
 void VulkanBackend::_allocHostBuffer(size_t size) const {
     if (mHostBuffer.get() == nullptr || mHostBuffer->size() < size) {
         mHostBuffer =
-            std::make_shared<VulkanBuffer>(getMemoryPool(), false, size, nullptr, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
+            std::make_shared<VulkanBuffer>(getMemoryPool(), false, size, nullptr,
+                                           VK_BUFFER_USAGE_STORAGE_BUFFER_BIT |
+                                           VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
+                                           VK_BUFFER_USAGE_TRANSFER_DST_BIT,
                                            VK_SHARING_MODE_EXCLUSIVE, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
         mConverters.clear();
     }
@@ -378,7 +381,7 @@ bool VulkanBackend::addCreator(OpType t, Creator* c) {
     return true;
 }
 
-void VulkanBackend::copyBufferToImage(const VulkanBuffer* buffer, const VulkanImage* image) const {
+void VulkanBackend::copyBufferToImage(const VulkanBuffer* buffer, const VulkanImage* image, VkImageLayout finalLayout) const {
     std::vector<int> dimVector = image->dims();
     if (image->format() != VK_FORMAT_R16G16B16A16_SFLOAT) {
         VkBufferImageCopy copyRegions;
@@ -397,8 +400,11 @@ void VulkanBackend::copyBufferToImage(const VulkanBuffer* buffer, const VulkanIm
         std::unique_ptr<VulkanCommandPool::Buffer> cmdbuffer(
             const_cast<VulkanCommandPool::Buffer*>(mCmdPool->allocBuffer()));
         cmdbuffer->begin(0);
+        cmdbuffer->barrierImageIfNeeded(image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
         vkCmdCopyBufferToImage(cmdbuffer->get(), buffer->buffer(), image->get(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                                1, &copyRegions);
+        if (finalLayout != VK_IMAGE_LAYOUT_UNDEFINED)
+            cmdbuffer->barrierImageIfNeeded(image, finalLayout);
         cmdbuffer->end();
         mCmdPool->submitAndWait(cmdbuffer->get());
     }
@@ -436,12 +442,14 @@ void VulkanBackend::copyBufferToImage(const VulkanBuffer* buffer, const VulkanIm
         const_cast<VulkanCommandPool::Buffer*>(mCmdPool->allocBuffer()));
     cmdbuffer->begin(0);
     cmdbuffer->barrierImageIfNeeded(image, VK_IMAGE_LAYOUT_GENERAL);
-    sets->writeImage(image->view(), mSampler->get(), image->layout(), 0);
+    sets->writeImage(image->view(), mSampler->get(), VK_IMAGE_LAYOUT_GENERAL, 0);
     sets->writeBuffer(buffer->buffer(), 1, buffer->size());
     sets->writeBuffer(constBuffer->buffer(), 2, constBuffer->size());
     transformPipeline->bind(cmdbuffer->get(), sets->get());
     vkCmdDispatch(cmdbuffer->get(), UP_DIV(image->width(), localX), UP_DIV(image->height(), localY),
                   UP_DIV(image->depth(), localZ));
+    if (finalLayout != VK_IMAGE_LAYOUT_UNDEFINED)
+        cmdbuffer->barrierImageIfNeeded(image, finalLayout);
     cmdbuffer->end();
     mCmdPool->submitAndWait(cmdbuffer->get());
 }

--- a/source/backend/vulkan/backend/VulkanBackend.cpp
+++ b/source/backend/vulkan/backend/VulkanBackend.cpp
@@ -357,6 +357,10 @@ const VulkanTensor* VulkanBackend::findTensor(uint64_t deviceId) const {
     if (iter != mAllBuffers.end()) {
         return iter->second.get();
     }
+    auto iter2 = mStaticeBuffers.find(deviceId);
+    if (iter2 != mStaticeBuffers.end()) {
+        return iter2->second.get();
+    }
     return nullptr;
 }
 

--- a/source/backend/vulkan/backend/VulkanBackend.hpp
+++ b/source/backend/vulkan/backend/VulkanBackend.hpp
@@ -81,7 +81,7 @@ public:
         return mGpuType;
     }
 
-    void copyBufferToImage(const VulkanBuffer* buffer, const VulkanImage* image) const;
+    void copyBufferToImage(const VulkanBuffer* buffer, const VulkanImage* image, VkImageLayout finalLayout = VK_IMAGE_LAYOUT_UNDEFINED) const;
     const VulkanSampler* getCommonSampler() const {
         return mSampler.get();
     }

--- a/source/backend/vulkan/component/VulkanBuffer.cpp
+++ b/source/backend/vulkan/component/VulkanBuffer.cpp
@@ -39,9 +39,11 @@ VulkanBuffer::~VulkanBuffer() {
     }
 }
 void* VulkanBuffer::map(int start, int size) const {
+    const auto& limits = mPool.device().proty().limits;
     if (size < 0) {
         size = mSize;
     }
+    size = UP_DIV(size, limits.nonCoherentAtomSize) * limits.nonCoherentAtomSize;
     void* data = nullptr;
     CALL_VK(mPool.device().mapMemory(mMemory->get(), start, size, 0, &data));
     return data;
@@ -59,9 +61,11 @@ void VulkanBuffer::release() {
 
 void VulkanBuffer::flush(bool write, int start, int size) const {
     VkMappedMemoryRange range;
+    const auto& limits = mPool.device().proty().limits;
+    range.sType  = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
     range.memory = mMemory->get();
     range.offset = start;
-    range.size   = size;
+    range.size   = UP_DIV(size, limits.nonCoherentAtomSize) * limits.nonCoherentAtomSize;
     range.pNext  = nullptr;
 
     if (write) {

--- a/source/backend/vulkan/component/VulkanCommandPool.hpp
+++ b/source/backend/vulkan/component/VulkanCommandPool.hpp
@@ -13,6 +13,7 @@
 #include "backend/vulkan/component/VulkanDevice.hpp"
 #include "backend/vulkan/vulkan/vulkan_wrapper.h"
 namespace MNN {
+class VulkanImage;
 class VulkanCommandPool : public NonCopyable {
 public:
     VulkanCommandPool(const VulkanDevice& dev);
@@ -31,6 +32,7 @@ public:
         void end() const;
         void barrierSource(VkBuffer source, size_t start, size_t end) const;
         void barrierImage(VkImage source, VkImageLayout oldLayout, VkImageLayout newLayout) const;
+        void barrierImageIfNeeded(const VulkanImage* image, VkImageLayout newLayout) const;
 
     private:
         VkCommandBuffer mBuffer;

--- a/source/backend/vulkan/component/VulkanDevice.cpp
+++ b/source/backend/vulkan/component/VulkanDevice.cpp
@@ -477,6 +477,7 @@ const VkResult VulkanDevice::createDescriptorPool(VkDescriptorPool& descriptorPo
     poolInfo.poolSizeCount              = poolSizeCount;
     poolInfo.pPoolSizes                 = pPoolSizes;
     poolInfo.maxSets                    = 1;
+    poolInfo.flags                      = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
     return vkCreateDescriptorPool(mDevice, &poolInfo, allocator, &descriptorPool);
 }
 

--- a/source/backend/vulkan/component/VulkanDevice.cpp
+++ b/source/backend/vulkan/component/VulkanDevice.cpp
@@ -297,7 +297,7 @@ const VkResult VulkanDevice::createImage(VkImage& image, const VkImageType image
     info.format            = format;
     info.tiling            = VK_IMAGE_TILING_OPTIMAL;
     info.initialLayout     = VK_IMAGE_LAYOUT_UNDEFINED;
-    info.usage             = VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    info.usage             = VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     info.samples           = VK_SAMPLE_COUNT_1_BIT;
     info.sharingMode       = VK_SHARING_MODE_EXCLUSIVE;
     info.pNext             = nullptr;

--- a/source/backend/vulkan/component/VulkanImage.cpp
+++ b/source/backend/vulkan/component/VulkanImage.cpp
@@ -78,6 +78,7 @@ VulkanImage::VulkanImage(const VulkanMemoryPool& pool, bool seperate, const std:
     mFormat     = format;
     // FUNC_PRINT(format);
     CALL_VK(mDevice.createImage(mImage, imageType, mWidth, mHeight, mDepth, format));
+    mLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     VkMemoryRequirements memRequirements;
     mDevice.getImageMemoryRequirements(mImage, memRequirements);

--- a/source/backend/vulkan/component/VulkanImage.hpp
+++ b/source/backend/vulkan/component/VulkanImage.hpp
@@ -57,6 +57,12 @@ public:
     inline VkFormat format() const {
         return mFormat;
     }
+    inline VkImageLayout layout() const {
+        return mLayout;
+    }
+    inline void setLayout(VkImageLayout layout) {
+        mLayout = layout;
+    }
 
     void release();
 
@@ -64,6 +70,7 @@ private:
     VkImage mImage;
     VkImageView mImageView;
     VkFormat mFormat;
+    VkImageLayout mLayout;
     const VulkanDevice& mDevice;
     int mWidth;
     int mHeight;

--- a/source/backend/vulkan/component/VulkanPipeline.cpp
+++ b/source/backend/vulkan/component/VulkanPipeline.cpp
@@ -132,6 +132,8 @@ void VulkanPipeline::DescriptorSet::writeBuffer(VkBuffer buffer, int bindIndex, 
     sourceInfo.buffer        = buffer;
     sourceInfo.offset        = offset;
     sourceInfo.range         = size;
+
+    writeSet.sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
     writeSet.descriptorCount = 1;
     writeSet.descriptorType  = mPipeline->argType(bindIndex);
     writeSet.dstBinding      = bindIndex;
@@ -149,6 +151,7 @@ void VulkanPipeline::DescriptorSet::writeImage(VkImageView view, VkSampler sampl
     sourceInfo.imageLayout = layout;
     sourceInfo.sampler     = sampler;
 
+    writeSet.sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
     writeSet.descriptorCount = 1;
     writeSet.descriptorType  = mPipeline->argType(bind);
     writeSet.dstBinding      = bind;

--- a/source/backend/vulkan/component/VulkanTensor.cpp
+++ b/source/backend/vulkan/component/VulkanTensor.cpp
@@ -39,7 +39,10 @@ VulkanTensor::VulkanTensor(const Tensor* shape, const VulkanMemoryPool& pool, bo
                                                shape->getType());
     } else {
         // Compute Shader don't support uint8 / int8 / float16 / uint64, all use int32/float32
-        mBuffer = std::make_shared<VulkanBuffer>(pool, seperate, getAlignSize(shape) * sizeof(float));
+        mBuffer = std::make_shared<VulkanBuffer>(pool, seperate, getAlignSize(shape) * sizeof(float), nullptr,
+                                                 VK_BUFFER_USAGE_STORAGE_BUFFER_BIT |
+                                                 VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
+                                                 VK_BUFFER_USAGE_TRANSFER_DST_BIT);
     }
 }
 void VulkanTensor::release() {

--- a/source/backend/vulkan/execution/VulkanBasicExecution.cpp
+++ b/source/backend/vulkan/execution/VulkanBasicExecution.cpp
@@ -31,8 +31,9 @@ ErrorCode VulkanBasicExecutionDirect::onResize(const std::vector<Tensor *> &inpu
             continue;
         }
         if (nullptr != vkTensor->image()) {
-            mCmdBuffer->barrierImage(vkTensor->image()->get(), VK_IMAGE_LAYOUT_GENERAL,
-                                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+            mCmdBuffer->barrierImageIfNeeded(vkTensor->image(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+            // mCmdBuffer->barrierImage(vkTensor->image()->get(), VK_IMAGE_LAYOUT_GENERAL,
+            //                          VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
         } else {
             MNN_ASSERT(vkTensor->buffer() != nullptr);
             mCmdBuffer->barrierSource(vkTensor->buffer()->buffer(), 0, vkTensor->buffer()->size());
@@ -57,8 +58,9 @@ ErrorCode VulkanBasicExecutionInDirect::onResize(const std::vector<Tensor *> &in
             continue;
         }
         if (nullptr != vkTensor->image()) {
-            mCmdBuffer->barrierImage(vkTensor->image()->get(), VK_IMAGE_LAYOUT_GENERAL,
-                                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+            mCmdBuffer->barrierImageIfNeeded(vkTensor->image(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+            // mCmdBuffer->barrierImage(vkTensor->image()->get(), VK_IMAGE_LAYOUT_GENERAL,
+            //                          VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
         } else {
             MNN_ASSERT(vkTensor->buffer() != nullptr);
             mCmdBuffer->barrierSource(vkTensor->buffer()->buffer(), 0, vkTensor->buffer()->size());

--- a/source/backend/vulkan/execution/VulkanBinary.cpp
+++ b/source/backend/vulkan/execution/VulkanBinary.cpp
@@ -173,8 +173,10 @@ ErrorCode VulkanBinary::onEncode(const std::vector<Tensor*>& inputs, const std::
                                        VK_IMAGE_LAYOUT_GENERAL, 0);
             auto input0T = vkBn->findTensor(input0->deviceId());
             auto input1T = vkBn->findTensor(input1->deviceId());
-            cmdBuffer->barrierImage(input0T->image()->get(), VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-            cmdBuffer->barrierImage(input1T->image()->get(), VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+            cmdBuffer->barrierImageIfNeeded(input0T->image(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+            cmdBuffer->barrierImageIfNeeded(input1T->image(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+            // cmdBuffer->barrierImage(input0T->image()->get(), VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+            // cmdBuffer->barrierImage(input1T->image()->get(), VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
             mDescriptorSet->writeImage(reinterpret_cast<VkImageView>(input0->deviceId()), sampler->get(),
                                        VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
             mDescriptorSet->writeImage(reinterpret_cast<VkImageView>(input1->deviceId()), sampler->get(),
@@ -211,8 +213,10 @@ ErrorCode VulkanBinary::onEncode(const std::vector<Tensor*>& inputs, const std::
                 auto sampler = vkBn->getCommonSampler();
                 auto input0T = vkBn->findTensor(input0->deviceId());
                 auto input1T = vkBn->findTensor(input1->deviceId());
-                cmdBuffer->barrierImage(input0T->image()->get(), VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-                cmdBuffer->barrierImage(input1T->image()->get(), VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+                cmdBuffer->barrierImageIfNeeded(input0T->image(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+                cmdBuffer->barrierImageIfNeeded(input1T->image(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+                // cmdBuffer->barrierImage(input0T->image()->get(), VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+                // cmdBuffer->barrierImage(input1T->image()->get(), VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
                 newSet->writeImage(reinterpret_cast<VkImageView>(output->deviceId()), sampler->get(),
                                            VK_IMAGE_LAYOUT_GENERAL, 0);
                 newSet->writeImage(reinterpret_cast<VkImageView>(input0->deviceId()), sampler->get(),

--- a/source/backend/vulkan/execution/VulkanBinary.cpp
+++ b/source/backend/vulkan/execution/VulkanBinary.cpp
@@ -171,8 +171,10 @@ ErrorCode VulkanBinary::onEncode(const std::vector<Tensor*>& inputs, const std::
             auto sampler = vkBn->getCommonSampler();
             mDescriptorSet->writeImage(reinterpret_cast<VkImageView>(output->deviceId()), sampler->get(),
                                        VK_IMAGE_LAYOUT_GENERAL, 0);
+            auto outputT = vkBn->findTensor(output->deviceId());
             auto input0T = vkBn->findTensor(input0->deviceId());
             auto input1T = vkBn->findTensor(input1->deviceId());
+            cmdBuffer->barrierImageIfNeeded(outputT->image(), VK_IMAGE_LAYOUT_GENERAL);
             cmdBuffer->barrierImageIfNeeded(input0T->image(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
             cmdBuffer->barrierImageIfNeeded(input1T->image(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
             // cmdBuffer->barrierImage(input0T->image()->get(), VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
@@ -211,8 +213,10 @@ ErrorCode VulkanBinary::onEncode(const std::vector<Tensor*>& inputs, const std::
                 const int icDiv4 = UP_DIV(input0->channel(), 4);
                 auto total = icDiv4 * input0->batch() * iw * ih;
                 auto sampler = vkBn->getCommonSampler();
+                auto outputT = vkBn->findTensor(output->deviceId());
                 auto input0T = vkBn->findTensor(input0->deviceId());
                 auto input1T = vkBn->findTensor(input1->deviceId());
+                cmdBuffer->barrierImageIfNeeded(outputT->image(), VK_IMAGE_LAYOUT_GENERAL);
                 cmdBuffer->barrierImageIfNeeded(input0T->image(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
                 cmdBuffer->barrierImageIfNeeded(input1T->image(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
                 // cmdBuffer->barrierImage(input0T->image()->get(), VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);

--- a/source/backend/vulkan/execution/VulkanConcat.cpp
+++ b/source/backend/vulkan/execution/VulkanConcat.cpp
@@ -104,6 +104,13 @@ ErrorCode VulkanConcatImageImpl::encodeImageImpl(const std::vector<Tensor*>& inp
         constBuffer->unmap();
         std::shared_ptr<VulkanPipeline::DescriptorSet> desSet;
         desSet.reset(pipeline->createSet());
+
+        auto vkOutput = mVkbackend->findTensor(output->deviceId());
+        auto vkInput = mVkbackend->findTensor(input->deviceId());
+
+        cmdBuffer->barrierImageIfNeeded(vkOutput->image(), VK_IMAGE_LAYOUT_GENERAL);
+        cmdBuffer->barrierImageIfNeeded(vkInput->image(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        
         desSet->writeImage(reinterpret_cast<VkImageView>(output->deviceId()), mSampler->get(), VK_IMAGE_LAYOUT_GENERAL,
                            0);
         desSet->writeImage(reinterpret_cast<VkImageView>(input->deviceId()), mSampler->get(),

--- a/source/backend/vulkan/execution/VulkanConvolution.hpp
+++ b/source/backend/vulkan/execution/VulkanConvolution.hpp
@@ -53,6 +53,7 @@ public:
             dim[0] = image->width();
             dim[1] = image->height();
             mConstBuffer->unmap();
+            cmdBuffer->barrierImageIfNeeded(image, VK_IMAGE_LAYOUT_GENERAL);
             mSets->writeImage(image->view(), mBackend->getCommonSampler()->get(), VK_IMAGE_LAYOUT_GENERAL, 0);
             mSets->writeBuffer(buffer, 1, bufferSize);
             mSets->writeBuffer(mConstBuffer->buffer(), 2, mConstBuffer->size());

--- a/source/backend/vulkan/execution/VulkanConvolutionWinograd.cpp
+++ b/source/backend/vulkan/execution/VulkanConvolutionWinograd.cpp
@@ -161,7 +161,7 @@ ErrorCode VulkanConvolutionWinograd::onEncode(const std::vector<Tensor*>& inputs
         mWinogradConst->unmap();
     }
 
-    mMultier->prepare(wPiece * hPiece);
+    mMultier->prepare(cmdBuffer, wPiece * hPiece);
     mOffsetsBuffer.resize(sliceNumber * sliceNumber);
     mSourceTransformSet.resize(sliceNumber * sliceNumber);
     mDestTransformSet.resize(sliceNumber * sliceNumber);

--- a/source/backend/vulkan/execution/VulkanConvolutionWinograd.cpp
+++ b/source/backend/vulkan/execution/VulkanConvolutionWinograd.cpp
@@ -65,7 +65,7 @@ VulkanConvolutionWinograd::VulkanConvolutionWinograd(VulkanBackend* backend, con
         ::memset(ptr, 0, ALIGN_UP4(co) * sizeof(float));
         ::memcpy(ptr, biasPtr, co * sizeof(float));
         biasBuffer->unmap();
-        backend->copyBufferToImage(biasBuffer.get(), mBias.get());
+        backend->copyBufferToImage(biasBuffer.get(), mBias.get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     }
     int unit = COMPUT_SIZE - convOption->kernelY() + 1;
     mUnit    = unit;
@@ -169,6 +169,13 @@ ErrorCode VulkanConvolutionWinograd::onEncode(const std::vector<Tensor*>& inputs
     ivec2 offsetData;
     offsetData[0] = 0;
     offsetData[1] = 0;
+
+    auto vkBackend = (VulkanBackend*)backend();
+    auto vkSrc     = vkBackend->findTensor(src->deviceId());
+    auto vkDst     = vkBackend->findTensor(dst->deviceId());
+    cmdBuffer->barrierImageIfNeeded(vkSrc->image(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    cmdBuffer->barrierImageIfNeeded(vkDst->image(), VK_IMAGE_LAYOUT_GENERAL);
+
     for (int y = 0; y < sliceNumber; ++y) {
         int hCount = hPiece;
         if (y == sliceNumber - 1) {
@@ -188,6 +195,7 @@ ErrorCode VulkanConvolutionWinograd::onEncode(const std::vector<Tensor*>& inputs
             mDestTransformSet[i].reset(mDestTransform->createSet());
             if (true) {
                 auto sourceImage = mMultier->source();
+                cmdBuffer->barrierImageIfNeeded(sourceImage, VK_IMAGE_LAYOUT_GENERAL);
                 mSourceTransformSet[i]->writeImage(sourceImage->view(), mSampler->get(), VK_IMAGE_LAYOUT_GENERAL, 0);
                 mSourceTransformSet[i]->writeImage((VkImageView)src->deviceId(), mSampler->get(),
                                                    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
@@ -201,6 +209,7 @@ ErrorCode VulkanConvolutionWinograd::onEncode(const std::vector<Tensor*>& inputs
             mMultier->compute(cmdBuffer);
             if (true) {
                 auto destImage = mMultier->dest();
+                cmdBuffer->barrierImageIfNeeded(destImage, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
                 mDestTransformSet[i]->writeImage((VkImageView)dst->deviceId(), mSampler->get(), VK_IMAGE_LAYOUT_GENERAL,
                                                  0);
                 mDestTransformSet[i]->writeImage(destImage->view(), mSampler->get(),

--- a/source/backend/vulkan/execution/VulkanConvolutionWinograd.cpp
+++ b/source/backend/vulkan/execution/VulkanConvolutionWinograd.cpp
@@ -210,8 +210,9 @@ ErrorCode VulkanConvolutionWinograd::onEncode(const std::vector<Tensor*>& inputs
                 mDestTransformSet[i]->writeBuffer(mWinogradConst->buffer(), 3, mWinogradConst->size());
                 mDestTransformSet[i]->writeBuffer(mOffsetsBuffer[i]->buffer(), 4, mOffsetsBuffer[i]->size());
                 mDestTransform->bind(cmdBuffer->get(), mDestTransformSet[i]->get());
-                cmdBuffer->barrierImage(destImage->get(), VK_IMAGE_LAYOUT_GENERAL,
-                                        VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+                cmdBuffer->barrierImageIfNeeded(destImage, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+                // cmdBuffer->barrierImage(destImage->get(), VK_IMAGE_LAYOUT_GENERAL,
+                //                         VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
                 vkCmdDispatch(cmdBuffer->get(), UP_DIV(wCount, mTransformLocalSize[0]),
                               UP_DIV(hCount, mTransformLocalSize[1]), UP_DIV(ocC4, mTransformLocalSize[2]));
             }

--- a/source/backend/vulkan/execution/VulkanDeconvolution.cpp
+++ b/source/backend/vulkan/execution/VulkanDeconvolution.cpp
@@ -136,7 +136,8 @@ ErrorCode VulkanDeconvolution::onEncode(const std::vector<Tensor*>& inputs, cons
             mBias.reset(new VulkanImage(vkBn->getDynamicMemoryPool(), false, std::vector<int>{UP_DIV(co, 4), 1}));
             mBiasCopy.reset(new VulkanConvolutionCommon::BufferToImageCopy(vkBn));
             mBiasCopy->encode(mBias.get(), (VkBuffer)(inputs[2]->deviceId()), inputs[2]->size(), cmdBuffer);
-            cmdBuffer->barrierImage(mBias->get(), VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+            cmdBuffer->barrierImageIfNeeded(mBias.get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+            // cmdBuffer->barrierImage(mBias->get(), VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
         }
     }
     {
@@ -175,7 +176,8 @@ ErrorCode VulkanDeconvolution::onEncode(const std::vector<Tensor*>& inputs, cons
         mIm2ColSet->writeImage(mBias->view(), mSampler->get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 2);
         mIm2ColSet->writeBuffer(mConvParam->buffer(), 3, mConvParam->size());
         mIm2Col->bind(cmdBuffer->get(), mIm2ColSet->get());
-        cmdBuffer->barrierImage(dstImage->get(), VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        cmdBuffer->barrierImageIfNeeded(dstImage, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        // cmdBuffer->barrierImage(dstImage->get(), VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
         vkCmdDispatch(cmdBuffer->get(), UP_DIV(totalSize, VulkanConvolutionCommon::gImage2ColLocal), 1, 1);
     }
     if (inputs.size() > 2) {

--- a/source/backend/vulkan/execution/VulkanDeconvolution.cpp
+++ b/source/backend/vulkan/execution/VulkanDeconvolution.cpp
@@ -148,7 +148,7 @@ ErrorCode VulkanDeconvolution::onEncode(const std::vector<Tensor*>& inputs, cons
         mConvParam->unmap();
     }
 
-    mMultiler->prepare(src->width() * src->height() * src->batch());
+    mMultiler->prepare(cmdBuffer, src->width() * src->height() * src->batch());
     if (true) {
         auto totalInputSize = src->width() * src->height() * icDiv4 * src->batch();
         auto dstImage = mMultiler->source();

--- a/source/backend/vulkan/execution/VulkanImageConverter.cpp
+++ b/source/backend/vulkan/execution/VulkanImageConverter.cpp
@@ -97,6 +97,10 @@ void VulkanImageConverter::_encodeImageBufferConvert(const Tensor* tensor, VkBuf
     dims[3]   = b;
     mConst->unmap();
 
+    auto backend = (VulkanBackend*)mBackend;
+    auto vkTensor = backend->findTensor(tensor->deviceId());
+    cmdBuffer->barrierImageIfNeeded(vkTensor->image(), layout);
+
     mSet->writeImage((VkImageView)tensor->deviceId(), mSampler->get(), layout, 0);
     mSet->writeBuffer(destBuffer, 1, bufferSize, bufferOffset);
     mSet->writeBuffer(mConst->buffer(), 2, mConst->size());

--- a/source/backend/vulkan/execution/VulkanMatrixMultier4x4.cpp
+++ b/source/backend/vulkan/execution/VulkanMatrixMultier4x4.cpp
@@ -100,8 +100,10 @@ void VulkanMatrixMultier4x4::prepare(int e, std::shared_ptr<VulkanImage> dst, st
 
 void VulkanMatrixMultier4x4::compute(const VulkanCommandPool::Buffer* commandBuffer) const {
     mPipeline->bind(commandBuffer->get(), mDescriptorSet->get());
-    commandBuffer->barrierImage(mSource->get(), VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-    commandBuffer->barrierImage(mKernel->get(), VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    commandBuffer->barrierImageIfNeeded(mSource.get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    commandBuffer->barrierImageIfNeeded(mKernel.get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    // commandBuffer->barrierImage(mSource->get(), VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    // commandBuffer->barrierImage(mKernel->get(), VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     vkCmdDispatch(commandBuffer->get(), UP_DIV(mOutputWidth, 8), UP_DIV(mOutputHeight / 4, 8), mDepth);
 }
 } // namespace MNN

--- a/source/backend/vulkan/execution/VulkanMatrixMultier4x4.cpp
+++ b/source/backend/vulkan/execution/VulkanMatrixMultier4x4.cpp
@@ -31,7 +31,7 @@ std::shared_ptr<VulkanImage> VulkanMatrixMultier4x4::createKernel(VulkanBackend*
         ::memcpy(dest, B, ALIGN_UP4(l) * ALIGN_UP4(h) * c * sizeof(float));
         tempBuffer->unmap();
     }
-    backend->copyBufferToImage(tempBuffer.get(), kernel.get());
+    backend->copyBufferToImage(tempBuffer.get(), kernel.get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     return kernel;
 }
 
@@ -61,7 +61,7 @@ VulkanMatrixMultier4x4::VulkanMatrixMultier4x4(VulkanBackend* backend, const flo
     }
     mKernel = kernel;
 }
-void VulkanMatrixMultier4x4::prepare(int e, std::shared_ptr<VulkanImage> dst, std::shared_ptr<VulkanImage> src) {
+void VulkanMatrixMultier4x4::prepare(const VulkanCommandPool::Buffer* commandBuffer, int e, std::shared_ptr<VulkanImage> dst, std::shared_ptr<VulkanImage> src) {
     int sw  = ALIGN_UP4(mWidth);
     int sh  = UP_DIV(e, 4);
     int ow  = sh;
@@ -81,6 +81,10 @@ void VulkanMatrixMultier4x4::prepare(int e, std::shared_ptr<VulkanImage> dst, st
     if (nullptr == dst) {
         mDest->release();
     }
+
+    commandBuffer->barrierImageIfNeeded(mDest.get(), VK_IMAGE_LAYOUT_GENERAL);
+    commandBuffer->barrierImageIfNeeded(mSource.get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    commandBuffer->barrierImageIfNeeded(mKernel.get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
     mDescriptorSet->writeImage(mDest->view(), mSampler->get(), VK_IMAGE_LAYOUT_GENERAL, 0);
     mDescriptorSet->writeImage(mSource->view(), mSampler->get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);

--- a/source/backend/vulkan/execution/VulkanMatrixMultier4x4.cpp
+++ b/source/backend/vulkan/execution/VulkanMatrixMultier4x4.cpp
@@ -104,10 +104,7 @@ void VulkanMatrixMultier4x4::prepare(const VulkanCommandPool::Buffer* commandBuf
 
 void VulkanMatrixMultier4x4::compute(const VulkanCommandPool::Buffer* commandBuffer) const {
     mPipeline->bind(commandBuffer->get(), mDescriptorSet->get());
-    commandBuffer->barrierImageIfNeeded(mSource.get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-    commandBuffer->barrierImageIfNeeded(mKernel.get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-    // commandBuffer->barrierImage(mSource->get(), VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-    // commandBuffer->barrierImage(mKernel->get(), VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     vkCmdDispatch(commandBuffer->get(), UP_DIV(mOutputWidth, 8), UP_DIV(mOutputHeight / 4, 8), mDepth);
 }
+
 } // namespace MNN

--- a/source/backend/vulkan/execution/VulkanMatrixMultier4x4.hpp
+++ b/source/backend/vulkan/execution/VulkanMatrixMultier4x4.hpp
@@ -17,7 +17,7 @@ public:
     virtual ~VulkanMatrixMultier4x4();
     static std::shared_ptr<VulkanImage> createKernel(VulkanBackend* backend, const float* B, int l, int h, int c);
     VulkanMatrixMultier4x4(VulkanBackend* backend, const float* B, int l, int h, int c = 1, std::shared_ptr<VulkanImage> kernel = nullptr);
-    void prepare(int e, std::shared_ptr<VulkanImage> dst = nullptr, std::shared_ptr<VulkanImage> src = nullptr);
+    void prepare(const VulkanCommandPool::Buffer* commandBuffer, int e, std::shared_ptr<VulkanImage> dst = nullptr, std::shared_ptr<VulkanImage> src = nullptr);
 
     void compute(const VulkanCommandPool::Buffer* commandBuffer) const;
 

--- a/source/backend/vulkan/execution/VulkanNormalize.cpp
+++ b/source/backend/vulkan/execution/VulkanNormalize.cpp
@@ -103,7 +103,8 @@ ErrorCode VulkanNormalize::onEncode(const std::vector<Tensor*>& inputs, const st
     mScaleDescriptorSet->writeBuffer(mParamBuffer->buffer(), 4, mParamBuffer->size());
     mVulkanScalePipeline->bind(cmdBuffer->get(), mScaleDescriptorSet->get());
 
-    cmdBuffer->barrierImage(tempTensorImage->get(), VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    cmdBuffer->barrierImageIfNeeded(tempTensorImage, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    // cmdBuffer->barrierImage(tempTensorImage->get(), VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
     vkCmdDispatch(cmdBuffer->get(), UP_DIV(input->width(), 16), UP_DIV(input->height(), 16),
                   channelDiv4 * input->batch());

--- a/source/backend/vulkan/execution/VulkanPadding.cpp
+++ b/source/backend/vulkan/execution/VulkanPadding.cpp
@@ -12,69 +12,12 @@
 
 namespace MNN {
 
-VulkanPadding::VulkanPadding(PadValueMode mode, int32_t* paddings, Backend* bn) : VulkanBasicExecution(bn), mMode(mode), mStorage(2) {
+VulkanPadding::VulkanPadding(PadValueMode mode, int32_t* paddings, Backend* bn) : VulkanBasicExecution(bn), mMode(mode) {
     ::memcpy(mPaddings, paddings, sizeof(int32_t) * 8);
     mDimType = MNN_DATA_FORMAT_NCHW;
-    auto vkBackend = static_cast<VulkanBackend*>(bn);
-    mTensorConvert0.reset(new VulkanImageConverter(vkBackend));
-    mTensorConvert1.reset(new VulkanImageConverter(vkBackend));
 }
 
 VulkanPadding::~VulkanPadding() {
-}
-
-ErrorCode VulkanPadding::setLayout(const Tensor* input, const Tensor* output) {
-    int totalSize = 1;
-
-    mWrapTensorForInput.buffer().type  = input->buffer().type;
-    mWrapTensorForOutput.buffer().type = output->buffer().type;
-    int extraMulti                     = 1;
-    int extraDivide                    = 1;
-    if (TensorUtils::getDescribe(input)->dimensionFormat == MNN_DATA_FORMAT_NC4HW4) {
-        TensorUtils::getDescribe(&mWrapTensorForInput)->dimensionFormat  = MNN_DATA_FORMAT_NCHW;
-        TensorUtils::getDescribe(&mWrapTensorForOutput)->dimensionFormat = MNN_DATA_FORMAT_NCHW;
-        extraMulti                                                       = ALIGN_UP4(input->channel());
-        extraDivide                                                      = input->channel();
-    } else {
-        TensorUtils::getDescribe(&mWrapTensorForInput)->dimensionFormat  = MNN_DATA_FORMAT_NHWC;
-        TensorUtils::getDescribe(&mWrapTensorForOutput)->dimensionFormat = MNN_DATA_FORMAT_NHWC;
-    }
-
-    for (int i = 0; i < input->buffer().dimensions; ++i) {
-        totalSize *= input->buffer().dim[i].extent;
-    }
-
-    mStorage.buffer().dim[0].extent = 1;
-    mStorage.buffer().dim[1].extent = totalSize / extraDivide * extraMulti;
-    backend()->onAcquireBuffer(&mStorage, Backend::DYNAMIC);
-
-    TensorUtils::copyShape(input, &mWrapTensorForInput);
-    if (TensorUtils::getDescribe(input)->dimensionFormat == MNN_DATA_FORMAT_NC4HW4 &&
-        mDimType == MNN_DATA_FORMAT_NHWC) {
-        TensorUtils::getDescribe(&mWrapTensorForInput)->dimensionFormat = MNN_DATA_FORMAT_NHWC;
-        if (mWrapTensorForInput.buffer().dimensions == 4) {
-            mWrapTensorForInput.buffer().dim[1].extent = mWrapTensorForInput.buffer().dim[2].extent;
-            mWrapTensorForInput.buffer().dim[2].extent = mWrapTensorForInput.buffer().dim[3].extent;
-            mWrapTensorForInput.buffer().dim[3].extent = mWrapTensorForInput.buffer().dim[1].extent;
-        }
-    }
-
-    mWrapTensorForInput.buffer().device = mStorage.buffer().device;
-    TensorUtils::setLinearLayout(&mWrapTensorForInput);
-
-    TensorUtils::copyShape(output, &mWrapTensorForOutput);
-    if (TensorUtils::getDescribe(input)->dimensionFormat == MNN_DATA_FORMAT_NC4HW4 &&
-        mDimType == MNN_DATA_FORMAT_NHWC) {
-        TensorUtils::getDescribe(&mWrapTensorForOutput)->dimensionFormat = MNN_DATA_FORMAT_NHWC;
-        if (mWrapTensorForOutput.buffer().dimensions == 4) {
-            mWrapTensorForOutput.buffer().dim[1].extent = mWrapTensorForOutput.buffer().dim[2].extent;
-            mWrapTensorForOutput.buffer().dim[2].extent = mWrapTensorForOutput.buffer().dim[3].extent;
-            mWrapTensorForOutput.buffer().dim[3].extent = mWrapTensorForOutput.buffer().dim[1].extent;
-        }
-    }
-    mWrapTensorForOutput.buffer().device = mStorage.buffer().device;
-    TensorUtils::setLinearLayout(&mWrapTensorForOutput);
-    return NO_ERROR;
 }
 
 ErrorCode VulkanPadding::onEncode(const std::vector<Tensor*>& inputs, const std::vector<Tensor*>& outputs,
@@ -83,61 +26,62 @@ ErrorCode VulkanPadding::onEncode(const std::vector<Tensor*>& inputs, const std:
     MNN_ASSERT(1 == outputs.size());
 
     auto input   = inputs[0];
-    auto padding = inputs[1];
     auto output  = outputs[0];
 
-    if (TensorUtils::getDescribe(input)->dimensionFormat != MNN_DATA_FORMAT_NC4HW4 &&
-        TensorUtils::getDescribe(output)->dimensionFormat != MNN_DATA_FORMAT_NC4HW4) {
-        // the layout of input and output tensor are all buffer, then copy buffer directly
-        auto inputBuffer  = reinterpret_cast<VkBuffer>(input->deviceId());
-        auto outputBuffer = reinterpret_cast<VkBuffer>(output->deviceId());
-        cmdBuffer->barrierSource(inputBuffer, 0, input->size());
-        const VkBufferCopy copyRegion = {0, 0, static_cast<VkDeviceSize>(input->size())};
-        vkCmdCopyBuffer(cmdBuffer->get(), inputBuffer, outputBuffer, 1, &copyRegion);
-    } else {
-        this->setLayout(input, output);
+    VkImageCopy copyRegion;
+    ::memset(&copyRegion, 0, sizeof(VkImageCopy));
+    copyRegion.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    copyRegion.srcSubresource.layerCount = 1;
+    copyRegion.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    copyRegion.dstSubresource.layerCount = 1;
+    copyRegion.srcOffset.x               = mPaddings[4]; // width offset
+    copyRegion.srcOffset.y               = mPaddings[6]; // height offset
+    copyRegion.srcOffset.z               = mPaddings[2]; // channels offset
+    copyRegion.extent.width              = input->width();
+    copyRegion.extent.height             = input->height();
+    copyRegion.extent.depth              = UP_DIV(input->channel(), 4) * input->batch();
 
-        // encode tensor convert
-        mTensorConvert0->encodeTensorToBuffer(
-            input, reinterpret_cast<VkBuffer>(mWrapTensorForInput.deviceId()), mStorage.size(), 0,
-            TensorUtils::getDescribe(&mWrapTensorForInput)->dimensionFormat, cmdBuffer);
-        cmdBuffer->barrierSource(reinterpret_cast<VkBuffer>(mWrapTensorForInput.deviceId()), 0,
-                                 mWrapTensorForInput.size());
-        mTensorConvert1->encodeBufferToTensor(
-            reinterpret_cast<VkBuffer>(mWrapTensorForOutput.deviceId()), output, mStorage.size(), 0,
-            TensorUtils::getDescribe(&mWrapTensorForOutput)->dimensionFormat, cmdBuffer);
+    auto vkBackend   = static_cast<VulkanBackend*>(backend());
+    auto inputImage = vkBackend->findTensor(input->deviceId())->image();
+    auto outputImage = vkBackend->findTensor(output->deviceId())->image();
 
-        backend()->onReleaseBuffer(&mStorage, Backend::DYNAMIC);
-    }
+    cmdBuffer->barrierImageIfNeeded(inputImage, VK_IMAGE_LAYOUT_GENERAL);
+    cmdBuffer->barrierImageIfNeeded(outputImage, VK_IMAGE_LAYOUT_GENERAL);
+    vkCmdCopyImage(cmdBuffer->get(), inputImage->get(), inputImage->layout(),
+        outputImage->get(), outputImage->layout(), 1, &copyRegion);
 
     return NO_ERROR;
 }
 
-// class VulkanPaddingCreator : public VulkanBackend::Creator {
-// public:
-//     virtual VulkanBasicExecution* onCreate(const std::vector<Tensor*>& inputs, const std::vector<Tensor*>& outputs, const MNN::Op* op, Backend* bn) const override {
-//         if (inputs.size() < 2) {
-//             MNN_ERROR("Need second input for padding parameters\n");
-//             return nullptr;
-//         }
-//         auto padding = inputs[1]->host<int32_t>();
-//         if (inputs[1]->size() != 8) {
-//             MNN_ERROR("Padding parameter size should be 8 for [NCHW min][NCHW max]\n");
-//             return nullptr;
-//         }
-//         auto param = op->main_as_PadParam();
-//         auto mode  = PadValueMode_CONSTANT;
-//         if (param) {
-//             mode = param->mode();
-//         }
+class VulkanPaddingCreator : public VulkanBackend::Creator {
+public:
+    virtual VulkanBasicExecution* onCreate(const std::vector<Tensor*>& inputs, const std::vector<Tensor*>& outputs, const MNN::Op* op, Backend* bn) const override {
+        if (inputs.size() < 2) {
+            MNN_ERROR("Need second input for padding parameters\n");
+            return nullptr;
+        }
+        auto padding = inputs[1]->host<int32_t>();
+        auto& paddingShape = inputs[1]->shape();
+        int paddingSize = 1;
+        for (auto dim: paddingShape)
+            paddingSize *= dim;
+        if (paddingSize != 8) {
+            MNN_ERROR("Padding parameter size should be 8 for [NCHW min][NCHW max]\n");
+            return nullptr;
+        }
+        auto param = op->main_as_PadParam();
+        auto mode  = PadValueMode_CONSTANT;
+        if (param) {
+            mode = param->mode();
+        }
 
-//         return new VulkanPadding(mode, padding, bn);
-//     }
-// };
+        return new VulkanPadding(mode, padding, bn);
+    }
+};
 
-// static bool gResistor = []() {
-//     VulkanBackend::addCreator(OpType_Padding, new VulkanPaddingCreator);
-//     return true;
-// }();
+static bool gResistor = []() {
+    VulkanBackend::addCreator(OpType_Padding, new VulkanPaddingCreator);
+    return true;
+}();
 
 } // namespace MNN

--- a/source/backend/vulkan/execution/VulkanPadding.cpp
+++ b/source/backend/vulkan/execution/VulkanPadding.cpp
@@ -1,0 +1,143 @@
+//
+//  VulkanPadding.cpp
+//  MNN
+//
+//  Created by MNN on 2019/01/31.
+//  Copyright © 2018, Alibaba Group Holding Limited
+//
+
+#include "backend/vulkan/execution/VulkanPadding.hpp"
+#include "core/Macro.h"
+#include "core/TensorUtils.hpp"
+
+namespace MNN {
+
+VulkanPadding::VulkanPadding(PadValueMode mode, int32_t* paddings, Backend* bn) : VulkanBasicExecution(bn), mMode(mode), mStorage(2) {
+    ::memcpy(mPaddings, paddings, sizeof(int32_t) * 8);
+    mDimType = MNN_DATA_FORMAT_NCHW;
+    auto vkBackend = static_cast<VulkanBackend*>(bn);
+    mTensorConvert0.reset(new VulkanImageConverter(vkBackend));
+    mTensorConvert1.reset(new VulkanImageConverter(vkBackend));
+}
+
+VulkanPadding::~VulkanPadding() {
+}
+
+ErrorCode VulkanPadding::setLayout(const Tensor* input, const Tensor* output) {
+    int totalSize = 1;
+
+    mWrapTensorForInput.buffer().type  = input->buffer().type;
+    mWrapTensorForOutput.buffer().type = output->buffer().type;
+    int extraMulti                     = 1;
+    int extraDivide                    = 1;
+    if (TensorUtils::getDescribe(input)->dimensionFormat == MNN_DATA_FORMAT_NC4HW4) {
+        TensorUtils::getDescribe(&mWrapTensorForInput)->dimensionFormat  = MNN_DATA_FORMAT_NCHW;
+        TensorUtils::getDescribe(&mWrapTensorForOutput)->dimensionFormat = MNN_DATA_FORMAT_NCHW;
+        extraMulti                                                       = ALIGN_UP4(input->channel());
+        extraDivide                                                      = input->channel();
+    } else {
+        TensorUtils::getDescribe(&mWrapTensorForInput)->dimensionFormat  = MNN_DATA_FORMAT_NHWC;
+        TensorUtils::getDescribe(&mWrapTensorForOutput)->dimensionFormat = MNN_DATA_FORMAT_NHWC;
+    }
+
+    for (int i = 0; i < input->buffer().dimensions; ++i) {
+        totalSize *= input->buffer().dim[i].extent;
+    }
+
+    mStorage.buffer().dim[0].extent = 1;
+    mStorage.buffer().dim[1].extent = totalSize / extraDivide * extraMulti;
+    backend()->onAcquireBuffer(&mStorage, Backend::DYNAMIC);
+
+    TensorUtils::copyShape(input, &mWrapTensorForInput);
+    if (TensorUtils::getDescribe(input)->dimensionFormat == MNN_DATA_FORMAT_NC4HW4 &&
+        mDimType == MNN_DATA_FORMAT_NHWC) {
+        TensorUtils::getDescribe(&mWrapTensorForInput)->dimensionFormat = MNN_DATA_FORMAT_NHWC;
+        if (mWrapTensorForInput.buffer().dimensions == 4) {
+            mWrapTensorForInput.buffer().dim[1].extent = mWrapTensorForInput.buffer().dim[2].extent;
+            mWrapTensorForInput.buffer().dim[2].extent = mWrapTensorForInput.buffer().dim[3].extent;
+            mWrapTensorForInput.buffer().dim[3].extent = mWrapTensorForInput.buffer().dim[1].extent;
+        }
+    }
+
+    mWrapTensorForInput.buffer().device = mStorage.buffer().device;
+    TensorUtils::setLinearLayout(&mWrapTensorForInput);
+
+    TensorUtils::copyShape(output, &mWrapTensorForOutput);
+    if (TensorUtils::getDescribe(input)->dimensionFormat == MNN_DATA_FORMAT_NC4HW4 &&
+        mDimType == MNN_DATA_FORMAT_NHWC) {
+        TensorUtils::getDescribe(&mWrapTensorForOutput)->dimensionFormat = MNN_DATA_FORMAT_NHWC;
+        if (mWrapTensorForOutput.buffer().dimensions == 4) {
+            mWrapTensorForOutput.buffer().dim[1].extent = mWrapTensorForOutput.buffer().dim[2].extent;
+            mWrapTensorForOutput.buffer().dim[2].extent = mWrapTensorForOutput.buffer().dim[3].extent;
+            mWrapTensorForOutput.buffer().dim[3].extent = mWrapTensorForOutput.buffer().dim[1].extent;
+        }
+    }
+    mWrapTensorForOutput.buffer().device = mStorage.buffer().device;
+    TensorUtils::setLinearLayout(&mWrapTensorForOutput);
+    return NO_ERROR;
+}
+
+ErrorCode VulkanPadding::onEncode(const std::vector<Tensor*>& inputs, const std::vector<Tensor*>& outputs,
+                                  const VulkanCommandPool::Buffer* cmdBuffer) {
+    MNN_ASSERT(1 <= inputs.size());
+    MNN_ASSERT(1 == outputs.size());
+
+    auto input   = inputs[0];
+    auto padding = inputs[1];
+    auto output  = outputs[0];
+
+    if (TensorUtils::getDescribe(input)->dimensionFormat != MNN_DATA_FORMAT_NC4HW4 &&
+        TensorUtils::getDescribe(output)->dimensionFormat != MNN_DATA_FORMAT_NC4HW4) {
+        // the layout of input and output tensor are all buffer, then copy buffer directly
+        auto inputBuffer  = reinterpret_cast<VkBuffer>(input->deviceId());
+        auto outputBuffer = reinterpret_cast<VkBuffer>(output->deviceId());
+        cmdBuffer->barrierSource(inputBuffer, 0, input->size());
+        const VkBufferCopy copyRegion = {0, 0, static_cast<VkDeviceSize>(input->size())};
+        vkCmdCopyBuffer(cmdBuffer->get(), inputBuffer, outputBuffer, 1, &copyRegion);
+    } else {
+        this->setLayout(input, output);
+
+        // encode tensor convert
+        mTensorConvert0->encodeTensorToBuffer(
+            input, reinterpret_cast<VkBuffer>(mWrapTensorForInput.deviceId()), mStorage.size(), 0,
+            TensorUtils::getDescribe(&mWrapTensorForInput)->dimensionFormat, cmdBuffer);
+        cmdBuffer->barrierSource(reinterpret_cast<VkBuffer>(mWrapTensorForInput.deviceId()), 0,
+                                 mWrapTensorForInput.size());
+        mTensorConvert1->encodeBufferToTensor(
+            reinterpret_cast<VkBuffer>(mWrapTensorForOutput.deviceId()), output, mStorage.size(), 0,
+            TensorUtils::getDescribe(&mWrapTensorForOutput)->dimensionFormat, cmdBuffer);
+
+        backend()->onReleaseBuffer(&mStorage, Backend::DYNAMIC);
+    }
+
+    return NO_ERROR;
+}
+
+// class VulkanPaddingCreator : public VulkanBackend::Creator {
+// public:
+//     virtual VulkanBasicExecution* onCreate(const std::vector<Tensor*>& inputs, const std::vector<Tensor*>& outputs, const MNN::Op* op, Backend* bn) const override {
+//         if (inputs.size() < 2) {
+//             MNN_ERROR("Need second input for padding parameters\n");
+//             return nullptr;
+//         }
+//         auto padding = inputs[1]->host<int32_t>();
+//         if (inputs[1]->size() != 8) {
+//             MNN_ERROR("Padding parameter size should be 8 for [NCHW min][NCHW max]\n");
+//             return nullptr;
+//         }
+//         auto param = op->main_as_PadParam();
+//         auto mode  = PadValueMode_CONSTANT;
+//         if (param) {
+//             mode = param->mode();
+//         }
+
+//         return new VulkanPadding(mode, padding, bn);
+//     }
+// };
+
+// static bool gResistor = []() {
+//     VulkanBackend::addCreator(OpType_Padding, new VulkanPaddingCreator);
+//     return true;
+// }();
+
+} // namespace MNN

--- a/source/backend/vulkan/execution/VulkanPadding.cpp
+++ b/source/backend/vulkan/execution/VulkanPadding.cpp
@@ -61,7 +61,7 @@ public:
             return nullptr;
         }
         auto padding = inputs[1]->host<int32_t>();
-        auto& paddingShape = inputs[1]->shape();
+        auto paddingShape = inputs[1]->shape();
         int paddingSize = 1;
         for (auto dim: paddingShape)
             paddingSize *= dim;

--- a/source/backend/vulkan/execution/VulkanPadding.hpp
+++ b/source/backend/vulkan/execution/VulkanPadding.hpp
@@ -1,0 +1,39 @@
+//
+//  VulkanPadding.hpp
+//  MNN
+//
+//  Created by MNN on 2019/01/31.
+//  Copyright © 2018, Alibaba Group Holding Limited
+//
+
+#ifndef VulkanPadding_hpp
+#define VulkanPadding_hpp
+#include "backend/vulkan/execution/VulkanBasicExecution.hpp"
+#include "backend/vulkan/execution/VulkanImageConverter.hpp"
+
+namespace MNN {
+class VulkanPadding : public VulkanBasicExecution {
+public:
+    VulkanPadding(PadValueMode mode, int32_t* paddings, Backend* bn);
+    virtual ~VulkanPadding();
+    ErrorCode onEncode(const std::vector<Tensor*>& inputs, const std::vector<Tensor*>& outputs,
+                       const VulkanCommandPool::Buffer* cmdBuffer) override;
+
+    ErrorCode setLayout(const Tensor* input, const Tensor* output);
+
+private:
+    MNN_DATA_FORMAT mDimType;
+
+public:
+    Tensor mStorage;
+    Tensor mWrapTensorForInput;
+    Tensor mWrapTensorForOutput;
+
+    PadValueMode mMode;
+    int32_t mPaddings[8];
+
+    std::shared_ptr<VulkanImageConverter> mTensorConvert0;
+    std::shared_ptr<VulkanImageConverter> mTensorConvert1;
+};
+} // namespace MNN
+#endif

--- a/source/backend/vulkan/execution/VulkanPadding.hpp
+++ b/source/backend/vulkan/execution/VulkanPadding.hpp
@@ -19,21 +19,12 @@ public:
     ErrorCode onEncode(const std::vector<Tensor*>& inputs, const std::vector<Tensor*>& outputs,
                        const VulkanCommandPool::Buffer* cmdBuffer) override;
 
-    ErrorCode setLayout(const Tensor* input, const Tensor* output);
-
 private:
     MNN_DATA_FORMAT mDimType;
 
 public:
-    Tensor mStorage;
-    Tensor mWrapTensorForInput;
-    Tensor mWrapTensorForOutput;
-
     PadValueMode mMode;
     int32_t mPaddings[8];
-
-    std::shared_ptr<VulkanImageConverter> mTensorConvert0;
-    std::shared_ptr<VulkanImageConverter> mTensorConvert1;
 };
 } // namespace MNN
 #endif

--- a/source/backend/vulkan/execution/VulkanPool.cpp
+++ b/source/backend/vulkan/execution/VulkanPool.cpp
@@ -101,6 +101,12 @@ ErrorCode VulkanPool::onEncode(const std::vector<Tensor*>& inputs, const std::ve
 
     // Set Command Buffer
     {
+        auto vkBackend = (VulkanBackend*)backend();
+        auto vkOutput  = vkBackend->findTensor(output->deviceId());
+        auto vkInput   = vkBackend->findTensor(input->deviceId());
+        cmdBuffer->barrierImageIfNeeded(vkOutput->image(), VK_IMAGE_LAYOUT_GENERAL);
+        cmdBuffer->barrierImageIfNeeded(vkInput->image(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        
         mDescriptorSet.reset(mPoolPipeline->createSet());
         mDescriptorSet->writeImage((VkImageView)output->deviceId(), extra->getCommonSampler()->get(),
                                    VK_IMAGE_LAYOUT_GENERAL, 0);

--- a/source/backend/vulkan/execution/VulkanResize.cpp
+++ b/source/backend/vulkan/execution/VulkanResize.cpp
@@ -57,6 +57,11 @@ ErrorCode VulkanResize::encodeImpl(Tensor* input, Tensor* output, float xScale, 
     mParamBuffer->flush(true, 0, sizeof(GpuParam));
     mParamBuffer->unmap();
 
+    auto vkOutput = extra->findTensor(output->deviceId());
+    auto vkInput  = extra->findTensor(input->deviceId());
+    cmdBuffer->barrierImageIfNeeded(vkOutput->image(), VK_IMAGE_LAYOUT_GENERAL);
+    cmdBuffer->barrierImageIfNeeded(vkInput->image(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    
     mDescriptorSet.reset(mVulkanResizePipeline->createSet());
     mDescriptorSet->writeImage((VkImageView)input->deviceId(), extra->getCommonSampler()->get(),
                                VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0);

--- a/source/backend/vulkan/execution/VulkanSoftmax.cpp
+++ b/source/backend/vulkan/execution/VulkanSoftmax.cpp
@@ -104,6 +104,11 @@ ErrorCode VulkanSoftmax::onEncode(const std::vector<Tensor*>& inputs, const std:
             mConstBuffer->unmap();
         }
 
+        auto vkOutput = mVkBackend->findTensor(output->deviceId());
+        auto vkInput  = mVkBackend->findTensor(input->deviceId());
+        cmdBuffer->barrierImageIfNeeded(vkOutput->image(), VK_IMAGE_LAYOUT_GENERAL);
+        cmdBuffer->barrierImageIfNeeded(vkInput->image(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+
         mDescriptorSet.reset(mSoftmaxPipeline->createSet());
         mDescriptorSet->writeImage(reinterpret_cast<VkImageView>(output->deviceId()),
                                    mVkBackend->getCommonSampler()->get(), VK_IMAGE_LAYOUT_GENERAL, 0);

--- a/source/backend/vulkan/execution/VulkanUnary.cpp
+++ b/source/backend/vulkan/execution/VulkanUnary.cpp
@@ -87,7 +87,8 @@ ErrorCode VulkanUnary::onEncode(const std::vector<Tensor*>& inputs, const std::v
     if (image) {
         auto vkBn = (VulkanBackend*)backend();
         auto inputTensor = vkBn->findTensor(inputs[0]->deviceId());
-        cmdBuffer->barrierImage(inputTensor->image()->get(), VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        cmdBuffer->barrierImageIfNeeded(inputTensor->image(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        // cmdBuffer->barrierImage(inputTensor->image()->get(), VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
         mDesSet->writeImage((VkImageView)(outputs[0])->deviceId(), vkBn->getCommonSampler()->get(), VK_IMAGE_LAYOUT_GENERAL, 0);
         mDesSet->writeImage((VkImageView)(inputs[0])->deviceId(), vkBn->getCommonSampler()->get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
         mDesSet->writeBuffer(mParam->buffer(), 2, mParam->size());

--- a/tools/converter/source/cli.cpp
+++ b/tools/converter/source/cli.cpp
@@ -105,7 +105,7 @@ cxxopts::Options Cli::initializeMNNConvertArgs(modelConfig &modelPath, int argc,
             DLOG(INFO) << "Model File Does Not Exist!";
             exit(EXIT_FAILURE);
         }
-    } else {
+    } else if (modelPath.model == modelConfig::CAFFE) {
         // caffe model must have this option
         if (modelPath.model == modelPath.CAFFE) {
             std::cout << options.help({""}) << std::endl;

--- a/tools/converter/source/tflite/PReluTflite.cpp
+++ b/tools/converter/source/tflite/PReluTflite.cpp
@@ -1,0 +1,62 @@
+//
+//  PReluTflite.cpp
+//  MNNConverter
+//
+//  Created by MNN on 2019/11/25.
+//  Copyright © 2018, Alibaba Group Holding Limited
+//
+
+#include <stdio.h>
+#include "TfliteUtils.hpp"
+#include "liteOpConverter.hpp"
+
+DECLARE_OP_COVERTER(PReluTflite);
+MNN::OpType PReluTflite::opType(bool quantizedModel) {
+    return MNN::OpType_PReLU;
+}
+MNN::OpParameter PReluTflite::type(bool quantizedModel) {
+    return MNN::OpParameter_PRelu;
+}
+
+void PReluTflite::run(MNN::OpT* dstOp, const std::unique_ptr<tflite::OperatorT>& tfliteOp,
+                      const std::vector<std::unique_ptr<tflite::TensorT>>& tfliteTensors,
+                      const std::vector<std::unique_ptr<tflite::BufferT>>& tfliteModelBuffer,
+                      const std::vector<std::unique_ptr<tflite::OperatorCodeT>>& tfliteOpSet, bool quantizedModel){
+
+    DCHECK(quantizedModel == false) << "tflite PRelu not support quantizedModel yet ERROR! ";
+    // 2 inputs: input tensor, slope
+    const int inputSize = tfliteOp->inputs.size();
+    DCHECK(inputSize == 2) << "tflite PRelu input ERROR! ";
+    // input, slope index
+    const int inputIndex    = tfliteOp->inputs[0];
+    const int slopeIndex    = tfliteOp->inputs[1];
+    const auto& inputTensor = tfliteTensors[inputIndex];
+    const auto& slopeTensor = tfliteTensors[slopeIndex];
+    // input & slope shape
+    const auto& inputShape = inputTensor->shape;
+    const auto& slopeShape = slopeTensor->shape;
+    int slopeSize = 1;
+    for (auto shape: slopeShape)
+        slopeSize *= (int)shape;
+
+    DCHECK(inputShape.size() >= 4 && inputShape[3] == slopeSize) << "tflite PRelu slope count differs from input tensor ERROR! ";
+
+    auto PRelu   = new MNN::PReluT;
+
+    std::vector<float> slopeData;
+    slopeData.resize(slopeSize);
+    auto originalSlopePtr = reinterpret_cast<const float*>(tfliteModelBuffer[slopeTensor->buffer]->data.data());
+    convertDataFormatTflite(originalSlopePtr, slopeData.data(), 1, 1, slopeSize, 1);
+
+    PRelu->slope = slopeData;
+    PRelu->slopeCount = slopeSize;
+
+    dstOp->main.value = PRelu;
+
+    dstOp->inputIndexes[0]  = tfliteOp->inputs[0];
+    dstOp->outputIndexes[0] = tfliteOp->outputs[0];
+}
+
+using namespace tflite;
+REGISTER_CONVERTER(PReluTflite, BuiltinOperator_PRELU);
+


### PR DESCRIPTION
Hello, I'm a developer living in Seoul, Korea.

I'm a newbie of the MNN, and first would like to say thank you for developing such a great framework.
I'm interested in the inference engine with Vulkan acceleration on a desktop application,
so I tried to compile the MNN project on my Windows machine,
and found some limitations and errors as below:
- TFLITE converter does not support the PRelu operation, even though MNN itself already supports it.
- The Padding operator for Vulkan backend is not implemented, thus it goes to CPU backend, which can make the session slower.
- Some Vulkan validation errors, especially due to image layout setting.

This PR is a draft for fixing above. Here is what I tried:
- MNNConverter
  * `prototxt` parameter does not have to be given when we don't use it for the CAFFE framework
  * Add PRelu converter implementation for TFLITE framework
- Vulkan backend: bug
  * In `VulkanBackend::findTensor()`, it also look up in `mStaticBuffers` as well as `mAllBuffers`.
    This modification can be fix crash bug when the output tensor set as a static buffer.
  * Add `VulkanPadding`, which is a simple image copy for zero-padding. It should be revised
- Vulkan backend: validation error
  * In buffer mapping and flushing process, align size in according to the physical device's limits 
  * Add some missing `sType` flags
  * Add `VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT` flag for creating descriptor pool in order to notify that we use `vkFreeDescriptorSet` function
  * Add a `mLayout` property in `VulkanImage`, which is used to track its layout type
  * Add a `barrierImageIfNeeded()` method in `VulkanCommandPool::Buffer`, which is a utility function to set the image layout when it's necessary.
  * Add additional parameter `finalLayout` for `VulkanBackend::copyBufferToImage()` to set image layout after finishing copy behaviour.
  * Switch `barrierImage()` to `barrierImageIfNeeded()`
  * Use `barrierImageIfNeeded()` for input and output tensors before dispatching.

I've tested the code in the Windows 10 / AMD Ryzen 3900X / nVidia GeForce 2080Ti,
and tested `expressDemo` with `deeplabv3`, `squeezenet-v1.1`, and `mobilenet-v2.1.tflite` networks.

Please let me know for any suggestion.
Thank you for reading!