### PR TITLE
Fixed several compile warnins in .cpp (-Wunused-variable)

### DIFF
--- a/express/Expr.cpp
+++ b/express/Expr.cpp
@@ -781,12 +781,12 @@ void Variable::save(const std::vector<VARP>& vars, NetT* dest) {
         auto op = dest->oplists[index].get();
         auto tensorIndexOffset = varIndexInfo[expr];
         for (int v=0; v<expr->outputSize(); ++v) {
-            auto index = tensorIndexOffset + v;
-            if (dest->tensorName[index].empty()) {
+            auto const tensorIndex = tensorIndexOffset + v;
+            if (dest->tensorName[tensorIndex].empty()) {
                 if (v == 0) {
-                    dest->tensorName[index] = op->name;
+                    dest->tensorName[tensorIndex] = op->name;
                 } else {
-                    dest->tensorName[index] = op->name + numberToString(v);
+                    dest->tensorName[tensorIndex] = op->name + numberToString(v);
                 }
             }
         }

--- a/source/backend/cpu/CPUConvolutionDepthwise.cpp
+++ b/source/backend/cpu/CPUConvolutionDepthwise.cpp
@@ -98,7 +98,6 @@ CPUConvolutionDepthwise::FloatExecution::FloatExecution(const Convolution2DCommo
     int outputCount = (int)biasSize;
     mBias.reset(Tensor::createDevice<float>(std::vector<int>{ALIGN_UP4(outputCount)}));
     int depthQuad   = UP_DIV(outputCount, 4);
-    int planeStride = kw * kh * 4;
     int kernelSize  = depthQuad * 4 * kw * kh;
     mWeight.reset(Tensor::createDevice<float>(std::vector<int>{kernelSize}));
     bool success =

--- a/source/backend/cpu/CPUDeconvolution.cpp
+++ b/source/backend/cpu/CPUDeconvolution.cpp
@@ -118,7 +118,6 @@ ErrorCode CPUDeconvolutionMultiInput::onResize(const std::vector<Tensor*>& input
     auto srcCount         = inputs[0]->channel();
     auto fw               = inputs[1]->width();
     auto fh               = inputs[1]->height();
-    int alignedWeightSize = ALIGN_UP4(outputCount) * ALIGN_UP4(srcCount) * fw * fh;
     int eP, lP, hP;
     MNNGetMatMulPackMode(&eP, &lP, &hP);
     auto outputAlign = ALIGN_UP4(outputCount) * fw * fh;
@@ -144,7 +143,6 @@ ErrorCode CPUDeconvolutionOrigin::onResize(const std::vector<Tensor*>& inputs, c
     if (ALIGN_UP4(oc) != inputs[2]->length(0)) {
         return INPUT_DATA_ERROR;
     }
-    auto weightAddr = inputs[1]->host<float>();
 
     auto ocC4       = UP_DIV(output->channel(), 4);
     auto icC4       = UP_DIV(input->channel(), 4);
@@ -174,7 +172,6 @@ ErrorCode CPUDeconvolutionOrigin::onResize(const std::vector<Tensor*>& inputs, c
     auto colBufferPtr = tempColTotalBuffer->host<float>();
     auto biasPtr      = inputs[2]->host<float>();
     auto inputPtr  = input->host<float>();
-    auto outputPtr = output->host<float>();
     std::shared_ptr<Tensor> tempInputBuffer(
         Tensor::create<float>({icC4, plane, 4}, inputPtr));
     std::shared_ptr<Tensor> tempInput(Tensor::createDevice<float>({icC4, plane, 4}));

--- a/source/backend/cpu/compute/Convolution1x1Strassen.cpp
+++ b/source/backend/cpu/compute/Convolution1x1Strassen.cpp
@@ -223,10 +223,7 @@ ErrorCode Convolution1x1Strassen::onExecute(const std::vector<Tensor *> &inputs,
     auto size   = mUnits.size();
     auto input  = inputs[0];
     auto output = outputs[0];
-    auto ocC4 = UP_DIV(output->channel(), 4);
-    auto outputPlane = output->width() * output->height();
-    auto threadNumber = static_cast<CPUBackend*>(backend())->threadNumber();
-    
+
     if (!mNeedPretreat) {
         MNN_CONCURRENCY_BEGIN(tId, size) {
             auto &unit = mUnits[tId];


### PR DESCRIPTION
Hi, MNN team.

I fixed several compile warnings in iOS XCODE compilation. Could you verify and accept my changes, pls?

ld/MNN.build/Release-iphoneos/MNN.build/Objects-normal/armv7/Convolution1x1Strassen.o
/Users/evgeny.proydakov/repository/MNN/source/backend/cpu/compute/Convolution1x1Strassen.cpp:226:10: warning: unused variable 'ocC4' [-Wunused-variable]
    auto ocC4 = UP_DIV(output->channel(), 4);
         ^
/Users/evgeny.proydakov/repository/MNN/source/backend/cpu/compute/Convolution1x1Strassen.cpp:227:10: warning: unused variable 'outputPlane' [-Wunused-variable]
    auto outputPlane = output->width() * output->height();
         ^
/Users/evgeny.proydakov/repository/MNN/source/backend/cpu/compute/Convolution1x1Strassen.cpp:228:10: warning: unused variable 'threadNumber' [-Wunused-variable]
    auto threadNumber = static_cast<CPUBackend*>(backend())->threadNumber();
         ^

/Users/evgeny.proydakov/repository/MNN/express/Expr.cpp:784:18: warning: declaration shadows a local variable [-Wshadow]
            auto index = tensorIndexOffset + v;
                 ^
/Users/evgeny.proydakov/repository/MNN/express/Expr.cpp:779:14: note: previous declaration is here
    for (int index = 0; index < executeOrder.size(); ++index) {
             ^

N.build/Release-iphoneos/MNN.build/Objects-normal/armv7/CPUConvolutionDepthwise.o
/Users/evgeny.proydakov/repository/MNN/source/backend/cpu/CPUConvolutionDepthwise.cpp:101:9: warning: unused variable 'planeStride' [-Wunused-variable]
    int planeStride = kw * kh * 4;
        ^

/Users/evgeny.proydakov/repository/MNN/source/backend/cpu/CPUDeconvolution.cpp:121:9: warning: unused variable 'alignedWeightSize' [-Wunused-variable]
    int alignedWeightSize = ALIGN_UP4(outputCount) * ALIGN_UP4(srcCount) * fw * fh;
        ^
/Users/evgeny.proydakov/repository/MNN/source/backend/cpu/CPUDeconvolution.cpp:147:10: warning: unused variable 'weightAddr' [-Wunused-variable]
    auto weightAddr = inputs[1]->host<float>();
         ^
/Users/evgeny.proydakov/repository/MNN/source/backend/cpu/CPUDeconvolution.cpp:177:10: warning: unused variable 'outputPtr' [-Wunused-variable]
    auto outputPtr = output->host<float>();
         ^