### PR TITLE
improvement(GridSample): accelerate GridSample in CPU/Arm82/AVX2/AVX512

### DIFF
--- a/source/backend/cpu/CPUGridSample.cpp
+++ b/source/backend/cpu/CPUGridSample.cpp
@@ -57,7 +57,9 @@ ErrorCode CPUGridSample::onExecute(const std::vector<Tensor *> &inputs, const st
     auto outH = outputTensor->buffer().dim[2].extent;
     auto outW = outputTensor->buffer().dim[3].extent;
     auto threadCount = static_cast<CPUBackend*>(backend())->threadNumber();
-    auto tileCount = channelC4 * outH;
+    auto tileCount = outH;
+    auto inOffset  = batches * inH * inW * core->pack;
+    auto outOffset = batches * outH * outW * core->pack;
     auto cordPtr = mTempCordBuffer->host<uint8_t>();
     for (auto b = 0; b < batches; ++b) {
         auto _inputPtr = inputPtr + b * inH * inW * core->pack * core->bytes;
@@ -73,7 +75,7 @@ ErrorCode CPUGridSample::onExecute(const std::vector<Tensor *> &inputs, const st
                 auto outputC = _outputPtr + c * outW * outH * batches * core->pack * core->bytes;
                 auto cordH = cordPtr + h * outW * 2 * core->bytes;
                 auto outputH = outputC + h * outW * core->pack * core->bytes;
-                core->MNNGridSampleInterp((float *)outputH, (const float *)inputC, (const float *)cordH, inH, inW, outW, (mMode == SampleMode_NEAREST), (mPaddingMode == BorderMode_ZEROS));
+                core->MNNGridSampleInterp((float *)outputH, (const float *)inputC, (const float *)cordH, inH, inW, outW, channelC4, inOffset, outOffset, (mMode == SampleMode_NEAREST), (mPaddingMode == BorderMode_ZEROS));
             }
         }
         MNN_CONCURRENCY_END();

--- a/source/backend/cpu/compute/CommonOptFunction.cpp
+++ b/source/backend/cpu/compute/CommonOptFunction.cpp
@@ -1543,22 +1543,22 @@ void MNNNorm(float *dst, const float *src, const float *gamma, const float *beta
 }
 #endif
 
-Vec4 MNNGridSampleLoadSample(int h, int w, const float *buffer, int height, int width, bool padMode) {
-    if (h < 0 || h >= height || w < 0 || w >= width) {
-        if(padMode == true) { //padMode == BorderMode_ZEROS
-            return 0.0f;
+size_t MNNGridSampleComputeOffset(int h, int w, int height, int width, bool padMode) {
+    if (padMode == true) { //padMode == BorderMode_ZEROS
+        if (h < 0 || h >= height || w < 0 || w >= width) {
+            return -1;
         }
+    } else {
         // Clearly, CLAMP is the right way to go for GridSamplePaddingMode_BORDER
         // For GridSamplePaddingMode_REFLECTION, since we have reflected the values into (-1, 1),
         // the leftover reflections degrade to GridSamplePaddingMode_BORDER
         h = h < 0 ? 0 : ( h > (height - 1) ? (height - 1) : h);
         w = w < 0 ? 0 : ( w > (width - 1) ? (width - 1) : w);
     }
-
-    return Vec4::load(buffer + h * width * 4 + w * 4);
+    return h * width * 4 + w * 4;
 }
 
-void MNNGridSampleInterp(float* outputPtr, const float* inputPtr, const float* cordPtr, size_t inH, size_t inW, size_t outW, bool sampleMode, bool padMode) {
+void MNNGridSampleInterp(float* outputPtr, const float* inputPtr, const float* cordPtr, size_t inH, size_t inW, size_t outW, size_t channelCUnit, size_t inOffset, size_t outOffset, bool sampleMode, bool padMode) {
     for (auto ow = 0; ow < outW; ++ow) {
         auto w = cordPtr[2 * ow + 0];
         auto h = cordPtr[2 * ow + 1];
@@ -1567,7 +1567,11 @@ void MNNGridSampleInterp(float* outputPtr, const float* inputPtr, const float* c
         if (sampleMode == true) { //sampleMode == SampleMode_NEAREST
             int nh = ::floor(h + 0.5f);
             int nw = ::floor(w + 0.5f);
-            interp = MNNGridSampleLoadSample(nh, nw, inputPtr, inH, inW, padMode);
+            size_t ns = MNNGridSampleComputeOffset(nh, nw, inH, inW, padMode);
+            for (int k = 0; k < channelCUnit; ++k) {
+                interp = ns == -1 ? Vec4(0.f) : Vec4::load(inputPtr + k * inOffset + ns);
+                Vec4::save(outputPtr + k * outOffset + 4 * ow, interp);
+            }
         } else { //sampleMode == GridSampleMode_BILINEAR
             int w0_h = ::floor(h);
             int w0_w = ::floor(w);
@@ -1575,22 +1579,29 @@ void MNNGridSampleInterp(float* outputPtr, const float* inputPtr, const float* c
             int w1_w = ::ceil(w);
             auto oneV = Vec4(1.0f);
 
-            Vec4 i00 = MNNGridSampleLoadSample(w0_h, w0_w, inputPtr, inH, inW, padMode);
-            Vec4 i01 = MNNGridSampleLoadSample(w0_h, w1_w, inputPtr, inH, inW, padMode);
-            Vec4 i10 = MNNGridSampleLoadSample(w1_h, w0_w, inputPtr, inH, inW, padMode);
-            Vec4 i11 = MNNGridSampleLoadSample(w1_h, w1_w, inputPtr, inH, inW, padMode);
             auto f0 = Vec4((float)w1_w - w);
             auto f1 = oneV - f0;
             auto h0 = Vec4((float)w1_h - h);
             auto h1 = oneV - h0;
 
-            Vec4 i0 = i00 * f0 + i01 * f1;
-            Vec4 i1 = i10 * f0 + i11 * f1;
+            size_t s00 = MNNGridSampleComputeOffset(w0_h, w0_w, inH, inW, padMode);
+            size_t s01 = MNNGridSampleComputeOffset(w0_h, w1_w, inH, inW, padMode);
+            size_t s10 = MNNGridSampleComputeOffset(w1_h, w0_w, inH, inW, padMode);
+            size_t s11 = MNNGridSampleComputeOffset(w1_h, w1_w, inH, inW, padMode);
 
-            interp = i0 * h0 + i1 * h1;
+            for (int k = 0; k < channelCUnit; ++k) {
+                Vec4 i00 = s00 == -1 ? Vec4(0.f) : Vec4::load(inputPtr + k * inOffset + s00);
+                Vec4 i01 = s01 == -1 ? Vec4(0.f) : Vec4::load(inputPtr + k * inOffset + s01);
+                Vec4 i10 = s10 == -1 ? Vec4(0.f) : Vec4::load(inputPtr + k * inOffset + s10);
+                Vec4 i11 = s11 == -1 ? Vec4(0.f) : Vec4::load(inputPtr + k * inOffset + s11);
+
+                Vec4 i0 = i00 * f0 + i01 * f1;
+                Vec4 i1 = i10 * f0 + i11 * f1;
+
+                interp = i0 * h0 + i1 * h1;
+                Vec4::save(outputPtr + k * outOffset + 4 * ow, interp);
+            }
         }
-
-        Vec4::save(outputPtr + 4 * ow, interp);
     }
 }
 

--- a/source/backend/cpu/compute/CommonOptFunction.h
+++ b/source/backend/cpu/compute/CommonOptFunction.h
@@ -150,7 +150,8 @@ void MNNInt8ToInt16(int16_t* dest, const int8_t* source, size_t count);
 
 
 void MNNGridSampleComputeCord(float* dst, const float* src, size_t inH, size_t inW, size_t outH, size_t outW, size_t stride, bool alignCorners);
-void MNNGridSampleInterp(float* outputPtr, const float* inputPtr, const float* cordPtr, size_t inH, size_t inW, size_t outW, bool sampleMode, bool padMode);
+void MNNGridSampleInterp(float* outputPtr, const float* inputPtr, const float* cordPtr, size_t inH, size_t inW, size_t outW, 
+                            size_t channelCUnit, size_t inOffset, size_t outOffset, bool sampleMode, bool padMode);
 
 typedef void(*MNNBinaryExecute)(void* outputRaw, const void* inputRaw0, const void* inputRaw1, int elementSize, int broadcastIndex);
 typedef void(*MNNUnaryExecute)(void* outputRaw, const void* inputRaw, int elementSize);
@@ -225,7 +226,7 @@ struct CoreFunctions {
     void(*MNNStrassenMergeCFunction)(float* c11, float* c12, float* c21, float* c22, float* xAddr, size_t cStride, size_t eSub, size_t hSub);
     void(*MNNScaleAndAddBias)(float* dst, const float* src, const float* bias, const float* alpha, size_t planeNumber, size_t biasNumber);
     void(*MNNGridSampleComputeCord)(float* dst, const float* src, size_t inH, size_t inW, size_t outH, size_t outW, size_t stride, bool alignCorners);
-    void(*MNNGridSampleInterp)(float* outputPtr, const float* inputPtr, const float* cordPtr, size_t inH, size_t inW, size_t outW, bool sampleMode, bool padMode);
+    void(*MNNGridSampleInterp)(float* outputPtr, const float* inputPtr, const float* cordPtr, size_t inH, size_t inW, size_t outW, size_t channelCUnit, size_t inOffset, size_t outOffset, bool sampleMode, bool padMode);
     float penalty;
 
     void(*MNNCopyC4WithStride)(const float* source, float* dest, size_t srcStride, size_t dstStride, size_t count);

--- a/source/backend/cpu/x86_x64/avx/PackedFunction.cpp
+++ b/source/backend/cpu/x86_x64/avx/PackedFunction.cpp
@@ -25,7 +25,9 @@ void _AVX_MNNDeconvRunForUnitDepthWise(const float* dst, float* src, const float
                                        size_t weight_y_step, size_t dilateX_step, size_t dilateY_step);
 void _AVX_MNNDeconvRunForLineDepthwise(const float* dst, float* src, const float* weight, size_t width, size_t src_w_setup,
                                        size_t fw, size_t fh, size_t dilateX_step, size_t dilateY_step);
-void _AVX_MNNGridSampleInterp(float* outputPtr, const float* inputPtr, const float* cordPtr, size_t inH, size_t inW, size_t outW, bool sampleMode, bool padMode);
+void _AVX_MNNGridSampleComputeCord(float* dst, const float* src, size_t inH, size_t inW, size_t outH, size_t outW, size_t stride, bool alignCorners);
+void _AVX_MNNGridSampleInterp(float* outputPtr, const float* inputPtr, const float* cordPtr, size_t inH, size_t inW, size_t outW, 
+                                    size_t channelCUnit, size_t inOffset, size_t outOffset, bool sampleMode, bool padMode);
 void _AVX_MNNStrassenMergeCFunction(float* c11, float* c12, float* c21, float* c22, float* xAddr, size_t cStride, size_t eSub, size_t hSub);
 void _AVX_MNNConvRunForUnitDepthWise(float* dst, const float* src, const float* weight, size_t fw, size_t fh,
                                      size_t weight_y_step, size_t dilateX_step, size_t dilateY_step);
@@ -240,21 +242,64 @@ void _AVX_MNNDeconvRunForLineDepthwise(const float* dst, float* src, const float
     }
 }
 
-static __m256 MNNGridSampleLoadSample(int h, int w, const float *buffer, int height, int width, bool padMode) {
-    if (h < 0 || h >= height || w < 0 || w >= width) {
-        if(padMode == true) { //padMode == BorderMode_ZEROS
-            return _mm256_setzero_ps();
+void _AVX_MNNGridSampleComputeCord(float* dst, const float* src, size_t inH, size_t inW, size_t outH, size_t outW, size_t stride, bool alignCorners) {
+    __m256 zero = _mm256_setzero_ps();
+    __m256 one = _mm256_set1_ps(1);
+    __m256 half = _mm256_set1_ps(0.5f);
+    __m256 a = alignCorners ? one : zero;
+    __m256 b = alignCorners ? zero : one;
+    __m256 inW_sub_a = _mm256_sub_ps(_mm256_set1_ps(inW), a);
+    __m256 inH_sub_a = _mm256_sub_ps(_mm256_set1_ps(inH), a);
+
+    int area = outH * outW;
+    int areaC4 = area / PACK_UNIT;
+    int areaRemain = area - areaC4 * PACK_UNIT;
+    for (int i = 0; i < areaC4; ++i) {
+        __m256 grid0 = _mm256_loadu_ps(src);               // x0, y0, x1, y1, x2, y2, x3, y3
+        __m256 grid1 = _mm256_loadu_ps(src + PACK_UNIT);   // x4, y4, x5, y5, x6, y6, x7, y7
+        __m256 x = _mm256_shuffle_ps(grid0, grid1, 0x88);  // x0, x1, x4, x5, x2, x3, x6, x7
+        __m256 y = _mm256_shuffle_ps(grid0, grid1, 0xdd);  // y0, y1, y4, y5, y2, y3, y6, y7
+        __m256 cord_x = _mm256_mul_ps(half, _mm256_sub_ps(_mm256_mul_ps(_mm256_add_ps(one, x), inW_sub_a), b));
+        __m256 cord_y = _mm256_mul_ps(half, _mm256_sub_ps(_mm256_mul_ps(_mm256_add_ps(one, y), inH_sub_a), b));
+        __m256 cord0 = _mm256_unpacklo_ps(cord_x, cord_y);  // x0, y0, x1, y1, x2, y2, x3, y3
+        __m256 cord1 = _mm256_unpackhi_ps(cord_x, cord_y);  // x4, y4, x5, y5, x6, y6, x7, y7
+
+        _mm256_storeu_ps(dst, cord0);
+        _mm256_storeu_ps(dst + PACK_UNIT, cord1);
+
+        src += PACK_UNIT * 2;
+        dst += PACK_UNIT * 2;
+    }
+
+    for (int i = 0; i < areaRemain; ++i) {
+        __m256 x = _mm256_set1_ps(src[0]);
+        __m256 y = _mm256_set1_ps(src[1]);
+        x = _mm256_mul_ps(half, _mm256_sub_ps(_mm256_mul_ps(_mm256_add_ps(one, x), inW_sub_a), b));
+        y = _mm256_mul_ps(half, _mm256_sub_ps(_mm256_mul_ps(_mm256_add_ps(one, y), inH_sub_a), b));
+        dst[0] = x[0];
+        dst[1] = y[0];
+
+        src += 2;
+        dst += 2;
+    }
+}
+
+static size_t _AVX_MNNGridSampleComputeOffset(int h, int w, int height, int width, bool padMode) {
+    if (padMode == true) { //padMode == BorderMode_ZEROS
+        if (h < 0 || h >= height || w < 0 || w >= width) {
+            return -1;
         }
+    } else {
         // Clearly, CLAMP is the right way to go for GridSamplePaddingMode_BORDER
         // For GridSamplePaddingMode_REFLECTION, since we have reflected the values into (-1, 1),
         // the leftover reflections degrade to GridSamplePaddingMode_BORDER
         h = h < 0 ? 0 : ( h > (height - 1) ? (height - 1) : h);
         w = w < 0 ? 0 : ( w > (width - 1) ? (width - 1) : w);
     }
-
-    return _mm256_loadu_ps(buffer + h * width * PACK_UNIT + w * PACK_UNIT);
+    return h * width * PACK_UNIT + w * PACK_UNIT;
 }
-void _AVX_MNNGridSampleInterp(float* outputPtr, const float* inputPtr, const float* cordPtr, size_t inH, size_t inW, size_t outW, bool sampleMode, bool padMode) {
+
+void _AVX_MNNGridSampleInterp(float* outputPtr, const float* inputPtr, const float* cordPtr, size_t inH, size_t inW, size_t outW, size_t channelCUnit, size_t inOffset, size_t outOffset, bool sampleMode, bool padMode) {
     for (auto ow = 0; ow < outW; ++ow) {
         auto w = cordPtr[2 * ow + 0];
         auto h = cordPtr[2 * ow + 1];
@@ -263,7 +308,11 @@ void _AVX_MNNGridSampleInterp(float* outputPtr, const float* inputPtr, const flo
         if (sampleMode == true) { //sampleMode == SampleMode_NEAREST
             int nh = ::floor(h + 0.5f);
             int nw = ::floor(w + 0.5f);
-            interp = MNNGridSampleLoadSample(nh, nw, inputPtr, inH, inW, padMode);
+            size_t ns = _AVX_MNNGridSampleComputeOffset(nh, nw, inH, inW, padMode);
+            for (int k = 0; k < channelCUnit; ++k) {
+                interp = ns == -1 ? _mm256_set1_ps(0.f) : _mm256_loadu_ps(inputPtr + k * inOffset + ns);
+                _mm256_storeu_ps(outputPtr + k * outOffset + PACK_UNIT * ow, interp);
+            }
         } else { //sampleMode == GridSampleMode_BILINEAR
             int w0_h = ::floor(h);
             int w0_w = ::floor(w);
@@ -271,21 +320,29 @@ void _AVX_MNNGridSampleInterp(float* outputPtr, const float* inputPtr, const flo
             int w1_w = ::ceil(w);
             auto oneV = _mm256_set1_ps(1.0f);
 
-            __m256 i00 = MNNGridSampleLoadSample(w0_h, w0_w, inputPtr, inH, inW, padMode);
-            __m256 i01 = MNNGridSampleLoadSample(w0_h, w1_w, inputPtr, inH, inW, padMode);
-            __m256 i10 = MNNGridSampleLoadSample(w1_h, w0_w, inputPtr, inH, inW, padMode);
-            __m256 i11 = MNNGridSampleLoadSample(w1_h, w1_w, inputPtr, inH, inW, padMode);
             auto f0 = _mm256_set1_ps((float)w1_w - w);
             auto f1 = _mm256_sub_ps(oneV, f0);
             auto h0 = _mm256_set1_ps((float)w1_h - h);
             auto h1 = _mm256_sub_ps(oneV, h0);
 
-            __m256 i0 = _mm256_add_ps(_mm256_mul_ps(i00, f0), _mm256_mul_ps(i01, f1));
-            __m256 i1 = _mm256_add_ps(_mm256_mul_ps(i10, f0), _mm256_mul_ps(i11, f1));
-            interp = _mm256_add_ps(_mm256_mul_ps(i0, h0), _mm256_mul_ps(i1, h1));
-        }
+            size_t s00 = _AVX_MNNGridSampleComputeOffset(w0_h, w0_w, inH, inW, padMode);
+            size_t s01 = _AVX_MNNGridSampleComputeOffset(w0_h, w1_w, inH, inW, padMode);
+            size_t s10 = _AVX_MNNGridSampleComputeOffset(w1_h, w0_w, inH, inW, padMode);
+            size_t s11 = _AVX_MNNGridSampleComputeOffset(w1_h, w1_w, inH, inW, padMode);
 
-        _mm256_storeu_ps(outputPtr + PACK_UNIT * ow, interp);
+            for (int k = 0; k < channelCUnit; ++k) {
+                __m256 i00 = s00 == -1 ? _mm256_setzero_ps() : _mm256_loadu_ps(inputPtr + k * inOffset + s00);
+                __m256 i01 = s01 == -1 ? _mm256_setzero_ps() : _mm256_loadu_ps(inputPtr + k * inOffset + s01);
+                __m256 i10 = s10 == -1 ? _mm256_setzero_ps() : _mm256_loadu_ps(inputPtr + k * inOffset + s10);
+                __m256 i11 = s11 == -1 ? _mm256_setzero_ps() : _mm256_loadu_ps(inputPtr + k * inOffset + s11);
+
+                __m256 i0 = _mm256_add_ps(_mm256_mul_ps(i00, f0), _mm256_mul_ps(i01, f1));
+                __m256 i1 = _mm256_add_ps(_mm256_mul_ps(i10, f0), _mm256_mul_ps(i11, f1));
+
+                interp = _mm256_add_ps(_mm256_mul_ps(i0, h0), _mm256_mul_ps(i1, h1));
+                _mm256_storeu_ps(outputPtr + k * outOffset + PACK_UNIT * ow, interp);
+            }
+        }
     }
 }
 
@@ -560,6 +617,7 @@ void _AVX_ExtraInit(void* functions) {
     coreFunction->MNNReluWithSlopeChannel = _AVX_MNNReluWithSlopeChannel;
     coreFunction->MNNDeconvRunForLineDepthwise = _AVX_MNNDeconvRunForLineDepthwise;
     coreFunction->MNNDeconvRunForUnitDepthWise = _AVX_MNNDeconvRunForUnitDepthWise;
+    coreFunction->MNNGridSampleComputeCord = _AVX_MNNGridSampleComputeCord;
     coreFunction->MNNGridSampleInterp = _AVX_MNNGridSampleInterp;
 
     // sparse conv funcs

--- a/source/backend/cpu/x86_x64/avx512/PackedFunction.cpp
+++ b/source/backend/cpu/x86_x64/avx512/PackedFunction.cpp
@@ -194,21 +194,64 @@ void _AVX512_MNNDeconvRunForLineDepthwise(const float* dst, float* src, const fl
     }
 }
 
-static __m512 MNNGridSampleLoadSample(int h, int w, const float *buffer, int height, int width, bool padMode) {
-    if (h < 0 || h >= height || w < 0 || w >= width) {
-        if(padMode == true) { //padMode == BorderMode_ZEROS
-            return _mm512_setzero_ps();
+void _AVX512_MNNGridSampleComputeCord(float* dst, const float* src, size_t inH, size_t inW, size_t outH, size_t outW, size_t stride, bool alignCorners) {
+    __m512 zero = _mm512_setzero_ps();
+    __m512 one = _mm512_set1_ps(1);
+    __m512 half = _mm512_set1_ps(0.5f);
+    __m512 a = alignCorners ? one : zero;
+    __m512 b = alignCorners ? zero : one;
+    __m512 inW_sub_a = _mm512_sub_ps(_mm512_set1_ps(inW), a);
+    __m512 inH_sub_a = _mm512_sub_ps(_mm512_set1_ps(inH), a);
+
+    int area = outH * outW;
+    int areaC4 = area / PACK_UNIT;
+    int areaRemain = area - areaC4 * PACK_UNIT;
+    for (int i = 0; i < areaC4; ++i) {
+        __m512 grid0 = _mm512_loadu_ps(src);
+        __m512 grid1 = _mm512_loadu_ps(src + PACK_UNIT);
+        __m512 x = _mm512_shuffle_ps(grid0, grid1, 0x88);
+        __m512 y = _mm512_shuffle_ps(grid0, grid1, 0xdd);
+        __m512 cord_x = _mm512_mul_ps(half, _mm512_sub_ps(_mm512_mul_ps(_mm512_add_ps(one, x), inW_sub_a), b));
+        __m512 cord_y = _mm512_mul_ps(half, _mm512_sub_ps(_mm512_mul_ps(_mm512_add_ps(one, y), inH_sub_a), b));
+        __m512 cord0 = _mm512_unpacklo_ps(cord_x, cord_y);
+        __m512 cord1 = _mm512_unpackhi_ps(cord_x, cord_y);
+
+        _mm512_storeu_ps(dst, cord0);
+        _mm512_storeu_ps(dst + PACK_UNIT, cord1);
+
+        src += PACK_UNIT * 2;
+        dst += PACK_UNIT * 2;
+    }
+
+    for (int i = 0; i < areaRemain; ++i) {
+        __m512 x = _mm512_set1_ps(src[0]);
+        __m512 y = _mm512_set1_ps(src[1]);
+        x = _mm512_mul_ps(half, _mm512_sub_ps(_mm512_mul_ps(_mm512_add_ps(one, x), inW_sub_a), b));
+        y = _mm512_mul_ps(half, _mm512_sub_ps(_mm512_mul_ps(_mm512_add_ps(one, y), inH_sub_a), b));
+        dst[0] = x[0];
+        dst[1] = y[0];
+
+        src += 2;
+        dst += 2;
+    }
+}
+
+static size_t _AVX512_MNNGridSampleComputeOffset(int h, int w, int height, int width, bool padMode) {
+    if (padMode == true) { //padMode == BorderMode_ZEROS
+        if (h < 0 || h >= height || w < 0 || w >= width) {
+            return -1;
         }
+    } else {
         // Clearly, CLAMP is the right way to go for GridSamplePaddingMode_BORDER
         // For GridSamplePaddingMode_REFLECTION, since we have reflected the values into (-1, 1),
         // the leftover reflections degrade to GridSamplePaddingMode_BORDER
         h = h < 0 ? 0 : ( h > (height - 1) ? (height - 1) : h);
         w = w < 0 ? 0 : ( w > (width - 1) ? (width - 1) : w);
     }
-
-    return _mm512_loadu_ps(buffer + h * width * PACK_UNIT + w * PACK_UNIT);
+    return h * width * PACK_UNIT + w * PACK_UNIT;
 }
-void _AVX512_MNNGridSampleInterp(float* outputPtr, const float* inputPtr, const float* cordPtr, size_t inH, size_t inW, size_t outW, bool sampleMode, bool padMode) {
+
+void _AVX512_MNNGridSampleInterp(float* outputPtr, const float* inputPtr, const float* cordPtr, size_t inH, size_t inW, size_t outW, size_t channelCUnit, size_t inOffset, size_t outOffset, bool sampleMode, bool padMode) {
     for (auto ow = 0; ow < outW; ++ow) {
         auto w = cordPtr[2 * ow + 0];
         auto h = cordPtr[2 * ow + 1];
@@ -217,7 +260,11 @@ void _AVX512_MNNGridSampleInterp(float* outputPtr, const float* inputPtr, const 
         if (sampleMode == true) { //sampleMode == SampleMode_NEAREST
             int nh = ::floor(h + 0.5f);
             int nw = ::floor(w + 0.5f);
-            interp = MNNGridSampleLoadSample(nh, nw, inputPtr, inH, inW, padMode);
+            size_t ns = _AVX512_MNNGridSampleComputeOffset(nh, nw, inH, inW, padMode);
+            for (int k = 0; k < channelCUnit; ++k) {
+                interp = ns == -1 ? _mm512_set1_ps(0.f) : _mm512_loadu_ps(inputPtr + k * inOffset + ns);
+                _mm512_storeu_ps(outputPtr + k * outOffset + PACK_UNIT * ow, interp);
+            }
         } else { //sampleMode == GridSampleMode_BILINEAR
             int w0_h = ::floor(h);
             int w0_w = ::floor(w);
@@ -225,21 +272,29 @@ void _AVX512_MNNGridSampleInterp(float* outputPtr, const float* inputPtr, const 
             int w1_w = ::ceil(w);
             auto oneV = _mm512_set1_ps(1.0f);
 
-            __m512 i00 = MNNGridSampleLoadSample(w0_h, w0_w, inputPtr, inH, inW, padMode);
-            __m512 i01 = MNNGridSampleLoadSample(w0_h, w1_w, inputPtr, inH, inW, padMode);
-            __m512 i10 = MNNGridSampleLoadSample(w1_h, w0_w, inputPtr, inH, inW, padMode);
-            __m512 i11 = MNNGridSampleLoadSample(w1_h, w1_w, inputPtr, inH, inW, padMode);
             auto f0 = _mm512_set1_ps((float)w1_w - w);
             auto f1 = _mm512_sub_ps(oneV, f0);
             auto h0 = _mm512_set1_ps((float)w1_h - h);
             auto h1 = _mm512_sub_ps(oneV, h0);
 
-            __m512 i0 = _mm512_add_ps(_mm512_mul_ps(i00, f0), _mm512_mul_ps(i01, f1));
-            __m512 i1 = _mm512_add_ps(_mm512_mul_ps(i10, f0), _mm512_mul_ps(i11, f1));
-            interp = _mm512_add_ps(_mm512_mul_ps(i0, h0), _mm512_mul_ps(i1, h1));
-        }
+            size_t s00 = _AVX512_MNNGridSampleComputeOffset(w0_h, w0_w, inH, inW, padMode);
+            size_t s01 = _AVX512_MNNGridSampleComputeOffset(w0_h, w1_w, inH, inW, padMode);
+            size_t s10 = _AVX512_MNNGridSampleComputeOffset(w1_h, w0_w, inH, inW, padMode);
+            size_t s11 = _AVX512_MNNGridSampleComputeOffset(w1_h, w1_w, inH, inW, padMode);
 
-        _mm512_storeu_ps(outputPtr + PACK_UNIT * ow, interp);
+            for (int k = 0; k < channelCUnit; ++k) {
+                __m512 i00 = s00 == -1 ? _mm512_setzero_ps() : _mm512_loadu_ps(inputPtr + k * inOffset + s00);
+                __m512 i01 = s01 == -1 ? _mm512_setzero_ps() : _mm512_loadu_ps(inputPtr + k * inOffset + s01);
+                __m512 i10 = s10 == -1 ? _mm512_setzero_ps() : _mm512_loadu_ps(inputPtr + k * inOffset + s10);
+                __m512 i11 = s11 == -1 ? _mm512_setzero_ps() : _mm512_loadu_ps(inputPtr + k * inOffset + s11);
+
+                __m512 i0 = _mm512_add_ps(_mm512_mul_ps(i00, f0), _mm512_mul_ps(i01, f1));
+                __m512 i1 = _mm512_add_ps(_mm512_mul_ps(i10, f0), _mm512_mul_ps(i11, f1));
+
+                interp = _mm512_add_ps(_mm512_mul_ps(i0, h0), _mm512_mul_ps(i1, h1));
+                _mm512_storeu_ps(outputPtr + k * outOffset + PACK_UNIT * ow, interp);
+            }
+        }
     }
 }
 
@@ -542,5 +597,6 @@ void _AVX512_ExtraInit(void* functions) {
     coreFunction->MNNReluWithSlopeChannel = _AVX512_MNNReluWithSlopeChannel;
     coreFunction->MNNDeconvRunForLineDepthwise = _AVX512_MNNDeconvRunForLineDepthwise;
     coreFunction->MNNDeconvRunForUnitDepthWise = _AVX512_MNNDeconvRunForUnitDepthWise;
+    coreFunction->MNNGridSampleComputeCord = _AVX512_MNNGridSampleComputeCord;
     coreFunction->MNNGridSampleInterp = _AVX512_MNNGridSampleInterp;
 }


### PR DESCRIPTION
1.优化大通道下GridSample的CPU端速度。由grid计算出对应的input坐标之后，此坐标可以作用于所有的channel，无需重复计算。
2.使用AVX2/AVX512指令优化相应后端的MNNGridSampleComputeCord函数。