### PR TITLE
Optimize Stft func

### DIFF
--- a/source/backend/cpu/CPUStft.hpp
+++ b/source/backend/cpu/CPUStft.hpp
@@ -19,6 +19,8 @@ public:
     virtual ~CPUStft() = default;
     virtual ErrorCode onResize(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) override;
     virtual ErrorCode onExecute(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) override;
+    static std::vector<float> gSinTable;
+    static std::vector<float> gCosTable;
 private:
     int mNfft, mHopLength;
     bool mAbs;


### PR DESCRIPTION
1. When the CPUStft constructor is called for the first time, initialize gCosTable and gSinTable.
2. When calling the CPUStft execution function, retrieve the corresponding values from gCosTable and gSinTable based on the index.