### PR TITLE
Fix some bugs of caffe transformation

### DIFF
--- a/source/core/OpCommonUtils.cpp
+++ b/source/core/OpCommonUtils.cpp
@@ -263,10 +263,16 @@ std::vector<std::tuple<int, int, int>> OpCommonUtils::computeReduceDims(const st
         int axisSize    = 1;
         auto start      = groupAxises[i].first;
         auto length     = groupAxises[i].second;
+        if (start >= (int)lengths.size()) {
+            break;
+        }
         for (int j = 0; j < start; ++j) {
             outsideSize *= lengths[j];
         }
         for (int j = start; j < start + length; ++j) {
+            if (j >= (int)lengths.size()) {
+                break;
+            }
             axisSize *= lengths[j];
             lengths[j] = 1;
         }

--- a/source/geometry/GeometryLRN.cpp
+++ b/source/geometry/GeometryLRN.cpp
@@ -40,7 +40,7 @@ public:
         // Across channel
         int inside  = inputTensor->width() * inputTensor->height();
         int axis    = inputTensor->channel();
-        int outside = 1;
+        int outside = inputTensor->batch();
 
         {
             // 1, axis, 1 -> outside, axis, inside
@@ -69,7 +69,6 @@ public:
         if (mAcrossSpatial) {
             inside  = 1;
             axis    = inputTensor->width() * inputTensor->height() * inputTensor->channel();
-            outside = 1;
         }
         std::shared_ptr<Tensor> inputRaw(Tensor::createDevice<float>({outside, axis, inside}));
         res.extras.emplace_back(inputRaw);

--- a/tools/converter/source/caffe/InnerProduct.cpp
+++ b/tools/converter/source/caffe/InnerProduct.cpp
@@ -54,7 +54,21 @@ class InnerProduct : public InnerProductCommon {
         const caffe::BlobProto& WeightBlob = v0w->blobs(0);
         innerproduct->weightSize           = WeightBlob.data_size();
         innerproduct->weight.resize(innerproduct->weightSize);
-        ::memcpy(innerproduct->weight.data(), WeightBlob.data().data(), sizeof(float) * innerproduct->weightSize);
+        if (innerproduct->transpose) {
+          const float *src = WeightBlob.data().data();
+          float *dst = innerproduct->weight.data();
+          const int outputCount = innerproduct->outputCount;
+          const int srcCount = innerproduct->weightSize / outputCount;
+          for (int i = 0; i < outputCount; i++) {
+            for (int j = 0; j < srcCount; j++) {
+              dst[i * srcCount + j] = src[i + j * outputCount];
+            }
+          }
+          innerproduct->transpose = false;
+        }
+        else {
+          ::memcpy(innerproduct->weight.data(), WeightBlob.data().data(), sizeof(float) * innerproduct->weightSize);
+        }
     }
 };
 

--- a/tools/converter/source/caffe/InnerProduct.cpp
+++ b/tools/converter/source/caffe/InnerProduct.cpp
@@ -55,10 +55,10 @@ class InnerProduct : public InnerProductCommon {
         innerproduct->weightSize           = WeightBlob.data_size();
         innerproduct->weight.resize(innerproduct->weightSize);
         if (innerproduct->transpose) {
-            const float *src = WeightBlob.data().data();
-            float *dst = innerproduct->weight.data();
-            const int outputCount = innerproduct->outputCount;
-            const int srcCount = innerproduct->weightSize / outputCount;
+            const float* src = WeightBlob.data().data();
+            float *dst       = innerproduct->weight.data();
+            int outputCount  = innerproduct->outputCount;
+            int srcCount     = innerproduct->weightSize / outputCount;
             for (int i = 0; i < outputCount; i++) {
                 for (int j = 0; j < srcCount; j++) {
                     dst[i * srcCount + j] = src[i + j * outputCount];

--- a/tools/converter/source/caffe/InnerProduct.cpp
+++ b/tools/converter/source/caffe/InnerProduct.cpp
@@ -55,19 +55,18 @@ class InnerProduct : public InnerProductCommon {
         innerproduct->weightSize           = WeightBlob.data_size();
         innerproduct->weight.resize(innerproduct->weightSize);
         if (innerproduct->transpose) {
-          const float *src = WeightBlob.data().data();
-          float *dst = innerproduct->weight.data();
-          const int outputCount = innerproduct->outputCount;
-          const int srcCount = innerproduct->weightSize / outputCount;
-          for (int i = 0; i < outputCount; i++) {
-            for (int j = 0; j < srcCount; j++) {
-              dst[i * srcCount + j] = src[i + j * outputCount];
+            const float *src = WeightBlob.data().data();
+            float *dst = innerproduct->weight.data();
+            const int outputCount = innerproduct->outputCount;
+            const int srcCount = innerproduct->weightSize / outputCount;
+            for (int i = 0; i < outputCount; i++) {
+                for (int j = 0; j < srcCount; j++) {
+                    dst[i * srcCount + j] = src[i + j * outputCount];
+                }
             }
-          }
-          innerproduct->transpose = false;
-        }
-        else {
-          ::memcpy(innerproduct->weight.data(), WeightBlob.data().data(), sizeof(float) * innerproduct->weightSize);
+            innerproduct->transpose = false;
+        } else {
+            ::memcpy(innerproduct->weight.data(), WeightBlob.data().data(), sizeof(float) * innerproduct->weightSize);
         }
     }
 };

--- a/tools/converter/source/caffe/OpConverter.cpp
+++ b/tools/converter/source/caffe/OpConverter.cpp
@@ -100,22 +100,23 @@ public:
             attr2->i = parameters.bias_param().num_axes();
             dstOp->main.AsExtra()->attr.emplace_back(std::move(attr2));
 
-            if (parameters.blobs_size() != 0) {
-                MNN_ASSERT(parameters.blobs_size() == 1);
+            if (weight.blobs_size() != 0) {
+                MNN_ASSERT(weight.blobs_size() == 1);
                 std::unique_ptr<MNN::AttributeT> attr3(new MNN::AttributeT);
                 attr3->key = "bias";
-                auto shapeSize = parameters.blobs(0).shape().dim_size();
+                auto shapeSize = weight.blobs(0).shape().dim_size();
                 std::vector<int> biasShape;
                 int biasSize = 1;
                 for (int i = 0; i < shapeSize; i++) {
-                    biasShape.emplace_back(parameters.blobs(0).shape().dim(i));
+                    biasShape.emplace_back(weight.blobs(0).shape().dim(i));
                     biasSize *= biasShape[i];
                 }
+                attr3->tensor.reset(new MNN::BlobT);
                 attr3->tensor->dims = biasShape;
                 attr3->tensor->dataFormat = MNN::MNN_DATA_FORMAT::MNN_DATA_FORMAT_NCHW;
                 attr3->tensor->float32s.clear();
                 for (int i = 0; i < biasSize; i++) {
-                    attr3->tensor->float32s.emplace_back(parameters.blobs(0).data(i));
+                    attr3->tensor->float32s.emplace_back(weight.blobs(0).data(i));
                 }
                 attr3->i = biasSize;
                 dstOp->main.AsExtra()->attr.emplace_back(std::move(attr3));
@@ -140,18 +141,19 @@ public:
 
             std::unique_ptr<MNN::AttributeT> attr4(new MNN::AttributeT);
             attr4->key = "weights";
-            auto shapeSize = parameters.blobs(0).shape().dim_size();
+            auto shapeSize = weight.blobs(0).shape().dim_size();
             std::vector<int> weightsShape;
             int weightsSize = 1;
             for (int i = 0; i < shapeSize; i++) {
-                weightsShape.emplace_back(parameters.blobs(0).shape().dim(i));
+                weightsShape.emplace_back(weight.blobs(0).shape().dim(i));
                 weightsSize *= weightsShape[i];
             }
+            attr4->tensor.reset(new MNN::BlobT);
             attr4->tensor->dims = weightsShape;
             attr4->tensor->dataFormat = MNN::MNN_DATA_FORMAT::MNN_DATA_FORMAT_NCHW;
             attr4->tensor->float32s.clear();
             for (int i = 0; i < weightsSize; i++) {
-                attr4->tensor->float32s.emplace_back(parameters.blobs(0).data(i));
+                attr4->tensor->float32s.emplace_back(weight.blobs(0).data(i));
             }
             attr4->i = weightsSize;
             dstOp->main.AsExtra()->attr.emplace_back(std::move(attr4));
@@ -159,18 +161,19 @@ public:
             if (parameters.embed_param().bias_term()) {
                 std::unique_ptr<MNN::AttributeT> attr5(new MNN::AttributeT);
                 attr5->key = "bias";
-                auto shapeSize = parameters.blobs(0).shape().dim_size();
+                auto shapeSize = weight.blobs(1).shape().dim_size();
                 std::vector<int> biasShape;
                 int biasSize = 1;
                 for (int i = 0; i < shapeSize; i++) {
-                    biasShape.emplace_back(parameters.blobs(0).shape().dim(i));
+                    biasShape.emplace_back(weight.blobs(1).shape().dim(i));
                     biasSize *= biasShape[i];
                 }
+                attr5->tensor.reset(new MNN::BlobT);
                 attr5->tensor->dims = biasShape;
                 attr5->tensor->dataFormat = MNN::MNN_DATA_FORMAT::MNN_DATA_FORMAT_NCHW;
                 attr5->tensor->float32s.clear();
                 for (int i = 0; i < biasSize; i++) {
-                    attr5->tensor->float32s.emplace_back(parameters.blobs(0).data(i));
+                    attr5->tensor->float32s.emplace_back(weight.blobs(1).data(i));
                 }
                 attr5->i = biasSize;
                 dstOp->main.AsExtra()->attr.emplace_back(std::move(attr5));

--- a/tools/converter/source/optimizer/caffeextra/CaffeExtraManager.cpp
+++ b/tools/converter/source/optimizer/caffeextra/CaffeExtraManager.cpp
@@ -10,12 +10,9 @@
 #include "MNN_generated.h"
 namespace MNN {
 namespace Express {
-std::shared_ptr<CaffeExtraManager> CaffeExtraManager::gInstance;
-std::shared_ptr<CaffeExtraManager> CaffeExtraManager::get() {
-    if (nullptr == gInstance) {
-        gInstance.reset(new CaffeExtraManager);
-    }
-    return gInstance;
+CaffeExtraManager* CaffeExtraManager::get() {
+    static std::shared_ptr<CaffeExtraManager> gInstance(new CaffeExtraManager);
+    return &*gInstance;
 }
 
 void CaffeExtraManager::insert(const std::string& name, std::shared_ptr<Transform> transform) {

--- a/tools/converter/source/optimizer/caffeextra/CaffeExtraManager.cpp
+++ b/tools/converter/source/optimizer/caffeextra/CaffeExtraManager.cpp
@@ -12,7 +12,7 @@ namespace MNN {
 namespace Express {
 CaffeExtraManager* CaffeExtraManager::get() {
     static std::shared_ptr<CaffeExtraManager> gInstance(new CaffeExtraManager);
-    return &*gInstance;
+    return gInstance->get();
 }
 
 void CaffeExtraManager::insert(const std::string& name, std::shared_ptr<Transform> transform) {

--- a/tools/converter/source/optimizer/caffeextra/CaffeExtraManager.hpp
+++ b/tools/converter/source/optimizer/caffeextra/CaffeExtraManager.hpp
@@ -22,10 +22,9 @@ public:
     
     void insert(const std::string& name, std::shared_ptr<Transform> transform);
     std::shared_ptr<Transform> find(const std::string& name) const;
-    static std::shared_ptr<CaffeExtraManager> get();
+    static CaffeExtraManager *get();
 private:
     std::map<std::string, std::shared_ptr<Transform>> mTransform;
-    static std::shared_ptr<CaffeExtraManager> gInstance;
 };
 }  // namespace Express
 } // namespace MNN


### PR DESCRIPTION
1. The initing order for `CaffeExtraManager::gInstance` is not so stable in Debug mode, and in my real project it caused some mysterious issues and made a bad MNN model file.
2. The code converting `Bias` and `Embed` layers didn't handle weight tensors correctly.
3. Fix Reduce may crash when forwarding, if it follows a Reshape / (MNN's) InnerProduct which has an output of 2 dimensions.