### PR TITLE
add function ellipse to cv/imgproc/draw

### DIFF
--- a/tools/cv/include/cv/imgproc/draw.hpp
+++ b/tools/cv/include/cv/imgproc/draw.hpp
@@ -29,6 +29,10 @@ MNN_PUBLIC void arrowedLine(VARP& img, Point pt1, Point pt2, const Scalar& color
 MNN_PUBLIC void circle(VARP& img, Point center, int radius, const Scalar& color,
                        int thickness=1, int line_type=8, int shift=0);
 
+MNN_PUBLIC void ellipse(VARP& img, Point center, Size axes, double angle,
+                        double start_angle, double end_angle, const Scalar& color,
+                        int thickness=1, int line_type=8, int shift=0);
+
 MNN_PUBLIC void line(VARP& img, Point pt1, Point pt2, const Scalar& color,
                      int thickness = 1, int lineType = LINE_8, int shift = 0);
 

--- a/tools/cv/source/imgproc/draw.cpp
+++ b/tools/cv/source/imgproc/draw.cpp
@@ -874,6 +874,25 @@ void circle(VARP& img, Point center, int radius, const Scalar& color, int thickn
     doDraw(img, regions, color);
 }
 
+void ellipse(VARP& img, Point center, Size axes, double angle,
+             double start_angle, double end_angle, const Scalar& color,
+             int thickness, int line_type, int shift){
+    int h, w, c; getVARPSize(img, &h, &w, &c);
+    Size size(w, h);
+    std::vector<Region> regions;
+    auto _angle = static_cast<int>(std::round(angle));
+    auto _start_angle = static_cast<int>(std::round(start_angle));
+    auto _end_angle = static_cast<int>(std::round(end_angle));
+    Point2l _center(static_cast<int64_t>(center.fX), static_cast<int64_t>(center.fY));
+    Size2l _axes(axes);
+    _center.x <<= XY_SHIFT - shift;
+    _center.y <<= XY_SHIFT - shift;
+    _axes.width <<= XY_SHIFT - shift;
+    _axes.height <<= XY_SHIFT - shift;
+    EllipseEx(regions, size, _center, _axes, _angle, _start_angle, _end_angle, thickness, line_type);
+    doDraw(img, regions, color);
+}
+
 void line(VARP& img, Point pt1, Point pt2, const Scalar& color,
           int thickness, int lineType, int shift) {
     int h, w, c; getVARPSize(img, &h, &w, &c);

--- a/tools/cv/test/imgproc/draw_test.cpp
+++ b/tools/cv/test/imgproc/draw_test.cpp
@@ -47,6 +47,25 @@ TEST(circle, fill) {
     EXPECT_TRUE(testEnv.equal(testEnv.cvSrc, testEnv.mnnSrc));
 }
 
+// ellipse
+TEST(ellipse, basic) {
+    cv::ellipse(testEnv.cvSrc, {50, 50}, {20, 30}, 0, 0, 360, {10, 120, 230}, 1);
+    ellipse(testEnv.mnnSrc, {50, 50}, {20, 30}, 0, 0, 360, {10, 120, 230}, 1);
+    EXPECT_TRUE(testEnv.equal(testEnv.cvSrc, testEnv.mnnSrc));
+}
+
+TEST(ellipse, thickness) {
+    cv::ellipse(testEnv.cvSrc, {100, 100}, {30, 50}, 0, 0, 360, {1, 128, 255}, 5);
+    ellipse(testEnv.mnnSrc, {100, 100}, {30, 50}, 0, 0, 360, {1, 128, 255}, 5);
+    EXPECT_TRUE(testEnv.equal(testEnv.cvSrc, testEnv.mnnSrc));
+}
+
+TEST(ellipse, fill) {
+    cv::ellipse(testEnv.cvSrc, {150, 150}, {40, 70}, 0, 0, 360, {10, 20, 30}, -1);
+    ellipse(testEnv.mnnSrc, {150, 150}, {40, 70}, 0, 0, 360, {10, 20, 30}, -1);
+    EXPECT_TRUE(testEnv.equal(testEnv.cvSrc, testEnv.mnnSrc));
+}
+
 // line
 TEST(line, basic) {
     // cv::line(testEnv.cvSrc, {10, 10}, {200, 300}, {0, 0, 255}, 1);


### PR DESCRIPTION
Considering that the current version of MNN already has good support for Stable Diffusion, elliptical masks will be used in some scenarios. By this PR, ellipse function(as well as unit tests) is added to the cv-api of MNN in imitation of the latest version of OpenCV. All unit tests for ellipse are well passed as shown in the attached figure.
![aa8b652135ea75336aca69da4b87cdb](https://github.com/user-attachments/assets/aac78a24-4b7f-4be3-9a4d-149e7d2e0f63)