### PR TITLE
fix opencl runtime error of MSVC; add 'clGetMemObjectInfo' wrapper

### DIFF
--- a/source/backend/opencl/core/runtime/OpenCLWrapper.cpp
+++ b/source/backend/opencl/core/runtime/OpenCLWrapper.cpp
@@ -164,6 +164,7 @@ bool OpenCLSymbols::LoadLibraryFromPath(const std::string &library_path) {
     MNN_LOAD_FUNCTION_PTR(clGetKernelWorkGroupInfo);
     MNN_LOAD_FUNCTION_PTR(clGetEventInfo);
     MNN_LOAD_FUNCTION_PTR(clGetEventProfilingInfo);
+    MNN_LOAD_FUNCTION_PTR(clGetMemObjectInfo);
     MNN_LOAD_FUNCTION_PTR(clGetImageInfo);
     MNN_LOAD_FUNCTION_PTR(clEnqueueCopyImage);
     MNN_LOAD_FUNCTION_PTR(clEnqueueReadImage);
@@ -476,6 +477,12 @@ cl_int CL_API_CALL clGetEventProfilingInfo(cl_event event, cl_profiling_info par
     return func(event, param_name, param_value_size, param_value, param_value_size_ret);
 }
 
+cl_int CL_API_CALL clGetMemObjectInfo(cl_mem memobj, cl_mem_info param_name, size_t param_value_size, void *param_value,
+                               size_t *param_value_size_ret) {
+    auto func = MNN::OpenCLSymbolsOperator::getOpenclSymbolsPtr()->clGetMemObjectInfo;
+    MNN_CHECK_NOTNULL(func);
+    return func(memobj, param_name, param_value_size, param_value, param_value_size_ret);
+}
 cl_int CL_API_CALL clEnqueueNDRangeKernel(cl_command_queue command_queue, cl_kernel kernel, cl_uint work_dim,
                               const size_t *global_work_offset, const size_t *global_work_size,
                               const size_t *local_work_size, cl_uint num_events_in_wait_list,

--- a/source/backend/opencl/core/runtime/OpenCLWrapper.hpp
+++ b/source/backend/opencl/core/runtime/OpenCLWrapper.hpp
@@ -85,11 +85,11 @@ public:
     using clEnqueueWriteBufferFunc    = cl_int (CL_API_CALL *)(cl_command_queue, cl_mem, cl_bool, size_t, size_t, const void *,
                                                 cl_uint, const cl_event *, cl_event *);
     using clEnqueueReadBufferFunc     = cl_int (CL_API_CALL *)(cl_command_queue, cl_mem, cl_bool, size_t, size_t, void *, cl_uint,
-                                               const cl_event *, cl_event *);                                             
+                                               const cl_event *, cl_event *);
     using clEnqueueReadImageFunc     = cl_int (CL_API_CALL *)(cl_command_queue, cl_mem, cl_bool, const size_t *, const size_t *, size_t, size_t, void *, cl_uint, const cl_event *, cl_event *);
     using clEnqueueWriteImageFunc    = cl_int (CL_API_CALL *)(cl_command_queue, cl_mem, cl_bool, const size_t *, const size_t *, size_t, size_t, const void *,
                                         cl_uint, const cl_event *, cl_event * );
-                                           
+
     using clGetProgramBuildInfoFunc   = cl_int (CL_API_CALL *)(cl_program, cl_device_id, cl_program_build_info, size_t, void *,
                                                  size_t *);
     using clRetainProgramFunc         = cl_int (CL_API_CALL *)(cl_program program);
@@ -129,6 +129,9 @@ public:
     using clGetEventInfoFunc           = cl_int (CL_API_CALL *)(cl_event event, cl_event_info param_name, size_t param_value_size,
                                           void *param_value, size_t *param_value_size_ret);
     using clGetEventProfilingInfoFunc  = cl_int (CL_API_CALL *)(cl_event event, cl_profiling_info param_name,
+                                                   size_t param_value_size, void *param_value,
+                                                   size_t *param_value_size_ret);
+    using clGetMemObjectInfoFunc       = cl_int (CL_API_CALL *)(cl_mem memobj, cl_mem_info param_name,
                                                    size_t param_value_size, void *param_value,
                                                    size_t *param_value_size_ret);
     using clGetImageInfoFunc           = cl_int (CL_API_CALL *)(cl_mem, cl_image_info, size_t, void *, size_t *);
@@ -180,6 +183,7 @@ public:
     MNN_CL_DEFINE_FUNC_PTR(clGetKernelWorkGroupInfo);
     MNN_CL_DEFINE_FUNC_PTR(clGetEventInfo);
     MNN_CL_DEFINE_FUNC_PTR(clGetEventProfilingInfo);
+    MNN_CL_DEFINE_FUNC_PTR(clGetMemObjectInfo);
     MNN_CL_DEFINE_FUNC_PTR(clGetImageInfo);
     MNN_CL_DEFINE_FUNC_PTR(clEnqueueReadImage);
     MNN_CL_DEFINE_FUNC_PTR(clEnqueueWriteImage);

--- a/source/core/Backend.cpp
+++ b/source/core/Backend.cpp
@@ -17,8 +17,8 @@ namespace MNN {
 
 void registerBackend();
 
-static std::once_flag gInitFlag;
 static std::map<MNNForwardType, std::pair<const RuntimeCreator*, bool>>& GetExtraCreator() {
+    static std::once_flag gInitFlag;
     static std::map<MNNForwardType, std::pair<const RuntimeCreator*, bool>>* gExtraCreator;
     std::call_once(gInitFlag,
                    [&]() { gExtraCreator = new std::map<MNNForwardType, std::pair<const RuntimeCreator*, bool>>; });


### PR DESCRIPTION
1. fix opencl runtime error of MSVC

Due to a BUG of VS compiler which makes 'call_once' function executing twice and is not fixed yet([link](https://developercommunity.visualstudio.com/t/dynamic-initializer-created-for-stdonce-flag/243273)), 
avoid to use global static variable, and use local static variable instead.

2. add 'clGetMemObjectInfo' wrapper