### PR TITLE
Fix incorrect division of two numbers by integer, should use double

### DIFF
--- a/tools/cv/source/imgproc/draw.cpp
+++ b/tools/cv/source/imgproc/draw.cpp
@@ -614,8 +614,8 @@ static void EllipseEx(std::vector<Region>& regions, Size size, Point2l center, S
     for (unsigned int i = 0; i < _v.size(); ++i)
     {
         Point2l pt;
-        pt.x = (int64_t)std::round(_v[i].x / XY_ONE) << XY_SHIFT;
-        pt.y = (int64_t)std::round(_v[i].y / XY_ONE) << XY_SHIFT;
+        pt.x = (int64_t)std::round(_v[i].x / static_cast<double>(XY_ONE)) << XY_SHIFT;
+        pt.y = (int64_t)std::round(_v[i].y / static_cast<double>(XY_ONE)) << XY_SHIFT;
         pt.x += std::round(_v[i].x - pt.x);
         pt.y += std::round(_v[i].y - pt.y);
         if (pt != prevPt) {


### PR DESCRIPTION
In the previous version, the results were as expected when rounding down, but incorrect results were obtained when rounding up. For example, when `_v[i].x == XY_ONE * 3 / 4`, the expression was rounded to `0`, whereas the expected value should be `1`. Otherwise, there would be no need to use `std::round` at all.