### PR TITLE
Correct cross-compiling error on array's auto conversion

### DIFF
--- a/source/backend/cpu/compute/WinogradInt8Helper.cpp
+++ b/source/backend/cpu/compute/WinogradInt8Helper.cpp
@@ -36,12 +36,14 @@ static inline void TRANS_4x4(VecType& vec0, VecType& vec1, VecType& vec2, VecTyp
     vec2.value = _mm_castps_si128(m2);
     vec3.value = _mm_castps_si128(m3);
 #else
-    auto m0 = vtrn1q_s32(vec0.value, vec1.value), m1 = vtrn2q_s32(vec0.value, vec1.value);
-    auto m2 = vtrn1q_s32(vec2.value, vec3.value), m3 = vtrn2q_s32(vec2.value, vec3.value);
-    vec0.value = vtrn1q_s64(m0, m2);
-    vec1.value = vtrn1q_s64(m1, m3);
-    vec2.value = vtrn2q_s64(m0, m2);
-    vec3.value = vtrn2q_s64(m1, m3);
+    auto m0 = vtrn1q_s32(reinterpret_cast<int32x4_t>(vec0.value), reinterpret_cast<int32x4_t>(vec1.value));
+    auto m1 = vtrn2q_s32(reinterpret_cast<int32x4_t>(vec0.value), reinterpret_cast<int32x4_t>(vec1.value));
+    auto m2 = vtrn1q_s32(reinterpret_cast<int32x4_t>(vec2.value), reinterpret_cast<int32x4_t>(vec3.value));
+    auto m3 = vtrn2q_s32(reinterpret_cast<int32x4_t>(vec2.value), reinterpret_cast<int32x4_t>(vec3.value));
+    vec0.value = reinterpret_cast<int8x16_t>(vtrn1q_s64(reinterpret_cast<int64x2_t>(m0), reinterpret_cast<int64x2_t>(m2)));
+    vec1.value = reinterpret_cast<int8x16_t>(vtrn1q_s64(reinterpret_cast<int64x2_t>(m1), reinterpret_cast<int64x2_t>(m3)));
+    vec2.value = reinterpret_cast<int8x16_t>(vtrn2q_s64(reinterpret_cast<int64x2_t>(m0), reinterpret_cast<int64x2_t>(m2)));
+    vec3.value = reinterpret_cast<int8x16_t>(vtrn2q_s64(reinterpret_cast<int64x2_t>(m1), reinterpret_cast<int64x2_t>(m3)));
 #endif
 }
 #endif


### PR DESCRIPTION
Correction of a compilation error due to conversions between vectors while cross-compiling for aarch64 with gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu

![CrossCompileError](https://user-images.githubusercontent.com/53231772/124883430-996abc00-dfd1-11eb-9ca0-57a779cba15d.jpg)

# How to reproduce

Download and extract https://releases.linaro.org/components/toolchain/binaries/7.5-2019.12/aarch64-linux-gnu/gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu.tar.xz

```sh
cd path/to/mnn

mkdir build_aarch64
cd build_aarch64

export crossCompiler=path/to/gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu

cmake -DCMAKE_C_COMPILER=$crossCompiler/bin/aarch64-linux-gnu-gcc \
      -DCMAKE_CXX_COMPILER=$crossCompiler/bin/aarch64-linux-gnu-g++ \
      -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
      -DCMAKE_SYSTEM_NAME=Linux \
      ..

make -j4
```

## :x: First try of correction - use '-flax-vector-conversions'

Result: `bad option '-flax-vector-conversions' to attribute 'optimize'`

## :heavy_check_mark: Second try of correction - use `reinterpret_cast`

No more compilation errors