### PR TITLE
Only yield at the end if the completion loop needs another pass

### DIFF
--- a/source/backend/cpu/ThreadPool.cpp
+++ b/source/backend/cpu/ThreadPool.cpp
@@ -287,7 +287,6 @@ void ThreadPool::enqueueInternal(TASK&& task, int index) {
     mTasks[index].first.first(0);
     bool complete = true;
     do {
-        std::this_thread::yield();
         complete = true;
         for (int i = 1; i < workSize; ++i) {
             if (*mTasks[index].second[i]) {
@@ -295,6 +294,7 @@ void ThreadPool::enqueueInternal(TASK&& task, int index) {
                 break;
             }
         }
+        std::this_thread::yield();
         // FUNC_PRINT(notComplete);
     } while (!complete);
 }


### PR DESCRIPTION
Currently the yield is occuring every time a completion loop iterates and this is quite an expensive kernel system call. It is not really required if we break out of the loop, so move the yield to the end of the do-while loop to reduce the yielding overhead

Perf metrics show that the current code eats up ~2.4% CPU yielding whereas this change reduces this down to ~0.6% of the total CPU run time.