### PR TITLE
Remove libc++ setting for Linux clang builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,10 +277,6 @@ endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "^Linux")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STRICT_ANSI__")
-    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-      # This is to workaround libgcc.a
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-    endif()
     if(CMAKE_SYSTEM_PROCESSOR MATCHES "^armv7")
         add_definitions(-mfpu=neon)    #please define in project/cross-compile/arm.toolchain.cmake
     endif()


### PR DESCRIPTION
This setting causes linker errors for any executables not using `libc++`.