### PR TITLE
refactor(cmake): refactor cmake for make install on ios/android/win64…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ add_definitions("-DMNN_VERSION_PATCH=${MNN_VERSION_PATCH}")
 
 cmake_policy(SET CMP0048 NEW)
 project(MNN VERSION ${MNN_VERSION_MAJOR}.${MNN_VERSION_MINOR}.${MNN_VERSION_PATCH}.${MNN_VERSION_BUILD} LANGUAGES C CXX ASM)
+set(MNN_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 # complier options
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 11)
@@ -73,7 +74,6 @@ option(MNN_BUILD_MINI "Build MNN-MINI that just supports fixed shape models." OF
 option(MNN_USE_SSE "Use SSE optimization for x86 if possiable" ON)
 option(MNN_BUILD_CODEGEN "Build with codegen" OFF)
 option(MNN_ENABLE_COVERAGE "Build with coverage enable" OFF)
-
 IF(NOT MNN_BUILD_SHARED_LIBS AND MNN_SEP_BUILD)
   message(WARNING "Close MNN_SEP_BUILD for static library")
   SET(MNN_SEP_BUILD OFF CACHE BOOL "<docstring>" FORCE)
@@ -538,9 +538,8 @@ IF(MNN_NPU)
     ELSE()
         list(APPEND MNN_TARGETS MNN_NPU)
         list(APPEND MNN_OBJECTS_TO_LINK $<TARGET_OBJECTS:MNN_NPU>)
-        list(APPEND MNN_EXTRA_DEPENDS ${CMAKE_CURRENT_LIST_DIR}/source/backend/hiai/3rdParty/${ANDROID_ABI}/libhiai.so)
-        list(APPEND MNN_EXTRA_DEPENDS ${CMAKE_CURRENT_LIST_DIR}/source/backend/hiai/3rdParty/${ANDROID_ABI}/libhiai_ir_build.so)
-        list(APPEND MNN_EXTRA_DEPENDS ${CMAKE_CURRENT_LIST_DIR}/source/backend/hiai/3rdParty/${ANDROID_ABI}/libhiai_ir.so)
+        # use target instead of absolute path for installing package
+        list(APPEND MNN_EXTRA_DEPENDS hiai hiai_ir hiai_ir_build)
     ENDIF()
 ENDIF()
 
@@ -576,6 +575,10 @@ if (MSVC)
 endif()
 if (MNN_ONEDNN)
     add_dependencies(MNN ONEDNN_COMMON ONEDNN_CPU ONEDNN_CPU_X64)
+endif()
+
+if(WIN32)
+    set_target_properties(MNN PROPERTIES DEBUG_POSTFIX _D )
 endif()
 
 if(APPLE)
@@ -644,60 +647,34 @@ IF(MNN_EVALUATION)
 include(${CMAKE_CURRENT_LIST_DIR}/tools/evaluation/CMakeLists.txt)
 ENDIF()
 
-# Install headers
-IF(CMAKE_SYSTEM_NAME MATCHES "^Android" AND NOT MNN_BUILD_FOR_ANDROID_COMMAND)
-    IF(NOT NATIVE_INCLUDE_OUTPUT)
-      set(NATIVE_INCLUDE_OUTPUT ".")
+# install mnn includes and metallib 
+IF(APPLE)
+  IF(MNN_AAPL_FMWK)
+    FOREACH(HDR ${MNN_EXPR_PUB_HDRS})
+      SET_SOURCE_FILES_PROPERTIES(${HDR} PROPERTIES MACOSX_PACKAGE_LOCATION Headers/expr/ )
+    ENDFOREACH()
+    FOREACH(HDR ${MNN_PUB_HDRS})
+      SET_SOURCE_FILES_PROPERTIES(${HDR} PROPERTIES MACOSX_PACKAGE_LOCATION Headers/ )
+    ENDFOREACH()
+    IF(MNN_METAL)
+      SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_BINARY_DIR}/mnn.metallib PROPERTIES MACOSX_PACKAGE_LOCATION Resources/)
     ENDIF()
-    set(MNN_INCLUDE_OUTPUT ${NATIVE_INCLUDE_OUTPUT}/MNN)
-    add_custom_command(
-      TARGET MNN
-      POST_BUILD
-      COMMAND ${CMAKE_COMMAND}
-      -E make_directory "${MNN_INCLUDE_OUTPUT}/"
-    )
-    add_custom_command(
-      TARGET MNN
-      POST_BUILD
-      COMMAND ${CMAKE_COMMAND}
-      -E make_directory "${MNN_INCLUDE_OUTPUT}/expr/"
-    )
-    FOREACH(header ${MNN_PUB_HDRS})
-      add_custom_command(
-        TARGET MNN
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND}
-        ARGS -E copy ${header} "${MNN_INCLUDE_OUTPUT}/"
-      )
-    ENDFOREACH()
-    FOREACH(header ${MNN_EXPR_PUB_HDRS})
-      add_custom_command(
-        TARGET MNN
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND}
-        ARGS -E copy ${header} "${MNN_INCLUDE_OUTPUT}/expr/"
-      )
-    ENDFOREACH()
-ELSEIF(NOT APPLE)
-  INSTALL(FILES ${MNN_PUB_HDRS} DESTINATION include/MNN/)
-  INSTALL(FILES ${MNN_EXPR_PUB_HDRS} DESTINATION include/MNN/expr/)
-  install(TARGETS MNN
-      LIBRARY DESTINATION lib
-      ARCHIVE DESTINATION lib
-  )
-ELSE()
-  install(TARGETS MNN
-      LIBRARY DESTINATION lib
-      ARCHIVE DESTINATION lib
-      FRAMEWORK DESTINATION /Library/Frameworks/
-  )
-  FOREACH(HDR ${MNN_EXPR_PUB_HDRS})
-    SET_SOURCE_FILES_PROPERTIES(${HDR} PROPERTIES MACOSX_PACKAGE_LOCATION Headers/expr/ )
-  ENDFOREACH()
-  FOREACH(HDR ${MNN_PUB_HDRS})
-    SET_SOURCE_FILES_PROPERTIES(${HDR} PROPERTIES MACOSX_PACKAGE_LOCATION Headers/ )
-  ENDFOREACH()
-  IF(MNN_METAL)
-    SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_BINARY_DIR}/mnn.metallib PROPERTIES MACOSX_PACKAGE_LOCATION Resources/)
+  ELSE()
+    install(DIRECTORY ${MNN_ROOT_DIR}/include DESTINATION .)
+    IF(MNN_METAL)
+      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/mnn.metallib  DESTINATION lib)
+    ENDIF()
   ENDIF()
+ELSE()
+  install(DIRECTORY ${MNN_ROOT_DIR}/include DESTINATION .)
 ENDIF()
+
+# install hiai library on android
+if(MNN_NPU)
+  install(FILES ${CMAKE_CURRENT_LIST_DIR}/source/backend/hiai/3rdParty/${ANDROID_ABI}/libhiai.so DESTINATION lib/${ANDROID_ABI})
+  install(FILES ${CMAKE_CURRENT_LIST_DIR}/source/backend/hiai/3rdParty/${ANDROID_ABI}/libhiai_ir.so DESTINATION lib/${ANDROID_ABI})
+  install(FILES ${CMAKE_CURRENT_LIST_DIR}/source/backend/hiai/3rdParty/${ANDROID_ABI}/libhiai_ir_build.so DESTINATION lib/${ANDROID_ABI})
+endif()
+
+# install MNN lib
+include(${MNN_ROOT_DIR}/cmake/MNNInstall.cmake)

--- a/cmake/MNNConfig.cmake.in
+++ b/cmake/MNNConfig.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/MNNTargets.cmake")
+
+set_and_check(MNN_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
+set_and_check(MNN_LIBS_DIR "@PACKAGE_LIB_INSTALL_DIR@")
+
+check_required_components(MNN)

--- a/cmake/MNNInstall.cmake
+++ b/cmake/MNNInstall.cmake
@@ -1,0 +1,61 @@
+if(APPLE AND MNN_AAPL_FMWK)
+    install(TARGETS MNN
+        EXPORT MNNTargets
+        CONFIGURATIONS Debug Release RelWithDebInfo
+        FRAMEWORK DESTINATION .
+        )
+    set(FRAMEWORK_NAME "MNN.framework")
+    set(TARGET_CONFIG_DIR ./${FRAMEWORK_NAME}/CMake/MNN)
+    set(INCLUDE_INSTALL_DIR Headers/)
+    set(LIB_INSTALL_DIR .)
+elseif(ANDROID)
+    install(TARGETS MNN
+        EXPORT MNNTargets
+        CONFIGURATIONS Debug Release RelWithDebInfo
+        RUNTIME DESTINATION lib/${ANDROID_ABI}
+        LIBRARY DESTINATION lib/${ANDROID_ABI}
+        ARCHIVE DESTINATION lib/${ANDROID_ABI}
+        )
+    set(TARGET_CONFIG_DIR lib/${ANDROID_ABI}/cmake/MNN)
+    set(INCLUDE_INSTALL_DIR include/)
+    set(LIB_INSTALL_DIR lib/${ANDROID_ABI})
+else()
+    install(TARGETS MNN
+        EXPORT MNNTargets
+        CONFIGURATIONS Debug Release RelWithDebInfo
+        RUNTIME DESTINATION lib
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        )
+    set(TARGET_CONFIG_DIR lib/cmake/MNN)
+    set(INCLUDE_INSTALL_DIR include/)
+    set(LIB_INSTALL_DIR lib/)
+endif()
+
+
+install(EXPORT MNNTargets
+    FILE MNNTargets.cmake
+    DESTINATION ${TARGET_CONFIG_DIR}
+    )
+
+include(CMakePackageConfigHelpers)
+
+
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/MNNConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/MNNConfig.cmake
+    INSTALL_DESTINATION ${TARGET_CONFIG_DIR}
+    PATH_VARS INCLUDE_INSTALL_DIR LIB_INSTALL_DIR
+    )
+
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/MNNConfigVersion.cmake
+    VERSION 1.1.6
+    COMPATIBILITY AnyNewerVersion 
+    )
+
+install(FILES 
+    ${CMAKE_CURRENT_BINARY_DIR}/MNNConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/MNNConfigVersion.cmake
+    DESTINATION ${TARGET_CONFIG_DIR}
+    )

--- a/project/android/build_32.sh
+++ b/project/android/build_32.sh
@@ -2,6 +2,7 @@
 cmake ../../../ \
 -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
 -DCMAKE_BUILD_TYPE=Release \
+-DCMAKE_INSTALL_PREFIX=install \
 -DANDROID_ABI="armeabi-v7a" \
 -DANDROID_STL=c++_static \
 -DCMAKE_BUILD_TYPE=Release \
@@ -14,4 +15,5 @@ cmake ../../../ \
 -DMNN_BUILD_FOR_ANDROID_COMMAND=true \
 -DNATIVE_LIBRARY_OUTPUT=. -DNATIVE_INCLUDE_OUTPUT=. $1 $2 $3
 
-make -j4
+make -j16
+make install

--- a/project/android/build_64.sh
+++ b/project/android/build_64.sh
@@ -2,6 +2,7 @@
 cmake ../../../ \
 -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
 -DCMAKE_BUILD_TYPE=Release \
+-DCMAKE_INSTALL_PREFIX=install \
 -DANDROID_ABI="arm64-v8a" \
 -DANDROID_STL=c++_static \
 -DMNN_USE_LOGCAT=false \
@@ -13,4 +14,5 @@ cmake ../../../ \
 -DMNN_BUILD_FOR_ANDROID_COMMAND=true \
 -DNATIVE_LIBRARY_OUTPUT=. -DNATIVE_INCLUDE_OUTPUT=. $1 $2 $3
 
-make -j4
+make -j16
+make install

--- a/project/ios/buildiOS.sh
+++ b/project/ios/buildiOS.sh
@@ -5,18 +5,45 @@ echo "Current PWD: ${PWD}"
 rm -rf ios_64
 mkdir ios_64
 cd ios_64
-cmake ../../../ -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=../../../cmake/ios.toolchain.cmake -DMNN_METAL=ON -DARCHS="arm64" -DENABLE_BITCODE=0 -DMNN_AAPL_FMWK=1 -DMNN_SEP_BUILD=0 -G Xcode
+cmake -G Xcode ../../../ \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_TOOLCHAIN_FILE=../../../cmake/ios.toolchain.cmake \
+    -DMNN_METAL=ON \
+    -DARCHS="arm64" \
+    -DENABLE_BITCODE=0 \
+    -DENABLE_ARC=1 \
+    -DMNN_AAPL_FMWK=1 \
+    -DMNN_SEP_BUILD=0
+
 echo "Building AArch64"
-xcodebuild ONLY_ACTIVE_ARCH=NO -configuration Release -scheme MNN -target MNN -sdk iphoneos -quiet
+xcodebuild -project MNN.xcodeproj \
+            -configuration Release \
+            -target MNN \
+            -sdk iphoneos \
+            -quiet \
+            ONLY_ACTIVE_ARCH=NO
 echo "End Building AArch64"
 cd ../
 
 rm -rf ios_32
 mkdir ios_32
 cd ios_32
-cmake ../../../ -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=../../../cmake/ios.toolchain.cmake -DMNN_METAL=ON -DARCHS="armv7;armv7s" -DENABLE_BITCODE=0 -DMNN_AAPL_FMWK=1 -DMNN_SEP_BUILD=0 -G Xcode
+cmake -G Xcode ../../../ \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_TOOLCHAIN_FILE=../../../cmake/ios.toolchain.cmake \
+    -DMNN_METAL=ON \
+    -DARCHS="armv7;armv7s" \
+    -DENABLE_BITCODE=0 \
+    -DMNN_AAPL_FMWK=1 \
+    -DMNN_SEP_BUILD=0 
 echo "Building AArch32"
-xcodebuild ONLY_ACTIVE_ARCH=NO -configuration Release -scheme MNN -target MNN -sdk iphoneos -quiet
+xcodebuild -project MNN.xcodeproj \
+            -configuration Release \
+            -target MNN \
+            -sdk iphoneos \
+            -quiet \
+            ONLY_ACTIVE_ARCH=NO
+
 echo "End Building AArch32"
 cd ../
 
@@ -26,7 +53,10 @@ find ios_64 -name "MNN*framework"
 mv ios_32/Release-iphoneos/MNN.framework/MNN ios_32/Release-iphoneos/MNN.framework/MNN_32
 
 echo "Creating Fat Binary"
-lipo -create ios_32/Release-iphoneos/MNN.framework/MNN_32 ios_64/Release-iphoneos/MNN.framework/MNN -output ios_32/Release-iphoneos/MNN.framework/MNN
+lipo -create \
+    ios_32/Release-iphoneos/MNN.framework/MNN_32 \
+    ios_64/Release-iphoneos/MNN.framework/MNN \
+    -output ios_32/Release-iphoneos/MNN.framework/MNN
 rm ios_32/Release-iphoneos/MNN.framework/MNN_32
 echo "Patching Framework Headers"
 rm -rf ./MNN.framework

--- a/source/backend/hiai/CMakeLists.txt
+++ b/source/backend/hiai/CMakeLists.txt
@@ -1,22 +1,24 @@
 file(GLOB_RECURSE MNN_NPU_SRCS ${CMAKE_CURRENT_LIST_DIR}/*.cpp)
+
+# generate hiai related target
+add_library(hiai SHARED IMPORTED GLOBAL)
+set_target_properties(hiai PROPERTIES
+        IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/3rdParty/${ANDROID_ABI}/libhiai.so")
+
+add_library(hiai_ir SHARED IMPORTED GLOBAL)
+set_target_properties(hiai_ir PROPERTIES
+        IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/3rdParty/${ANDROID_ABI}/libhiai_ir.so")
+
+add_library(hiai_ir_build SHARED IMPORTED GLOBAL)
+set_target_properties(hiai_ir_build PROPERTIES
+        IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/3rdParty/${ANDROID_ABI}/libhiai_ir_build.so")
+
 IF(MNN_SEP_BUILD)
         add_library(
                 MNN_NPU 
                 SHARED 
                 ${MNN_NPU_SRCS}
         )
-        add_library(hiai SHARED IMPORTED )
-        set_target_properties(hiai PROPERTIES
-                IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/3rdParty/${ANDROID_ABI}/libhiai.so")
-
-        add_library(hiai_ir SHARED IMPORTED )
-        set_target_properties(hiai_ir PROPERTIES
-                IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/3rdParty/${ANDROID_ABI}/libhiai_ir.so")
-
-        add_library(hiai_ir_build SHARED IMPORTED )
-        set_target_properties(hiai_ir_build PROPERTIES
-                IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/3rdParty/${ANDROID_ABI}/libhiai_ir_build.so")
-
         target_link_libraries(MNN_NPU PRIVATE
                 hiai hiai_ir hiai_ir_build
                 MNN


### PR DESCRIPTION
重构了Make Install部分代码，便于MNN库在各平台打包成package，使用者可通过find_package()调用。
note:
- windows下debug模式，为MNN库添加了后缀MNN_D，便于与Release区分
- 各平台在MNN_SEP_BUILD=OFF情况下自测过。如果MNN_SEP_BUILD=ON，只会install MNN主库，如果需要install其他子库，可直接在CMakeLists根据条件对应添加。