### PR TITLE
add runtime CPU big-performance-little core

### DIFF
--- a/include/MNN/Interpreter.hpp
+++ b/include/MNN/Interpreter.hpp
@@ -219,10 +219,9 @@ public:
         // 0: Close dynamic quant; 1: per batch quant; 2: per tensor quant
         DYNAMIC_QUANT_OPTIONS = 5,
 
-        // For Mobile CPU with big-litter core, set decrease rate to let MNN divide task differential by CPU's performance
-        // 0-100, 50 means litter core has 50% capacity of large core
-        // Default is 50
-        CPU_LITTLECORE_DECREASE_RATE = 6,
+        // For Mobile CPU with big-little core, set decrease rate to let MNN divide task differential by CPU's performance
+        // 0-100, e.g., 70 means performance core has 70% capacity of large core
+        CPU_PERFORMANCECORE_DECREASE_RATE = 6,
 
         // 0: Do not quantize
         // 1: Only quantize key, use int8 asymmetric quantization 
@@ -236,6 +235,10 @@ public:
         KVCACHE_SIZE_LIMIT = 8,
         // Op encoder number for commit
         OP_ENCODER_NUMBER_FOR_COMMIT = 9,
+
+        // For Mobile CPU with big-little core, set decrease rate to let MNN divide task differential by CPU's performance
+        // 0-100, e.g., 20 means little core has 20% capacity of large core
+        CPU_LITTLECORE_DECREASE_RATE = 10,
     };
 
     enum ExternalPathType {

--- a/source/backend/cpu/CPUBackend.hpp
+++ b/source/backend/cpu/CPUBackend.hpp
@@ -183,7 +183,7 @@ protected:
     CoreInt8Functions* mInt8CoreFunctions;
 private:
     int mThreadNumber;
-    std::vector<std::pair<float, int>> mGroupWithComputeRate;
+    std::vector<float> mGroupWithComputeRate;
     float mComputeI = 0.f;
 
     std::shared_ptr<CPURuntime::DynamicAllocator> mDmaInfo;

--- a/source/backend/cpu/CPUConvolutionDepthwise.hpp
+++ b/source/backend/cpu/CPUConvolutionDepthwise.hpp
@@ -30,6 +30,8 @@ public:
                            size_t fw, size_t fh, size_t dilateX_step, size_t dilateY_step, size_t height,
                            size_t srcHStep, size_t dstHStep)> mFastKernel;
         int mNumber = 1;
+        std::vector<int> divides;
+        int mTotalWork;
         std::shared_ptr<Tensor> mInputPad;
         bool mFastKernelApply = false;
     };

--- a/source/backend/cpu/compute/ConvInt8TiledExecutor.hpp
+++ b/source/backend/cpu/compute/ConvInt8TiledExecutor.hpp
@@ -72,7 +72,10 @@ private:
     std::shared_ptr<Tensor> mTempMaxMinValueBuffer;
     std::vector<uint8_t> mTempSrcSum;
     std::vector<int32_t> mDivides;
+    void computeDivideSizes();
 
+    float mflops, mios;
+    int mTotalWork, mPart;
     int mThreadNums;
     int mBlockNum = 1;
     int mOcPerThread;

--- a/source/backend/cpu/compute/ConvolutionPackWinograd.hpp
+++ b/source/backend/cpu/compute/ConvolutionPackWinograd.hpp
@@ -36,6 +36,8 @@ private:
     }
     std::pair<int, std::function<void(int tId, const uint8_t*, uint8_t*)>> mMainFunction;
     std::pair<int, std::function<void(int, uint8_t*)>> mPostFunction;
+    std::vector<int> divides;
+    int mTotalWork, mPostWork;
 
 };
 } // namespace MNN

--- a/source/backend/cpu/compute/DenseConvolutionTiledExecutor.hpp
+++ b/source/backend/cpu/compute/DenseConvolutionTiledExecutor.hpp
@@ -31,6 +31,8 @@ public:
     static PerfConfig bestTileConvolutionConfig(const Convolution2DCommon *common, const Tensor *inputTensor,
                                           const Tensor *outputTensor, int threadNumber, Backend* b);
 protected:
+    std::vector<int> divides;
+    int mTotalWork;
 };
 class DenseConvolutionTiledExecutor : public ConvolutionTiledExecutor {
 public:

--- a/source/core/Backend.hpp
+++ b/source/core/Backend.hpp
@@ -30,8 +30,10 @@ struct RuntimeHint {
     int memoryAllocatorType = 0;
     int winogradMemoryUsed = 3;
     
-    // 0-100, 50 means litter core has 50% capacity of large core
-    int cpuDecreaseRate = 50;
+    // 0-100, 70 means performance core has 70% capacity of large core
+    // 0-100, 20 means little core has 20% capacity of large core
+    int cpuMiddleDecreaseRate = 70;
+    int cpuLittleDecreaseRate = 15;
     int dynamicQuantOption = 0;
 
     // 0: Do not quantize

--- a/source/core/Session.cpp
+++ b/source/core/Session.cpp
@@ -79,8 +79,11 @@ void Session::ModeGroup::setHint(Interpreter::HintMode mode, int hint) {
         case Interpreter::WINOGRAD_MEMORY_LEVEL:
             runtimeHint.winogradMemoryUsed = hint;
             break;
+        case Interpreter::CPU_PERFORMANCECORE_DECREASE_RATE:
+            runtimeHint.cpuMiddleDecreaseRate = hint;
+            break;
         case Interpreter::CPU_LITTLECORE_DECREASE_RATE:
-            runtimeHint.cpuDecreaseRate = hint;
+            runtimeHint.cpuLittleDecreaseRate = hint;
             break;
         case Interpreter::GEOMETRY_COMPUTE_MASK:
             geometryMask = hint;

--- a/tools/cpp/ModuleBasic.cpp
+++ b/tools/cpp/ModuleBasic.cpp
@@ -245,7 +245,7 @@ int main(int argc, char *argv[]) {
     std::shared_ptr<Executor::RuntimeManager> rtmgr(Executor::RuntimeManager::createRuntimeManager(config));
     rtmgr->setCache(cacheFileName);
     if (cpuDecreaseRate > 0 && cpuDecreaseRate <= 100) {
-        rtmgr->setHint(Interpreter::CPU_LITTLECORE_DECREASE_RATE, cpuDecreaseRate);
+        rtmgr->setHint(Interpreter::CPU_PERFORMANCECORE_DECREASE_RATE, cpuDecreaseRate);
     }
     if (runMask & 1) {
         // Need dump tensor, open debug

--- a/transformers/llm/engine/llm_demo.cpp
+++ b/transformers/llm/engine/llm_demo.cpp
@@ -12,6 +12,9 @@
 #include <fstream>
 #include <sstream>
 #include <stdlib.h>
+#include <iterator>
+#include <random>
+#include <algorithm>
 using namespace MNN::Transformer;
 
 static void trace_prepare(Llm* llm) {
@@ -193,5 +196,10 @@ int main(int argc, const char* argv[]) {
         return 0;
     }
     std::string prompt_file = argv[2];
+    std::vector<std::vector<int>> dialogs, dataset;
+    std::random_device rd;
+    std::mt19937 g(rd());
+    std::sample(dialogs.begin(), dialogs.end(), std::back_inserter(dataset),
+                    sample_size, g);
     return eval(llm.get(), prompt_file);
 }

--- a/transformers/llm/engine/src/llm.cpp
+++ b/transformers/llm/engine/src/llm.cpp
@@ -202,6 +202,8 @@ void Llm::init_runtime() {
     ExecutorScope::Current()->setGlobalExecutorConfig(config.type, cpuBackendConfig, config.numThread);
 
     runtime_manager_.reset(Executor::RuntimeManager::createRuntimeManager(config));
+    runtime_manager_->setHint(MNN::Interpreter::CPU_PERFORMANCECORE_DECREASE_RATE, config_->perfcore_ratio());
+    runtime_manager_->setHint(MNN::Interpreter::CPU_LITTLECORE_DECREASE_RATE, config_->littlecore_ratio());
     runtime_manager_->setHint(MNN::Interpreter::MEM_ALLOCATOR_TYPE, 0);
     runtime_manager_->setHint(MNN::Interpreter::DYNAMIC_QUANT_OPTIONS, 1); // 1: per batch quant, 2: per tensor quant
     runtime_manager_->setHint(MNN::Interpreter::QKV_QUANT_OPTIONS, config_->quant_qkv());
@@ -473,7 +475,7 @@ void Llm::chat() {
     while (true) {
         std::cout << "\nQ: ";
         std::string user_str;
-        std::cin >> user_str;
+        std::getline(std::cin, user_str);
         if (user_str == "/exit") {
             break;
         }

--- a/transformers/llm/engine/src/llmconfig.hpp
+++ b/transformers/llm/engine/src/llmconfig.hpp
@@ -277,6 +277,14 @@ public:
         return config_.value("memory", "low");
     }
 
+    int perfcore_ratio() const {
+        return config_.value("perfcore_ratio", 70);
+    }
+
+    int littlecore_ratio() const {
+        return config_.value("littlecore_ratio", 20);
+    }
+
     int quant_qkv() const {
         return config_.value("quant_qkv", 0);
     }
@@ -329,7 +337,7 @@ public:
     }
 
     std::string prompt_template() const {
-        return llm_config_.value("prompt_template", "");
+        return llm_config_.value("prompt_template", "<|im_start|>user\n%s<|im_end|>\n<|im_start|>assistant\n'");
     }
 
     std::vector<int64_t> tie_embeddings() const {


### PR DESCRIPTION
Add runtime dynamic big-performance-little core scheduling, performance tested on Huawei phones and Meizu phones. Needs further improvements for cpuDecreaseRate tuning.
- [x] dynamic runtime big small core identification.
- [x] dynamic runtime task division according to big-small core.
- [ ] cpuDecreaseRate tuning (future work) 