### PR TITLE
improvement(GridSample): accelerate GridSample in CPU/Arm82/AVX

### DIFF
--- a/source/backend/cpu/CPUGridSample.cpp
+++ b/source/backend/cpu/CPUGridSample.cpp
@@ -57,7 +57,9 @@ ErrorCode CPUGridSample::onExecute(const std::vector<Tensor *> &inputs, const st
     auto outH = outputTensor->buffer().dim[2].extent;
     auto outW = outputTensor->buffer().dim[3].extent;
     auto threadCount = static_cast<CPUBackend*>(backend())->threadNumber();
-    auto tileCount = channelC4 * outH;
+    auto tileCount = outH;
+    auto inOffset  = batches * inH * inW * core->pack;
+    auto outOffset = batches * outH * outW * core->pack;
     auto cordPtr = mTempCordBuffer->host<uint8_t>();
     for (auto b = 0; b < batches; ++b) {
         auto _inputPtr = inputPtr + b * inH * inW * core->pack * core->bytes;
@@ -73,7 +75,7 @@ ErrorCode CPUGridSample::onExecute(const std::vector<Tensor *> &inputs, const st
                 auto outputC = _outputPtr + c * outW * outH * batches * core->pack * core->bytes;
                 auto cordH = cordPtr + h * outW * 2 * core->bytes;
                 auto outputH = outputC + h * outW * core->pack * core->bytes;
-                core->MNNGridSampleInterp((float *)outputH, (const float *)inputC, (const float *)cordH, inH, inW, outW, (mMode == SampleMode_NEAREST), (mPaddingMode == BorderMode_ZEROS));
+                core->MNNGridSampleInterp((float *)outputH, (const float *)inputC, (const float *)cordH, inH, inW, outW, channelC4, inOffset, outOffset, (mMode == SampleMode_NEAREST), (mPaddingMode == BorderMode_ZEROS));
             }
         }
         MNN_CONCURRENCY_END();

--- a/source/backend/cpu/compute/CommonOptFunction.h
+++ b/source/backend/cpu/compute/CommonOptFunction.h
@@ -141,6 +141,7 @@ void MNNInt8ToInt16(int16_t* dest, const int8_t* source, size_t count);
 
 
 void MNNGridSampleComputeCord(float* dst, const float* src, size_t inH, size_t inW, size_t outH, size_t outW, size_t stride, bool alignCorners);
+size_t MNNGridSampleComputeOffset(int h, int w, int height, int width, bool padMode);
 void MNNGridSampleInterp(float* outputPtr, const float* inputPtr, const float* cordPtr, size_t inH, size_t inW, size_t outW, bool sampleMode, bool padMode);
 
 typedef void(*MNNBinaryExecute)(void* outputRaw, const void* inputRaw0, const void* inputRaw1, int elementSize, int broadcastIndex);
@@ -201,7 +202,7 @@ struct CoreFunctions {
     void(*MNNStrassenMergeCFunction)(float* c11, float* c12, float* c21, float* c22, float* xAddr, size_t cStride, size_t eSub, size_t hSub);
     void(*MNNScaleAndAddBias)(float* dst, const float* src, const float* bias, const float* alpha, size_t planeNumber, size_t biasNumber);
     void(*MNNGridSampleComputeCord)(float* dst, const float* src, size_t inH, size_t inW, size_t outH, size_t outW, size_t stride, bool alignCorners);
-    void(*MNNGridSampleInterp)(float* outputPtr, const float* inputPtr, const float* cordPtr, size_t inH, size_t inW, size_t outW, bool sampleMode, bool padMode);
+    void(*MNNGridSampleInterp)(float* outputPtr, const float* inputPtr, const float* cordPtr, size_t inH, size_t inW, size_t outW, size_t channelCUnit, size_t inOffset, size_t outOffset, bool sampleMode, bool padMode);
     float penalty;
 
     void(*MNNCopyC4WithStride)(const float* source, float* dest, size_t srcStride, size_t dstStride, size_t count);

--- a/source/backend/cpu/x86_x64/AVX2Functions.cpp
+++ b/source/backend/cpu/x86_x64/AVX2Functions.cpp
@@ -55,6 +55,7 @@ bool AVX2Functions::init(int cpuFlags) {
     coreFunction->MNNReluWithSlopeChannel = _AVX_MNNReluWithSlopeChannel;
     coreFunction->MNNDeconvRunForLineDepthwise = _AVX_MNNDeconvRunForLineDepthwise;
     coreFunction->MNNDeconvRunForUnitDepthWise = _AVX_MNNDeconvRunForUnitDepthWise;
+    coreFunction->MNNGridSampleComputeCord = _AVX_MNNGridSampleComputeCord;
     coreFunction->MNNGridSampleInterp = _AVX_MNNGridSampleInterp;
     // For Pooling / Binary
     _AVX_ExtraInit(coreFunction);

--- a/source/backend/cpu/x86_x64/avx/FunctionSummary.hpp
+++ b/source/backend/cpu/x86_x64/avx/FunctionSummary.hpp
@@ -98,6 +98,7 @@ void _AVX_MNNDeconvRunForLineDepthwise(const float* dst, float* src, const float
 void _AVX_MNNGelu(float *dst, const float *src, size_t size);
 void _AVX_MNNNorm(float *dst, const float *src, const float *gamma, const float *beta, float epsilon, size_t size);
 
-void _AVX_MNNGridSampleInterp(float* outputPtr, const float* inputPtr, const float* cordPtr, size_t inH, size_t inW, size_t outW, bool sampleMode, bool padMode);
+void _AVX_MNNGridSampleInterp(float* outputPtr, const float* inputPtr, const float* cordPtr, size_t inH, size_t inW, size_t outW, size_t channelCUnit, size_t inOffset, size_t outOffset, bool sampleMode, bool padMode);
+void _AVX_MNNGridSampleComputeCord(float* dst, const float* src, size_t inH, size_t inW, size_t outH, size_t outW, size_t stride, bool alignCorners); 
 
 }


### PR DESCRIPTION
1.优化大通道下GridSample的CPU端速度。由grid计算出对应的input坐标之后，此坐标可以作用于所有的channel，无需重复计算。
2.使用avx2指令优化MNNGridSampleComputeCord函数。