### PR TITLE
Fix bug for nullptr in Pipeline::allocMemory

### DIFF
--- a/source/core/Pipeline.cpp
+++ b/source/core/Pipeline.cpp
@@ -964,7 +964,7 @@ ErrorCode Pipeline::allocMemory(bool firstMalloc, bool forbidReplace) {
 #ifdef MNN_PIPELINE_DEBUG
                 MNN_ERROR("Pipeline Resize error: %d\n", code);
 #endif
-                if (!iter.info.get()) {
+                if (iter.info != nullptr) {
                     MNN_ERROR("Resize error for type = %s, name = %s \n", iter.info->type().c_str(), iter.info->name().c_str());
                 }
                 return code;


### PR DESCRIPTION
In current implementation, when object managed by `iter.info` is `nullptr`, `!iter.info.get()` will return `true`.
Fix to avoid protentional `nullptr` error.