### PR TITLE
Fix compile errors caused by "#define MNN_THREAD_LOCK_CPU"

### DIFF
--- a/source/backend/cpu/ThreadPool.cpp
+++ b/source/backend/cpu/ThreadPool.cpp
@@ -9,13 +9,15 @@
 #include "backend/cpu/ThreadPool.hpp"
 #include <string.h>
 #include <MNN/MNNDefine.h>
-#ifdef __ANDROID__
+
+//#define MNN_THREAD_LOCK_CPU
+
+#ifdef MNN_THREAD_LOCK_CPU
 #include <stdint.h>
 #include <sys/syscall.h>
 #include <unistd.h>
 #include <algorithm>
 #endif
-//#define MNN_THREAD_LOCK_CPU
 
 #define MNN_THREAD_POOL_MAX_TASKS 2
 namespace MNN {


### PR DESCRIPTION
error: sort is not a member of std
error: gettid was not declared in this scope
error: __NR_sched_setaffinity was not declared in this scope
error: syscall was not declared in this scope