### PR TITLE
Fixed compile warning for macos in OnnxUtils/TfUtils (-Wdeprecated-declarations)

### DIFF
--- a/tools/converter/source/onnx/OnnxUtils.cpp
+++ b/tools/converter/source/onnx/OnnxUtils.cpp
@@ -20,7 +20,11 @@ bool onnx_read_proto_from_binary(const char* filepath, google::protobuf::Message
     google::protobuf::io::IstreamInputStream input(&fs);
     google::protobuf::io::CodedInputStream codedstr(&input);
 
+#if GOOGLE_PROTOBUF_VERSION >= 3011000
+    codedstr.SetTotalBytesLimit(INT_MAX);
+#else
     codedstr.SetTotalBytesLimit(INT_MAX, INT_MAX / 2);
+#endif
 
     bool success = message->ParseFromCodedStream(&codedstr);
 

--- a/tools/converter/source/onnx/OnnxUtils.cpp
+++ b/tools/converter/source/onnx/OnnxUtils.cpp
@@ -22,8 +22,6 @@ bool onnx_read_proto_from_binary(const char* filepath, google::protobuf::Message
 
 #if GOOGLE_PROTOBUF_VERSION >= 3011000
     codedstr.SetTotalBytesLimit(INT_MAX);
-#else
-    codedstr.SetTotalBytesLimit(INT_MAX, INT_MAX / 2);
 #endif
 
     bool success = message->ParseFromCodedStream(&codedstr);

--- a/tools/converter/source/tensorflow/TfUtils.cpp
+++ b/tools/converter/source/tensorflow/TfUtils.cpp
@@ -25,7 +25,11 @@ bool tf_read_proto_from_binary(const char* filepath, google::protobuf::Message* 
     google::protobuf::io::IstreamInputStream input(&fs);
     google::protobuf::io::CodedInputStream codedstr(&input);
 
+#if GOOGLE_PROTOBUF_VERSION >= 3011000
+    codedstr.SetTotalBytesLimit(INT_MAX);
+#else
     codedstr.SetTotalBytesLimit(INT_MAX, INT_MAX / 2);
+#endif
 
     bool success = message->ParseFromCodedStream(&codedstr);
 

--- a/tools/converter/source/tensorflow/TfUtils.cpp
+++ b/tools/converter/source/tensorflow/TfUtils.cpp
@@ -27,8 +27,6 @@ bool tf_read_proto_from_binary(const char* filepath, google::protobuf::Message* 
 
 #if GOOGLE_PROTOBUF_VERSION >= 3011000
     codedstr.SetTotalBytesLimit(INT_MAX);
-#else
-    codedstr.SetTotalBytesLimit(INT_MAX, INT_MAX / 2);
 #endif
 
     bool success = message->ParseFromCodedStream(&codedstr);


### PR DESCRIPTION
Hello, MNN Team.

As I see google updated protobuf library.

https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.io.coded_stream

This change will require a bit of 'ifdef' magic. More details here:

onnx/onnx#2678

Could you review and accept my PR, pls?

/Users/evgeny.proydakov/repository/MNN/tools/converter/source/tensorflow/TfUtils.cpp:28:14: warning: 'SetTotalBytesLimit' is deprecated: Please use the single parameter version of SetTotalBytesLimit().
The second parameter is ignored. [-Wdeprecated-declarations]
codedstr.SetTotalBytesLimit(INT_MAX, INT_MAX / 2);
^
/Users/evgeny.proydakov/repository/MNN/tools/converter/source/onnx/OnnxUtils.cpp:23:14: warning: 'SetTotalBytesLimit' is deprecated: Please use the single parameter version of SetTotalBytesLimit(). The
second parameter is ignored. [-Wdeprecated-declarations]
codedstr.SetTotalBytesLimit(INT_MAX, INT_MAX / 2);
^