### PR TITLE
feat(cl): decoupling numThread and gpuMode

### DIFF
--- a/include/MNN/Interpreter.hpp
+++ b/include/MNN/Interpreter.hpp
@@ -26,9 +26,9 @@ struct ScheduleConfig {
     /** forward type */
     MNNForwardType type = MNN_FORWARD_CPU;
     /** CPU:number of threads in parallel , Or GPU: mode setting*/
-    union {
+    struct {
         int numThread = 4;
-        int mode;
+        int gpuMode = 4;
     };
 
     /** subpath to run */

--- a/source/core/Backend.hpp
+++ b/source/core/Backend.hpp
@@ -33,9 +33,9 @@ public:
         /** forward type. */
         MNNForwardType type = MNN_FORWARD_CPU;
         /** numThread for CPU . number of threads.  gpuMode for GPU only. tuning/memory Mode setting. */
-        union {
+        struct {
             int numThread = 4;
-            int gpuMode;
+            int gpuMode = 4;
         };
         /** user data. */
         BackendConfig* user = NULL;

--- a/source/core/Interpreter.cpp
+++ b/source/core/Interpreter.cpp
@@ -463,6 +463,7 @@ RuntimeInfo Interpreter::createRuntime(const std::vector<ScheduleConfig>& config
         Backend::Info compute;
         compute.type      = Schedule::getApprociateType(config);
         compute.numThread = config.numThread;
+        compute.gpuMode = config.gpuMode;
         compute.user      = config.backendConfig;
         if (mRuntimes.find(compute.type) == mRuntimes.end()) {
             auto newBn = RuntimeFactory::create(compute);

--- a/source/core/Schedule.cpp
+++ b/source/core/Schedule.cpp
@@ -256,6 +256,7 @@ bool Schedule::schedule(ScheduleInfo& scheduleInfo, const Net* net, const std::v
         Backend::Info compute;
         compute.type      = getApprociateType(config);
         compute.numThread = config.numThread;
+        compute.gpuMode = config.gpuMode;
         compute.user      = config.backendConfig;
         auto oplists      = _scheduleUnit(net, config, allTensors);
         result.emplace_back(std::make_pair(compute, std::move(oplists)));

--- a/tools/cpp/MNNV2Basic.cpp
+++ b/tools/cpp/MNNV2Basic.cpp
@@ -189,6 +189,7 @@ static int test_main(int argc, const char* argv[]) {
     config.type      = type;
     /*modeNum means gpuMode for GPU usage, Or means numThread for CPU usage.*/
     config.numThread = modeNum;
+    config.gpuMode = modeNum;
     // If type not fount, let it failed
     config.backupType = type;
     BackendConfig backendConfig;

--- a/tools/cpp/timeProfile.cpp
+++ b/tools/cpp/timeProfile.cpp
@@ -64,10 +64,10 @@ int main(int argc, const char* argv[]) {
         MNN_PRINT("%d ", dim);
     }
     MNN_PRINT("\n");
-    int threadNumber = 4;
+    int modeNum = 4;
     if (argc > 5) {
-        threadNumber = ::atoi(argv[5]);
-        MNN_PRINT("Set ThreadNumber = %d\n", threadNumber);
+        modeNum = ::atoi(argv[5]);
+        MNN_PRINT("Set modeNum = %d\n", modeNum);
     }
 
     float sparsity = 0.0f;
@@ -94,7 +94,8 @@ int main(int argc, const char* argv[]) {
     // create session
     MNN::ScheduleConfig config;
     config.type           = type;
-    config.numThread      = threadNumber;
+    config.numThread      = modeNum;
+    config.gpuMode = modeNum;
     MNN::Session* session = NULL;
     session               = net->createSession(config);
     auto inputTensor      = net->getSessionInput(session, NULL);


### PR DESCRIPTION
It is not flexiable to put numThread and gpuMode in **Union**, especially When I want to use MNN_AUTO and set OpenCL/CPU backend separately. So I think using **Struct** is much more resonable.