### PR TITLE
neon optimization for sigmid cpu

### DIFF
--- a/source/backend/cpu/CPUSigmoid.cpp
+++ b/source/backend/cpu/CPUSigmoid.cpp
@@ -11,6 +11,7 @@
 #include "backend/cpu/CPUBackend.hpp"
 #include "backend/cpu/compute/CommonOptFunction.h"
 #include "core/Macro.h"
+
 #ifdef MNN_USE_NEON
 #include <arm_neon.h>
 #endif

--- a/source/backend/cpu/CPUSigmoid.cpp
+++ b/source/backend/cpu/CPUSigmoid.cpp
@@ -11,7 +11,6 @@
 #include "backend/cpu/CPUBackend.hpp"
 #include "backend/cpu/compute/CommonOptFunction.h"
 #include "core/Macro.h"
-
 #ifdef MNN_USE_NEON
 #include <arm_neon.h>
 #endif

--- a/source/backend/cpu/CPUSigmoid.cpp
+++ b/source/backend/cpu/CPUSigmoid.cpp
@@ -11,7 +11,9 @@
 #include "backend/cpu/CPUBackend.hpp"
 #include "backend/cpu/compute/CommonOptFunction.h"
 #include "core/Macro.h"
+#ifdef MNN_USE_NEON
 #include <arm_neon.h>
+#endif
 
 namespace MNN {
 ErrorCode CPUSigmoid::onExecute(const std::vector<Tensor*>& inputs, const std::vector<Tensor*>& outputs) {


### PR DESCRIPTION
在使用MNN测试EffcientNetB0时发现Sigmoid层开销较大，发现在循环计算sum(1/（1+exp）)有可优化的空间，因此提交了自己的优化方法(NEON)。
我在不同ARM开发板上优化的数据对比（EfficientNetB0）：
RK3399优化：8ms左右
RK3328优化：12ms左右
RK3288优化：47ms左右

