### PR TITLE
fix(HiAI): unload model before setting dynameic inputs

### DIFF
--- a/source/backend/hiai/backend/NPUBackend.cpp
+++ b/source/backend/hiai/backend/NPUBackend.cpp
@@ -416,6 +416,9 @@ namespace MNN {
         mInputTensors.clear();
         mOutputTensors.clear();
         mSclipMap.clear();
+        if (mMgrClient != nullptr) {
+            mMgrClient->UnLoadModel();
+        }
     }
 
     void NPUBackend::onResizeEnd() {


### PR DESCRIPTION
支持动态输入的模型在初始化时其初始输入大小会被构建一次HiAI模型并申请内存。等到设置动态输入时会再次创建一次模型并额外申请内存。所以在此之前需要释放之前的模型和内存。