### PR TITLE
Fixed several compile warning in .hpp (-Wdocumentation warning)

### DIFF
--- a/source/backend/cpu/CPUNonMaxSuppressionV2.hpp
+++ b/source/backend/cpu/CPUNonMaxSuppressionV2.hpp
@@ -15,12 +15,12 @@ namespace MNN {
 
 /**
  * @brief apply non_max_suppression, output the selected boxes index
- * @param decodedBoxes, Tensor, shape is [num_boxes, 4], where 4 represent [ymin, xmin, ymax, xmax]
- * @param scores, float*, length is [num_boxes]
- * @param maxDetections, output maxDetections boxes
- * @param iouThreshold: float
- * @param scoreThreshold: float
- * @param selected:std::vector<int32_t>*
+ * @param decodedBoxes : Tensor, shape is [num_boxes, 4], where 4 represent [ymin, xmin, ymax, xmax]
+ * @param scores : float*, length is [num_boxes]
+ * @param maxDetections : int output maxDetections boxes
+ * @param iouThreshold : float
+ * @param scoreThreshold : float
+ * @param selected : std::vector<int32_t>*
  */
 void NonMaxSuppressionSingleClasssImpl(const Tensor* decodedBoxes, const float* scores, int maxDetections, float iouThreshold, float scoreThreshold, std::vector<int>* selected);
 

--- a/source/core/Backend.hpp
+++ b/source/core/Backend.hpp
@@ -184,7 +184,7 @@ public:
 
     /**
      * @brief get backend memory allocator
-     * @param type: StorageType, default vaule is DYNAMIC
+     * @param type : StorageType, default vaule is DYNAMIC
      */
     virtual void* getAllocator(StorageType type = DYNAMIC) const{
         return nullptr;


### PR DESCRIPTION
Hi, MNN team.

I fixed several compile warnings in iOS XCODE compilation. Could you verify and accept my changes, pls?

In file included from /Users/evgeny.proydakov/repository/MNN/source/core/BackendFactory.hpp:12:
/Users/evgeny.proydakov/repository/MNN/source/core/Backend.hpp:187:15: warning: parameter 'type:' not found in the function declaration [-Wdocumentation]
     * @param type: StorageType, default vaule is DYNAMIC
              ^~~~~
/Users/evgeny.proydakov/repository/MNN/source/core/Backend.hpp:187:15: note: did you mean 'type'?
     * @param type: StorageType, default vaule is DYNAMIC
              ^~~~~
              type
1 warning generated.