### PR TITLE
Fixed several clang warning in half 3rd_party library (errors: -Wdocumentation, -Wcomma)

### DIFF
--- a/3rd_party/half/half.hpp
+++ b/3rd_party/half/half.hpp
@@ -22,6 +22,11 @@
 #ifndef HALF_HALF_HPP
 #define HALF_HALF_HPP
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcomma"
+#endif
+
 /// Combined gcc version number.
 #define HALF_GNUC_VERSION (__GNUC__*100+__GNUC_MINOR__)
 
@@ -1036,7 +1041,6 @@ namespace half_float
 		HALF_CONSTEXPR half() HALF_NOEXCEPT : data_() {}
 
 		/// Copy constructor.
-		/// \tparam T type of concrete half expression
 		/// \param rhs half expression to copy from
 		half(detail::expr rhs) : data_(detail::float2half<round_style>(static_cast<float>(rhs))) {}
 
@@ -1049,7 +1053,6 @@ namespace half_float
 		operator float() const { return detail::half2float<float>(data_); }
 
 		/// Assignment operator.
-		/// \tparam T type of concrete half expression
 		/// \param rhs half expression to copy from
 		/// \return reference to this half
 		half& operator=(detail::expr rhs) { return *this = static_cast<float>(rhs); }
@@ -3006,6 +3009,10 @@ namespace std
 #ifdef HALF_POP_WARNINGS
 	#pragma warning(pop)
 	#undef HALF_POP_WARNINGS
+#endif
+
+#ifdef __clang__
+#pragma clang diagnostic pop
 #endif
 
 #endif


### PR DESCRIPTION
Hi, MNN team.

I fixed several compile warnings in iOS XCODE compilation. Could you verify and accept my changes, pls?

/Users/evgeny.proydakov/repository/MNN/3rd_party/half/half.hpp:1039:8: warning: '\tparam' command used in a comment that is not attached to a template declaration [-Wdocumentation]
                /// \tparam T type of concrete half expression
                     ^~~~~~
/Users/evgeny.proydakov/repository/MNN/3rd_party/half/half.hpp:1052:8: warning: '\tparam' command used in a comment that is not attached to a template declaration [-Wdocumentation]
                /// \tparam T type of concrete half expression
                     ^~~~~~
/Users/evgeny.proydakov/repository/MNN/3rd_party/half/half.hpp:1248:34: warning: possible misuse of comma operator here [-Wcomma]
                                        return *quo = qsign ? -1 : 1, expr(sign ? -0.0f : 0.0f);
                                                                    ^
/Users/evgeny.proydakov/repository/MNN/3rd_party/half/half.hpp:1248:13: note: cast expression to void to silence warning
                                        return *quo = qsign ? -1 : 1, expr(sign ? -0.0f : 0.0f);
                                               ^~~~~~~~~~~~~~~~~~~~~
                                               static_cast<void>(   )
/Users/evgeny.proydakov/repository/MNN/3rd_party/half/half.hpp:1272:39: warning: possible misuse of comma operator here [-Wcomma]
                                return *quo = qsign ? -cquo : cquo, expr(sign ? -ax : ax);
                                                                  ^
/Users/evgeny.proydakov/repository/MNN/3rd_party/half/half.hpp:1272:12: note: cast expression to void to silence warning
                                return *quo = qsign ? -cquo : cquo, expr(sign ? -ax : ax);
                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~
                                       static_cast<void>(         )
/Users/evgeny.proydakov/repository/MNN/3rd_party/half/half.hpp:1622:21: warning: possible misuse of comma operator here [-Wcomma]
                                        return *exp = 0, arg;
                                                       ^
/Users/evgeny.proydakov/repository/MNN/3rd_party/half/half.hpp:1622:13: note: cast expression to void to silence warning
                                        return *exp = 0, arg;
                                               ^~~~~~~~
                                               static_cast<void>( )
/Users/evgeny.proydakov/repository/MNN/3rd_party/half/half.hpp:1624:28: warning: possible misuse of comma operator here [-Wcomma]
                                return *exp = e+(m>>10), half(binary, (arg.data_&0x8000)|0x3800|(m&0x3FF));
                                                       ^
/Users/evgeny.proydakov/repository/MNN/3rd_party/half/half.hpp:1624:12: note: cast expression to void to silence warning
                                return *exp = e+(m>>10), half(binary, (arg.data_&0x8000)|0x3800|(m&0x3FF));
                                       ^~~~~~~~~~~~~~~~
                                       static_cast<void>( )
/Users/evgeny.proydakov/repository/MNN/3rd_party/half/half.hpp:1635:24: warning: possible misuse of comma operator here [-Wcomma]
                                        return *iptr = arg, half(binary, arg.data_&(0x8000U|-(e>0x7C00)));
                                                          ^
/Users/evgeny.proydakov/repository/MNN/3rd_party/half/half.hpp:1635:13: note: cast expression to void to silence warning
                                        return *iptr = arg, half(binary, arg.data_&(0x8000U|-(e>0x7C00)));
                                               ^~~~~~~~~~~
                                               static_cast<void>( )
/Users/evgeny.proydakov/repository/MNN/3rd_party/half/half.hpp:1637:45: warning: possible misuse of comma operator here [-Wcomma]
                                        return iptr->data_ = arg.data_ & 0x8000, arg;
                                                                               ^
/Users/evgeny.proydakov/repository/MNN/3rd_party/half/half.hpp:1637:13: note: cast expression to void to silence warning
                                        return iptr->data_ = arg.data_ & 0x8000, arg;
                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                               static_cast<void>(              )
