### PR TITLE
fix the quantization progress bar

### DIFF
--- a/tools/quantization/Helper.cpp
+++ b/tools/quantization/Helper.cpp
@@ -98,9 +98,8 @@ void Helper::readClibrationFiles(std::vector<std::string>& images, const std::st
         ent = readdir(root);
     }
 #endif
-    if (*usedImageNum == 0) {
-        *usedImageNum = count;
-    }
+
+    *usedImageNum = images.size();
     DLOG(INFO) << "used image num: " << images.size();
 }
 


### PR DESCRIPTION
when the number of images in the folder is less than `used_sample_num`, the quantization progress bar may be wrong.

`MNN_PRINT("\rXXXXXXXXXXXX: %.2lf %%", (float)count * 100.0f / (float)_calibrationFileNum);`