### PR TITLE
Fix ThreadPool behavior

### DIFF
--- a/source/backend/cpu/CPUBackend.hpp
+++ b/source/backend/cpu/CPUBackend.hpp
@@ -29,10 +29,13 @@ public:
     virtual CompilerType onGetCompilerType() const override {
         return Compiler_Loop;
     }
+    void onConcurrencyBegin() const;
+    void onConcurrencyEnd() const;
+
 private:
     std::shared_ptr<BufferAllocator> mStaticAllocator;
     int mThreadNumber;
-    int mTaskIndex;
+    mutable int mTaskIndex;
     BackendConfig::MemoryMode mMemory;
     BackendConfig::PowerMode mPower;
     BackendConfig::PrecisionMode mPrecision;


### PR DESCRIPTION
Pipeline::encode may anr when other session call ThreadPool::active()

 Pipeline::encode -> GeometryComputerUtils::shapeComputeAndGeometryTransform -> onExecute