### PR TITLE
update mTuneLws when updateCache is called.

### DIFF
--- a/express/Executor.cpp
+++ b/express/Executor.cpp
@@ -376,9 +376,9 @@ void Executor::RuntimeManager::updateCache() {
         MNN_PRINT("Update cache to %s, size = %zu\n", mInside->mCache->cacheFile.c_str(), buffer.second);
         writeCacheFile(mInside->mCache, buffer);
         mInside->mCache->lastCacheSize = buffer.second;
+        // Reset cache
+        loadCache(mInside->mInfo, buffer.first, buffer.second);
     }
-    // Reset cache
-    loadCache(mInside->mInfo, nullptr, 0);
 }
 
 std::vector<bool> Executor::RuntimeManager::isBackendSupport(const std::vector<MNNForwardType> types) {


### PR DESCRIPTION
Before this commit, `mTuneLws` is not synchronized, and tuning can only take effects after reload the cache. This commit resolve this problem. Now tuning information is automatically up-to-date after a call to `RuntimeManager::updateCache` without reload the program nor the cachefile. 