### PR TITLE
Fixed the issue 2654 -- Removed a duplicated build option for bench_a…

### DIFF
--- a/benchmark/android/bench_android.sh
+++ b/benchmark/android/bench_android.sh
@@ -44,7 +44,6 @@ function build_android_bench() {
           -DCMAKE_BUILD_TYPE=Release \
           -DANDROID_ABI="${ABI}" \
           -DANDROID_STL=c++_static \
-          -DCMAKE_BUILD_TYPE=Release \
           -DANDROID_NATIVE_API_LEVEL=android-21  \
           -DMNN_USE_LOGCAT:BOOL=OFF \
           -DMNN_VULKAN:BOOL=$VULKAN \


### PR DESCRIPTION
There is a duplicated build option in script bench_android.sh, and it's better to remove one of them.