### PR TITLE
auxv.h defined __aarch64__

### DIFF
--- a/source/backend/cpu/CPURuntime.cpp
+++ b/source/backend/cpu/CPURuntime.cpp
@@ -16,7 +16,9 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 #include <fcntl.h>
+#if defined(__linux__) && defined(__aarch64__)
 #include <sys/auxv.h>
+#endif
 #include <sys/time.h>
 #include <sys/stat.h>
 #include <sys/types.h>


### PR DESCRIPTION
部份`arm`(非`arm64`)的工具链，没有`auxv.h`文件

所以同步以下代码定义，加上宏定义`defined(__linux__) && defined(__aarch64__)`

https://github.com/alibaba/MNN/blob/c23d82cee71c4ce1e54586bf4815748333a9e450/source/backend/cpu/CPURuntime.cpp#L1285-L1305