### PR TITLE
fix element-wise add bug in armv82

### DIFF
--- a/source/backend/arm82/Arm82Backend.hpp
+++ b/source/backend/arm82/Arm82Backend.hpp
@@ -13,6 +13,7 @@
 #include "backend/cpu/CPUBackend.hpp"
 #include "core/Backend.hpp"
 #include "core/Macro.h"
+#include "core/TensorUtils.hpp"
 
 // armv82's data type default is fp16, so set
 // armv82's dataformat: NC8HW8
@@ -85,6 +86,18 @@ void MyPrint(const T* data, int size) {
 inline int ARM82TensorBatchStrideHelper(const Tensor* t) {
     int channel = t->channel();
     return t->height() * t->width() * ROUND_UP(channel, ARMV82_CHANNEL_UNIT);
+}
+
+inline int ARM82TensorElementSizeHelper(const Tensor* t) {
+    int size = 1;
+    for (int i = 0; i < t->dimensions(); i++) {
+        int currentDimSize = t->length(i);
+        if (TensorUtils::getDescribe(t)->dimensionFormat == MNN_DATA_FORMAT_NC4HW4 && 1 == i) {
+            currentDimSize = UP_DIV(currentDimSize, 8) * 8;
+        }
+        size *= currentDimSize;
+    }
+    return size;
 }
 
 } // namespace MNN

--- a/source/backend/arm82/Arm82Eltwise.cpp
+++ b/source/backend/arm82/Arm82Eltwise.cpp
@@ -29,7 +29,7 @@ ErrorCode Arm82Eltwise::onExecute(const std::vector<Tensor *> &inputs, const std
     auto input0 = inputs[0];
     auto input1 = inputs[1];
     auto output = outputs[0];
-    const int elementSize = input0->elementSize();
+    const int elementSize = ARM82TensorElementSizeHelper(input0);
     
     const int sizeDivUnit = elementSize / ARMV82_CHANNEL_UNIT;
     const int remainCount = elementSize - sizeDivUnit * ARMV82_CHANNEL_UNIT;


### PR DESCRIPTION
在armv8.2的element算子中，tensor->elementSize()返回的size是基于C4计算的，而fp16实际是8对齐所以应该按C8计算。按C4计算会导致结果错误（在aone的测试模型上余弦距离为2e-3），修正后余弦距离降至1e-5以下。