### PR TITLE
VulkanImage: fix VkImageSubresourceRange initialization

### DIFF
--- a/source/backend/vulkan/component/VulkanImage.cpp
+++ b/source/backend/vulkan/component/VulkanImage.cpp
@@ -70,6 +70,7 @@ VulkanImage::~VulkanImage() {
 }
 void VulkanImage::barrierWrite(VkCommandBuffer buffer) const {
     VkImageSubresourceRange subrange;
+    ::memset(&subrange, 0, sizeof(VkImageSubresourceRange));
     subrange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     subrange.layerCount = 1;
     subrange.levelCount = 1;
@@ -82,6 +83,7 @@ void VulkanImage::barrierRead(VkCommandBuffer buffer) const {
         return;
     }
     VkImageSubresourceRange subrange;
+    ::memset(&subrange, 0, sizeof(VkImageSubresourceRange));
     subrange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     subrange.layerCount = 1;
     subrange.levelCount = 1;


### PR DESCRIPTION
Fixes segmentation fault due to unitialised struct fields with Android NDK 23.1.7779620
[stacktrace.txt](https://github.com/alibaba/MNN/files/13719687/stacktrace.txt)
