### PR TITLE
improvement(ConvWino): use fma to accelerate computation

### DIFF
--- a/source/backend/arm82/Arm82Vec.hpp
+++ b/source/backend/arm82/Arm82Vec.hpp
@@ -58,6 +58,14 @@ struct Vec<FLOAT16, 8> {
     static void mls(VecType& v1, const VecType& v2, const VecType& v3) {
         v1.value = vfmsq_f16(v1.value, v2.value, v3.value);
     }
+    static VecType fma(const VecType& v1, const VecType& v2, const VecType& v3) {
+        VecType dst = { vfmaq_f16(v1.value, v2.value, v3.value) };
+        return dst;
+    }
+    static VecType fms(const VecType& v1, const VecType& v2, const VecType& v3) {
+        VecType dst = { vfmsq_f16(v1.value, v2.value, v3.value) };
+        return dst;
+    }
     VecType operator+(const VecType& lr) {
         VecType dst = { vaddq_f16(value, lr.value) };
         return dst;

--- a/source/backend/arm82/Arm82WinogradOptFunc.cpp
+++ b/source/backend/arm82/Arm82WinogradOptFunc.cpp
@@ -46,6 +46,10 @@ using ElementType = FLOAT16;
     VecType::save(srcPtr + 10 * packCUnit, v10);                            \
     VecType::save(srcPtr + 11 * packCUnit, v11);
 
+extern "C" {
+    void MNNConvWinoSourceTransformUnit6x6FP16(const FLOAT16* srcBlock, FLOAT16* dstStart, size_t srcStep, size_t dstStep);
+}
+
 namespace MNN {
 
 static void _sourceTransformUnit4x4Pack12(ElementType* srcBlock, ElementType* dstStart, size_t dstStep) {
@@ -193,68 +197,106 @@ static void _sourceTransformUnit8x8Pack12(ElementType* srcBlock, ElementType* ds
 
 
         // to-try: reorder complicated commpute of 8x8
-        auto ep0 = s00 * 36.f - s20 * 49.f + s40 * 14.f - s60;
-        auto ep1 = s01 * 36.f - s21 * 49.f + s41 * 14.f - s61;
-        auto ep2 = s02 * 36.f - s22 * 49.f + s42 * 14.f - s62;
+        Vec ep0, ep1, ep2;
+        Vec a0, a1, a2;
+        Vec b0, b1, b2;
+
+        a0 = Vec::fma(Vec::fma(s60, s20, Vec(36)), s40, Vec(-13));
+        a1 = Vec::fma(Vec::fma(s61, s21, Vec(36)), s41, Vec(-13));
+        a2 = Vec::fma(Vec::fma(s62, s22, Vec(36)), s42, Vec(-13));
+
+        b0 = Vec::fma(Vec::fma(s40, s00, Vec(36)), s20, Vec(-13));
+        b1 = Vec::fma(Vec::fma(s41, s01, Vec(36)), s21, Vec(-13));
+        b2 = Vec::fma(Vec::fma(s42, s02, Vec(36)), s22, Vec(-13));
+
+        ep0 = b0 - a0;
+        ep1 = b1 - a1;
+        ep2 = b2 - a2;
         VecType::save(dstPtr + 0 * dstStep + 0 * packCUnit, ep0);
         VecType::save(dstPtr + 0 * dstStep + 1 * packCUnit, ep1);
         VecType::save(dstPtr + 0 * dstStep + 2 * packCUnit, ep2);
 
-        ep0 = (s10 + s20) * 36.f - (s30 + s40) * 13.f + (s50 + s60);
-        ep1 = (s11 + s21) * 36.f - (s31 + s41) * 13.f + (s51 + s61);
-        ep2 = (s12 + s22) * 36.f - (s32 + s42) * 13.f + (s52 + s62);
+        b0 = Vec::fma(Vec::fma(s50, s10, Vec(36)), s30, Vec(-13));
+        b1 = Vec::fma(Vec::fma(s51, s11, Vec(36)), s31, Vec(-13));
+        b2 = Vec::fma(Vec::fma(s52, s12, Vec(36)), s32, Vec(-13));
+
+        ep0 = a0 + b0;
+        ep1 = a1 + b1;
+        ep2 = a2 + b2;
         VecType::save(dstPtr + 1 * dstStep + 0 * packCUnit, ep0);
         VecType::save(dstPtr + 1 * dstStep + 1 * packCUnit, ep1);
         VecType::save(dstPtr + 1 * dstStep + 2 * packCUnit, ep2);
 
-        ep0 = (s20 - s10) * 36.f + (s30 - s40) * 13.f + (s60 - s50);
-        ep1 = (s21 - s11) * 36.f + (s31 - s41) * 13.f + (s61 - s51);
-        ep2 = (s22 - s12) * 36.f + (s32 - s42) * 13.f + (s62 - s52);
+        ep0 = a0 - b0;
+        ep1 = a1 - b1;
+        ep2 = a2 - b2;
         VecType::save(dstPtr + 2 * dstStep + 0 * packCUnit, ep0);
         VecType::save(dstPtr + 2 * dstStep + 1 * packCUnit, ep1);
         VecType::save(dstPtr + 2 * dstStep + 2 * packCUnit, ep2);
 
-        ep0 = s10 * 18.f + s20 * 9.f - s30 * 20.f - s40 * 10.f + s50 * 2.f + s60;
-        ep1 = s11 * 18.f + s21 * 9.f - s31 * 20.f - s41 * 10.f + s51 * 2.f + s61;
-        ep2 = s12 * 18.f + s22 * 9.f - s32 * 20.f - s42 * 10.f + s52 * 2.f + s62;
+        a0 = Vec::fma(Vec::fma(s70, s30, Vec(36)), s50, Vec(-13));
+        a1 = Vec::fma(Vec::fma(s71, s31, Vec(36)), s51, Vec(-13));
+        a2 = Vec::fma(Vec::fma(s72, s32, Vec(36)), s52, Vec(-13));
+
+        ep0 = a0 - b0;
+        ep1 = a1 - b1;
+        ep2 = a2 - b2;
+
+        VecType::save(dstPtr + 7 * dstStep + 0 * packCUnit, ep0);
+        VecType::save(dstPtr + 7 * dstStep + 1 * packCUnit, ep1);
+        VecType::save(dstPtr + 7 * dstStep + 2 * packCUnit, ep2);
+
+        a0 = Vec::fma(Vec::fma(s60, s20, Vec(9)), s40, Vec(-10));
+        a1 = Vec::fma(Vec::fma(s61, s21, Vec(9)), s41, Vec(-10));
+        a2 = Vec::fma(Vec::fma(s62, s22, Vec(9)), s42, Vec(-10));
+
+        b0 = Vec::fma(s50, s10, Vec(18)) + Vec::fma(s50, s30, Vec(-20));
+        b1 = Vec::fma(s51, s11, Vec(18)) + Vec::fma(s51, s31, Vec(-20));
+        b2 = Vec::fma(s52, s12, Vec(18)) + Vec::fma(s52, s32, Vec(-20));
+
+        ep0 = a0 + b0;
+        ep1 = a1 + b1;
+        ep2 = a2 + b2;
         VecType::save(dstPtr + 3 * dstStep + 0 * packCUnit, ep0);
         VecType::save(dstPtr + 3 * dstStep + 1 * packCUnit, ep1);
         VecType::save(dstPtr + 3 * dstStep + 2 * packCUnit, ep2);
 
-        ep0 = s20 * 9.f - s10 * 18.f + s30 * 20.f - s40 * 10.f - s50 * 2.f + s60;
-        ep1 = s21 * 9.f - s11 * 18.f + s31 * 20.f - s41 * 10.f - s51 * 2.f + s61;
-        ep2 = s22 * 9.f - s12 * 18.f + s32 * 20.f - s42 * 10.f - s52 * 2.f + s62;
+        ep0 = a0 - b0;
+        ep1 = a1 - b1;
+        ep2 = a2 - b2;
         VecType::save(dstPtr + 4 * dstStep + 0 * packCUnit, ep0);
         VecType::save(dstPtr + 4 * dstStep + 1 * packCUnit, ep1);
         VecType::save(dstPtr + 4 * dstStep + 2 * packCUnit, ep2);
 
-        ep0 = s10 * 12.f + s20 * 4.f - s30 * 15.f - s40 * 5.f + s50 * 3.f + s60;
-        ep1 = s11 * 12.f + s21 * 4.f - s31 * 15.f - s41 * 5.f + s51 * 3.f + s61;
-        ep2 = s12 * 12.f + s22 * 4.f - s32 * 15.f - s42 * 5.f + s52 * 3.f + s62;
+
+        a0 = Vec::fma(Vec::fma(s60, s20, Vec(4)), s40, Vec(-5));
+        a1 = Vec::fma(Vec::fma(s61, s21, Vec(4)), s41, Vec(-5));
+        a2 = Vec::fma(Vec::fma(s62, s22, Vec(4)), s42, Vec(-5));
+
+        b0 = Vec::fma(Vec::fma(s50 * 3, s10, Vec(12)), s30, Vec(-15));
+        b1 = Vec::fma(Vec::fma(s51 * 3, s11, Vec(12)), s31, Vec(-15));
+        b2 = Vec::fma(Vec::fma(s52 * 3, s12, Vec(12)), s32, Vec(-15));
+
+        ep0 = a0 + b0;
+        ep1 = a1 + b1;
+        ep2 = a2 + b2;
         VecType::save(dstPtr + 5 * dstStep + 0 * packCUnit, ep0);
         VecType::save(dstPtr + 5 * dstStep + 1 * packCUnit, ep1);
         VecType::save(dstPtr + 5 * dstStep + 2 * packCUnit, ep2);
 
-        ep0 = s20 * 4.f - s10 * 12.f + s30 * 15.f - s40 * 5.f - s50 * 3.f + s60;
-        ep1 = s21 * 4.f - s11 * 12.f + s31 * 15.f - s41 * 5.f - s51 * 3.f + s61;
-        ep2 = s22 * 4.f - s12 * 12.f + s32 * 15.f - s42 * 5.f - s52 * 3.f + s62;
+        ep0 = a0 - b0;
+        ep1 = a1 - b1;
+        ep2 = a2 - b2;
         VecType::save(dstPtr + 6 * dstStep + 0 * packCUnit, ep0);
         VecType::save(dstPtr + 6 * dstStep + 1 * packCUnit, ep1);
         VecType::save(dstPtr + 6 * dstStep + 2 * packCUnit, ep2);
-
-        ep0 = s30 * 49.f - s10 * 36.f - s50 * 14.f + s70;
-        ep1 = s31 * 49.f - s11 * 36.f - s51 * 14.f + s71;
-        ep2 = s32 * 49.f - s12 * 36.f - s52 * 14.f + s72;
-        VecType::save(dstPtr + 7 * dstStep + 0 * packCUnit, ep0);
-        VecType::save(dstPtr + 7 * dstStep + 1 * packCUnit, ep1);
-        VecType::save(dstPtr + 7 * dstStep + 2 * packCUnit, ep2);
+        
         srcPtr += ePack << 1;
         dstPtr += ePack << 1;
     }
 }
 
 static void _sourceTransformUnit6x6Pack12(ElementType* srcBlock, ElementType* dstStart, size_t dstStep) {
-
     // source transform D * B. register number : (srcUnit + 1) * EPack/packCUnit
     constexpr int Nh = 6; // srcUnit
     constexpr int ePack = 12;
@@ -297,44 +339,68 @@ static void _sourceTransformUnit6x6Pack12(ElementType* srcBlock, ElementType* ds
         VecType s52 = VecType::load(srcPtr + 5 * loadTransposeStride + 2 * packCUnit);
 
         // to-try: reorder
-        auto ep0 = s00 * 4.f - s20 * 5.f + s40;
-        auto ep1 = s01 * 4.f - s21 * 5.f + s41;
-        auto ep2 = s02 * 4.f - s22 * 5.f + s42;
+        auto b00 = Vec::fma(s40, s20, Vec(-4));
+        auto b01 = Vec::fma(s41, s21, Vec(-4));
+        auto b02 = Vec::fma(s42, s22, Vec(-4));
+
+        auto b10 = Vec::fma(s30, s10, Vec(-4));
+        auto b11 = Vec::fma(s31, s11, Vec(-4));
+        auto b12 = Vec::fma(s32, s12, Vec(-4));
+
+        auto b20 = Vec::fma(s20, s00, Vec(-4));
+        auto b21 = Vec::fma(s21, s01, Vec(-4));
+        auto b22 = Vec::fma(s22, s02, Vec(-4));
+
+        auto b30 = Vec::fma(s50, s30, Vec(-4));
+        auto b31 = Vec::fma(s51, s31, Vec(-4));
+        auto b32 = Vec::fma(s52, s32, Vec(-4));
+
+        auto b40 = s40 - s20;
+        auto b41 = s41 - s21;
+        auto b42 = s42 - s22;
+
+        auto b50 = (s30 - s10) * Vec(2);
+        auto b51 = (s31 - s11) * Vec(2);
+        auto b52 = (s32 - s12) * Vec(2);
+
+        auto ep0 = b00 - b20;
+        auto ep1 = b01 - b21;
+        auto ep2 = b02 - b22;
         VecType::save(dstPtr + 0 * dstStep + 0 * packCUnit, ep0);
         VecType::save(dstPtr + 0 * dstStep + 1 * packCUnit, ep1);
         VecType::save(dstPtr + 0 * dstStep + 2 * packCUnit, ep2);
 
-        ep0 = (s10 + s20) * (-4.f) + s30 + s40;
-        ep1 = (s11 + s21) * (-4.f) + s31 + s41;
-        ep2 = (s12 + s22) * (-4.f) + s32 + s42;
+        ep0 = b00 + b10;
+        ep1 = b01 + b11;
+        ep2 = b02 + b12;
         VecType::save(dstPtr + 1 * dstStep + 0 * packCUnit, ep0);
         VecType::save(dstPtr + 1 * dstStep + 1 * packCUnit, ep1);
         VecType::save(dstPtr + 1 * dstStep + 2 * packCUnit, ep2);
 
-        ep0 = (s10 - s20) * (4.f) + s40 - s30;
-        ep1 = (s11 - s21) * (4.f) + s41 - s31;
-        ep2 = (s12 - s22) * (4.f) + s42 - s32;
+        ep0 = b00 - b10;
+        ep1 = b01 - b11;
+        ep2 = b02 - b12;
         VecType::save(dstPtr + 2 * dstStep + 0 * packCUnit, ep0);
         VecType::save(dstPtr + 2 * dstStep + 1 * packCUnit, ep1);
         VecType::save(dstPtr + 2 * dstStep + 2 * packCUnit, ep2);
 
-        ep0 = s10 * (-2.f) - s20 + s30 * 2.f + s40;
-        ep1 = s11 * (-2.f) - s21 + s31 * 2.f + s41;
-        ep2 = s12 * (-2.f) - s22 + s32 * 2.f + s42;
+        ep0 = b40 + b50;
+        ep1 = b41 + b51;
+        ep2 = b42 + b52;
         VecType::save(dstPtr + 3 * dstStep + 0 * packCUnit, ep0);
         VecType::save(dstPtr + 3 * dstStep + 1 * packCUnit, ep1);
         VecType::save(dstPtr + 3 * dstStep + 2 * packCUnit, ep2);
 
-        ep0 = s10 * 2.f - s20 - s30 * 2.f + s40;
-        ep1 = s11 * 2.f - s21 - s31 * 2.f + s41;
-        ep2 = s12 * 2.f - s22 - s32 * 2.f + s42;
+        ep0 = b40 - b50;
+        ep1 = b41 - b51;
+        ep2 = b42 - b52;
         VecType::save(dstPtr + 4 * dstStep + 0 * packCUnit, ep0);
         VecType::save(dstPtr + 4 * dstStep + 1 * packCUnit, ep1);
         VecType::save(dstPtr + 4 * dstStep + 2 * packCUnit, ep2);
 
-        ep0 = s10 * 4.f - s30 * 5.f + s50;
-        ep1 = s11 * 4.f - s31 * 5.f + s51;
-        ep2 = s12 * 4.f - s32 * 5.f + s52;
+        ep0 = b30 - b10;
+        ep1 = b31 - b11;
+        ep2 = b32 - b12;
         VecType::save(dstPtr + 5 * dstStep + 0 * packCUnit, ep0);
         VecType::save(dstPtr + 5 * dstStep + 1 * packCUnit, ep1);
         VecType::save(dstPtr + 5 * dstStep + 2 * packCUnit, ep2);
@@ -396,17 +462,22 @@ Vec s3 = Vec::load(srcBlock + 3 * srcStep); \
 Vec s4 = Vec::load(srcBlock + 4 * srcStep); \
 Vec s5 = Vec::load(srcBlock + 5 * srcStep);
 
-static void _sourceTransformUnit6x6(const FLOAT16* srcBlock, FLOAT16* dstStart, size_t srcStep, size_t dstStep) {
+static void MNNConvWinoSourceTransformUnit6x6FP16(const FLOAT16* srcBlock, FLOAT16* dstStart, size_t srcStep, size_t dstStep) {
     LOAD6;
-    Vec m0 = s0 * (FLOAT16)4 - s2 * (FLOAT16)5 + s4;
 
-    Vec m1 = (s1 + s2) * (-(FLOAT16)4) + (s3 + s4);
-    Vec m2 = (s1 - s2) * ((FLOAT16)4) + (s4 - s3);
+    auto b0 = Vec::fma(s4, s2, Vec(-4));
+    auto b1 = Vec::fma(s3, s1, Vec(-4));
+    auto b2 = Vec::fma(s2, s0, Vec(-4));
+    auto b3 = Vec::fma(s5, s3, Vec(-4));
+    auto b4 = s4 - s2;
+    auto b5 = (s3 - s1) * Vec(2);
 
-    Vec m3 = s1 * -(FLOAT16)2 - s2 + s3 * (FLOAT16)2 + s4;
-    Vec m4 = s1 * (FLOAT16)2 - s2 - s3 * (FLOAT16)2 + s4;
-
-    Vec m5 = s1 * (FLOAT16)4 - s3 * (FLOAT16)5 + s5;
+    Vec m0 = b0 - b2;
+    Vec m1 = b0 + b1;
+    Vec m2 = b0 - b1;
+    Vec m3 = b4 + b5;
+    Vec m4 = b4 - b5;
+    Vec m5 = b3 - b1;
 
     Vec::save(dstStart + 0 * dstStep, m0);
     Vec::save(dstStart + 1 * dstStep, m1);
@@ -424,11 +495,16 @@ static void _destTransformUnit6x5(const FLOAT16* srcBlock, FLOAT16* dstStart, si
     Vec s4 = Vec::load(srcBlock + 4 * srcStep);
     Vec s5 = Vec::load(srcBlock + 5 * srcStep);
 
-    auto m0 = s0 + s1 + s2 + s3 + s4;
-    auto m1 = (s1 - s2) + (s3 - s4) * (FLOAT16)2;
-    auto m2 = (s1 + s2) + (s3 + s4) * (FLOAT16)4;
-    auto m3 = (s1 - s2) + (s3 - s4) * (FLOAT16)8;
-    auto m4 = (s1 + s2) + (s3 + s4) * (FLOAT16)16 + s5;
+    auto v0 = s1 + s2;
+    auto v1 = s1 - s2;
+    auto v2 = s3 + s4;
+    auto v3 = s3 - s4;
+    
+    auto m0 = s0 + v0 + v2;
+    auto m1 = Vec::fma(v1, v3, Vec(2));
+    auto m2 = Vec::fma(v0, v2, Vec(4));
+    auto m3 = Vec::fma(v1, v3, Vec(8));
+    auto m4 = Vec::fma(v0, v2, Vec(16)) + s5;
 
     Vec::save(dstStart + 0 * dstStep, m0);
     Vec::save(dstStart + 1 * dstStep, m1);
@@ -443,6 +519,7 @@ static void _destTransformUnit6x4(const FLOAT16* srcBlock, FLOAT16* dstStart, si
     Vec s3 = Vec::load(srcBlock + 3 * srcStep);
     Vec s4 = Vec::load(srcBlock + 4 * srcStep);
     Vec s5 = Vec::load(srcBlock + 5 * srcStep);
+
     auto v0 = s3 + s4;
     auto v1 = s3 - s4;
     auto v2 = s1 + s2;
@@ -450,8 +527,8 @@ static void _destTransformUnit6x4(const FLOAT16* srcBlock, FLOAT16* dstStart, si
 
     auto m0 = s0 + v2 + v0;
     auto m1 = v3 + v1 + v1;
-    auto m2 = v2 + v0 * (FLOAT16)4;
-    auto m3 = v3 + v1 * (FLOAT16)8 + s5;
+    auto m2 = Vec::fma(v2, v0, Vec(4));
+    auto m3 = Vec::fma(v3, v1, Vec(8)) + s5;
 
     Vec::save(dstStart + 0 * dstStep, m0);
     Vec::save(dstStart + 1 * dstStep, m1);
@@ -466,9 +543,12 @@ static void _destTransformUnit6x3(const FLOAT16* srcBlock, FLOAT16* dstStart, si
     Vec s4 = Vec::load(srcBlock + 4 * srcStep);
     Vec s5 = Vec::load(srcBlock + 5 * srcStep);
 
-    auto m0 = s0 + s1 + s2 + s3 + s4;
-    auto m1 = (s1 - s2) + (s3 - s4) * (FLOAT16)2;
-    auto m2 = (s1 + s2) + (s3 + s4) * (FLOAT16)4 + s5;
+    auto v0 = s1 + s2;
+    auto v1 = s3 + s4;
+
+    auto m0 = s0 + v0 + v1;
+    auto m1 = Vec::fma(s1 - s2, s3 - s4, Vec(2));
+    auto m2 = Vec::fma(v0, v1, Vec(4)) + s5;
 
     Vec::save(dstStart + 0 * dstStep, m0);
     Vec::save(dstStart + 1 * dstStep, m1);
@@ -520,7 +600,7 @@ Arm82WinogradFunction::TransformPackFunc Arm82WinogradFunction::chooseWinoSource
 
 Arm82WinogradFunction::TransformFunc Arm82WinogradFunction::chooseSourceTransform(int k, int w) {
     if (6 == k && 6 == w) {
-        return _sourceTransformUnit6x6;
+        return MNNConvWinoSourceTransformUnit6x6FP16;
     }
     if (4 == k && 4 == w) {
         return _sourceTransformUnit4x4;

--- a/source/backend/arm82/asm/arm32/MNNConvWinoSourceTransformUnit6x6FP16.S
+++ b/source/backend/arm82/asm/arm32/MNNConvWinoSourceTransformUnit6x6FP16.S
@@ -1,0 +1,62 @@
+//
+//  MNNConvWinoSourceTransformUnit6x6FP16.S
+//  MNN
+//
+//  Created by MNN on 2021/10/20.
+//  Copyright © 2018, Alibaba Group Holding Limited
+//
+#ifdef __arm__
+#ifndef __aarch64__
+
+#include "MNNAsmGlobal.h"
+
+.text
+.align 5
+
+asm_function MNNConvWinoSourceTransformUnit6x6FP16
+//    void MNNConvWinoSourceTransformUnit6x6FP16(const FLOAT16* srcBlock, FLOAT16* dstStart, size_t srcStep, size_t dstStep);
+
+//Auto:
+//r0: srcBlock, r1:dstStart, r2:srcStep, r3:dstStep
+
+push {lr}
+
+lsl r2, r2, #1
+lsl r3, r3, #1
+
+vld1.16 {q0}, [r0], r2        //s0
+vld1.16 {q1}, [r0], r2        //s1
+vld1.16 {q2}, [r0], r2        //s2
+vld1.16 {q3}, [r0], r2        //s3
+vld1.16 {q8}, [r0], r2        //s4
+vld1.16 {q9}, [r0], r2        //s5
+
+vmov.i16 q14, #0xc400
+
+vsub.f16 q11, q3, q1
+vsub.f16 q10, q8, q2           //b4
+vadd.f16 q11, q11, q11         //b5
+
+vadd.f16 q12, q10, q11         //m3
+vsub.f16 q13, q10, q11         //m4
+
+vmla.f16 q8, q14, q2           //b0
+vmla.f16 q9, q14, q3           //b1
+vmla.f16 q2, q14, q0           //b2
+vmla.f16 q3, q14, q1           //b3
+
+vsub.f16 q2, q8, q2            //m0
+vsub.f16 q9, q9, q3            //m5
+vadd.f16 q14, q8, q3           //m1
+vsub.f16 q15, q8, q3           //m2
+
+vst1.16 {q2}, [r1], r3
+vst1.16 {q14}, [r1], r3
+vst1.16 {q15}, [r1], r3
+vst1.16 {q12}, [r1], r3
+vst1.16 {q13}, [r1], r3
+vst1.16 {q9}, [r1], r3
+
+pop {pc}
+#endif
+#endif

--- a/source/backend/arm82/asm/arm64/MNNConvWinoSourceTransformUnit6x6FP16.S
+++ b/source/backend/arm82/asm/arm64/MNNConvWinoSourceTransformUnit6x6FP16.S
@@ -1,0 +1,59 @@
+//
+//  MNNConvWinoSourceTransformUnit6x6FP16.S
+//  MNN
+//
+//  Created by MNN on 2021/10/18.
+//  Copyright © 2018, Alibaba Group Holding Limited
+//
+#ifdef __aarch64__
+
+#include "MNNAsmGlobal.h"
+
+.text
+.align 5
+
+asm_function MNNConvWinoSourceTransformUnit6x6FP16
+//    void MNNConvWinoSourceTransformUnit6x6FP16(const FLOAT16* srcBlock, FLOAT16* dstStart, size_t srcStep, size_t dstStep);
+
+//Auto:
+//x0: srcBlock, x1:dstStart, x2:srcStep, x3:dstStep
+
+lsl x2, x2, #1
+lsl x3, x3, #1
+
+ld1 {v16.8h}, [x0], x2          //s0
+ld1 {v17.8h}, [x0], x2          //s1
+ld1 {v18.8h}, [x0], x2          //s2
+ld1 {v19.8h}, [x0], x2          //s3
+ld1 {v20.8h}, [x0], x2          //s4
+ld1 {v21.8h}, [x0], x2          //s5
+
+movi v26.8h, #0xc4, lsl #8
+
+fsub v23.8h, v19.8h, v17.8h
+fsub v22.8h, v20.8h, v18.8h     //b4
+fadd v23.8h, v23.8h, v23.8h     //b5
+
+fadd v24.8h, v22.8h, v23.8h     //m3
+fsub v25.8h, v22.8h, v23.8h     //m4
+
+fmla v20.8h, v26.8h, v18.8h     //b0
+fmla v21.8h, v26.8h, v19.8h     //b1
+fmla v18.8h, v26.8h, v16.8h     //b2
+fmla v19.8h, v26.8h, v17.8h     //b3
+
+fsub v18.8h, v20.8h, v18.8h     //m0
+fsub v21.8h, v21.8h, v19.8h     //m5
+fadd v26.8h, v20.8h, v19.8h     //m1
+fsub v27.8h, v20.8h, v19.8h     //m2
+
+st1 {v18.8h}, [x1], x3
+st1 {v26.8h}, [x1], x3
+st1 {v27.8h}, [x1], x3
+st1 {v24.8h}, [x1], x3
+st1 {v25.8h}, [x1], x3
+st1 {v21.8h}, [x1], x3
+
+ret
+
+#endif


### PR DESCRIPTION
1._sourceTransformUnit6x6用上fma是确定会比原版有加速的，但是其汇编和c实现，我这测不出有加速，mnn开发者可以试着再优化一下汇编代码。
2. _sourceTransformUnit6x6由于写了汇编实现，名字改成了MNNConvWinoSourceTransformUnit6x6FP16，跟其他tranform函数名称不太统一。
3. MNNConvWinoSourceTransformUnit6x6FP16 汇编代码的arm64是测过没问题的，arm32的没测。
4. _sourceTransformUnit6x6Pack12和_sourceTransformUnit8x8Pack12，理论上是做了计算简化的，实际运行不知道能加速多少