### PR TITLE
build(hiai): fix for update hiai to 100.520.020.010

### DIFF
--- a/source/backend/hiai/execution/NPUDepthToSpace.cpp
+++ b/source/backend/hiai/execution/NPUDepthToSpace.cpp
@@ -39,7 +39,7 @@ ErrorCode NPUDepthToSpace::onResize(const std::vector<Tensor *> &inputs, const s
     (*permuteBefore)
         .set_input_x(*xOp1.get())
         .set_attr_order({0,2,3,1})
-        .SetAttr("NCHW_to_NHWC", ge::AttrValue::CreateFrom<ge::AttrValue::INT>(1));
+        .SetAttr("NCHW_to_NHWC", ge::AttrValue::CreateFrom(static_cast<int64_t>(1)));
     
     (*depthToSpace)
         .set_input_x(*permuteBefore.get())
@@ -49,7 +49,7 @@ ErrorCode NPUDepthToSpace::onResize(const std::vector<Tensor *> &inputs, const s
     (*permuteAfter)
         .set_input_x(*depthToSpace.get())
         .set_attr_order({0,3,1,2})
-        .SetAttr("NHWC_to_NCHW", ge::AttrValue::CreateFrom<ge::AttrValue::INT>(1));
+        .SetAttr("NHWC_to_NCHW", ge::AttrValue::CreateFrom(static_cast<int64_t>(1)));
 
     mNpuBackend->setOutputOps(mOp, {permuteBefore, depthToSpace, permuteAfter}, outputs);
     return NO_ERROR;


### PR DESCRIPTION
华为hiai更新到100.520.020.010编译出错，主要是hiai的头文件（graph/attr_value.h）发生了改变：
1、旧版本100.320的：CreateFrom
template <typename T, typename DT, EnableIfTypeValid = 0>
static AttrValue CreateFrom(DT &&val)
2、新版本的不再使用模板方式
static AttrValue CreateFrom(int64_t val);

考虑到100.520版本支持9000系列芯片更多，建议直接依赖最新的头文件，支持列表见：https://developer.huawei.com/consumer/cn/doc/development/hiai-Library/ddk-download-0000001053590180