### PR TITLE
MNN:BugFix:fix bug when use quantized.out with multi-images

### DIFF
--- a/tools/quantization/calibration.cpp
+++ b/tools/quantization/calibration.cpp
@@ -1056,7 +1056,7 @@ void Calibration::_quantizeModelEMA() {
                 auto singleInput = _Input(originDims, originFormat, originType);
                 auto inputTensor = (MNN::Tensor*)singleInput->getTensor();
                 Helper::preprocessInput(_process.get(), _preprocessConfig, file, inputTensor, _inputType, inputs[0]);
-                ::memcpy(inputs[0]->writeMap<float>() + k * inputTensor->elementSize(), inputTensor->host<float>(), inputTensor->elementSize() * sizeof(float));
+                ::memcpy(inputs[0]->writeMap<float>() + (k - indicesStart) * inputTensor->elementSize(), inputTensor->host<float>(), inputTensor->elementSize() * sizeof(float));
 
             }
         }


### PR DESCRIPTION
使用多张图片运行 quantized.out 对网络进行量化时会出现内存错误