### PR TITLE
[bugfix] add return value to lambda of std::async

### DIFF
--- a/source/core/Pipeline.cpp
+++ b/source/core/Pipeline.cpp
@@ -510,7 +510,7 @@ void Pipeline::_pushTuningTask(std::vector<Schedule::OpCacheInfo>&& initInfos) {
     }
     // Make async task for tuning
     const_cast<Runtime*>(mRuntime)->mCancelled = false;
-    auto future = std::async(std::launch::async, [&, this](std::vector<Schedule::OpCacheInfo>&& infos, std::map<Tensor*, std::shared_ptr<Tensor>>&& tensors, std::shared_ptr<Backend> backend, const std::atomic_bool& cancelled) {
+    auto future = std::async(std::launch::async, [&, this](std::vector<Schedule::OpCacheInfo>&& infos, std::map<Tensor*, std::shared_ptr<Tensor>>&& tensors, std::shared_ptr<Backend> backend, const std::atomic_bool& cancelled) -> int {
 
         backend->onClearBuffer();
         backend->onResizeBegin();


### PR DESCRIPTION
To align with function body, [return type is automatically deduced only after C++14](https://en.cppreference.com/w/cpp/language/lambda).