### PR TITLE
[CI:Bugfix] Update cibuildwheel to 2.16.5 to fix windows bug.

### DIFF
--- a/.github/workflows/pymnn_release.yml
+++ b/.github/workflows/pymnn_release.yml
@@ -29,7 +29,7 @@ jobs:
         python-version: '3.9'
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.11.4
+      uses: pypa/cibuildwheel@v2.16.5
       env:
         CIBW_ARCHS_MACOS: ${{ matrix.arch }}
         CIBW_ARCHS_LINUX: ${{ matrix.arch }}


### PR DESCRIPTION
问题：pymnn_release在Windows上编译失败：https://github.com/alibaba/MNN/actions/runs/8093412361/job/22116012498
原因：https://github.com/pypa/cibuildwheel/issues/1740
解决方案：升级cibuildwheel到2.16.5