### PR TITLE
fix a bug when converting 1-D NC4HW4 tensors to others

### DIFF
--- a/source/backend/cpu/CPUTensorConvert.cpp
+++ b/source/backend/cpu/CPUTensorConvert.cpp
@@ -172,7 +172,8 @@ ErrorCode CPUTensorConverter::convert(const Tensor* input, const Tensor* output)
     auto ob     = output->buffer();
     auto source = TensorUtils::getDescribe(input)->dimensionFormat;
     auto dest   = TensorUtils::getDescribe(output)->dimensionFormat;
-    if (ib.dimensions <= 1 || source == dest) {
+    if (source == dest || ib.dimensions <= 1 && (source == MNN_DATA_FORMAT_NCHW || source == MNN_DATA_FORMAT_NHWC)
+        && (dest == MNN_DATA_FORMAT_NCHW || dest == MNN_DATA_FORMAT_NHWC)) {
         ::memcpy(ob.host, ib.host, input->size());
         return NO_ERROR;
     }


### PR DESCRIPTION
When converting `NC4HW4` or `NCHW4` tensors to `NCHW` or `NHWC` tensors, the old code will use a fast path of `memory`, but the result is wrong. In a 1-D tensor of `NC4HW4` whose size is 4 floats, the memory layout will be:
``` csv
// (float(*)[16])mBuffer.host
val_0, _unused, _unused, _unused,
val_1, _unused, _unused, _unused,
val_2, _unused, _unused, _unused,
val_3, _unused, _unused, _unused
```

As a result, a converted result of `NHWC` would be `[val_0, _unused, _unused, _unused]`.

This PR fixes it by adding a much stricter check rule.