### PR TITLE
add return value for setCache, fix cache update bug

### DIFF
--- a/source/backend/opencl/core/runtime/OpenCLRuntime.hpp
+++ b/source/backend/opencl/core/runtime/OpenCLRuntime.hpp
@@ -81,11 +81,11 @@ public:
 
     unsigned int mQueueCount = 0;
     unsigned int getQueueNum();
-    
+
     unsigned int mKernelTime = 0;
 
     std::map<std::pair<std::string, std::vector<uint32_t>>, std::pair<std::vector<uint32_t>, uint32_t>>& tunedLwsMap();
-    
+
     ::cl::Kernel buildKernel(const std::string &programName, const std::string &kernelName,
                              const std::set<std::string> &buildOptions);
 
@@ -103,7 +103,7 @@ public:
     double getSubmitTime(const cl::Event *event);
 
     std::pair<const void*, size_t> makeCache();
-    void setCache(std::pair<const void*, size_t> cache);
+    bool setCache(std::pair<const void*, size_t> cache);
 private:
     bool loadProgram(const std::string &programName, cl::Program *program);
     bool buildProgram(const std::string &buildOptionsStr, cl::Program *program);
@@ -132,7 +132,7 @@ private:
     std::string mDefaultBuildParams;
     float mFlops = 4.0f;
     bool mIsCreateError{false};
-    
+
     double mStartNanos;
     double mStopNanos;
 

--- a/source/core/Interpreter.cpp
+++ b/source/core/Interpreter.cpp
@@ -198,7 +198,9 @@ Session* Interpreter::createMultiPathSession(const std::vector<ScheduleConfig>& 
     if (validForResize && mNet->inputMode == Session_Input_Inside) {
         result->resize(mNet->net->usage() == Usage_INFERENCE_STATIC);
     }
-    if ((!mNet->cacheFile.empty()) && (!valid)) {
+    // Reset cache
+    result->loadCache(nullptr, 0);
+    if ((!mNet->cacheFile.empty()) || (!valid)) {
         // Try to save extra cache
         auto res = result->getCache();
         if (res.first != nullptr && res.second > 0) {
@@ -234,8 +236,6 @@ Session* Interpreter::createMultiPathSession(const std::vector<ScheduleConfig>& 
             } while (false);
         }
     }
-    // Reset cache
-    result->loadCache(nullptr, 0);
 
     mNet->sessions.emplace_back(std::move(newSession));
     return result;


### PR DESCRIPTION
## Issue Describe
If there is an old cache file which is built by an old model, and now we are trying to create a new session using the cache file.
It reports error everytime but the cache file is not updated at all.

## Bug Fix
1. Currently, cache is rebuilt and saved when `if ((!mNet->cacheFile.empty()) && (!valid)) ` is true.
However, **`valid` indicates whether old cache is loaded successfully or not**. If load failed, rebuild and save are STILL needed. so it should be `if ((!mNet->cacheFile.empty()) || (!valid))`.
2. At the same time, cache should be reset before rebuild and save.
3. In addition, `setCache` should return the right value to ensure `valid` is reliable.