### PR TITLE
Fix and complete android build doc.

### DIFF
--- a/project/android/apps/MnnLlmApp/README.md
+++ b/project/android/apps/MnnLlmApp/README.md
@@ -34,25 +34,54 @@ This is our full multimodal language model (LLM) Android app
 
 
 # Development 
-+ Clone the repository:
++ Clone the repository：
   ```shell
     git clone https://github.com/alibaba/MNN.git
   ```
-+ Build library:
-  ```shell
-  cd project/android
-  mkdir build_64
-  ../build_64.sh "-DMNN_LOW_MEMORY=true -DMNN_CPU_WEIGHT_DEQUANT_GEMM=true -DMNN_BUILD_LLM=true -DMNN_SUPPORT_TRANSFORMER_FUSE=true -DMNN_ARM82=true -DMNN_USE_LOGCAT=true -DMNN_OPENCL=true -DLLM_SUPPORT_VISION=true -DMNN_BUILD_OPENCV=true -DMNN_IMGCODECS=true -DLLM_SUPPORT_AUDIO=true -DMNN_BUILD_AUDIO=true -DMNN_BUILD_DIFFUSION=ON -DMNN_SEP_BUILD=ON"
-  ```
-+ copy to llm android app project
-  ```shell
-  find . -name "*.so" -exec cp {} ../apps/MnnLlmApp/app/src/main/jniLibs/arm64-v8a/  \;
-  ```
-+ build android app project and install
+  
+#### 1.Build the Library for 64-bit:
+
+1. Build the arm64 library:
+
+	  ```shell
+	  cd project/android
+	  mkdir build_64
+	  cd build_64
+	  ../build_64.sh "-DMNN_LOW_MEMORY=true -DMNN_CPU_WEIGHT_DEQUANT_GEMM=true -DMNN_BUILD_LLM=true -DMNN_SUPPORT_TRANSFORMER_FUSE=true -DMNN_ARM82=true -DMNN_USE_LOGCAT=true -DMNN_OPENCL=true -DLLM_SUPPORT_VISION=true -DMNN_BUILD_OPENCV=true -DMNN_IMGCODECS=true -DLLM_SUPPORT_AUDIO=true -DMNN_BUILD_AUDIO=true -DMNN_BUILD_DIFFUSION=ON -DMNN_SEP_BUILD=ON"
+	  ```
++ Copy the arm64-v8a .so libraries to the LLM Android application project:
+
+	  ```shell
+	  mkdir -p ../apps/MnnLlmApp/app/src/main/jniLibs/arm64-v8a
+	  find . -name "*.so" -exec cp {} ../apps/MnnLlmApp/app/src/main/jniLibs/arm64-v8a/  \;
+	  ```
+  
+#### 2.Build the Library for 32-bit (Optional):
+
+1. Build the armeabi-v7a library:
+
+	  ```shell
+	  cd project/android
+	  mkdir build_32
+	  cd build_32
+	  ../build_32.sh "-DMNN_LOW_MEMORY=true -DMNN_CPU_WEIGHT_DEQUANT_GEMM=true -DMNN_BUILD_LLM=true -DMNN_SUPPORT_TRANSFORMER_FUSE=true -DMNN_ARM82=true -DMNN_USE_LOGCAT=true -DMNN_OPENCL=true -DLLM_SUPPORT_VISION=true -DMNN_BUILD_OPENCV=true -DMNN_IMGCODECS=true -DLLM_SUPPORT_AUDIO=true -DMNN_BUILD_AUDIO=true -DMNN_BUILD_DIFFUSION=ON -DMNN_SEP_BUILD=ON"
+	  ```
+	  
++ Copy the armeabi-v7a .so libraries to the LLM Android application project:
+
+	  ```shell
+	  mkdir -p ../apps/MnnLlmApp/app/src/main/jniLibs/armeabi-v7a
+	  find . -name "*.so" -exec cp {} ../apps/MnnLlmApp/app/src/main/jniLibs/armeabi-v7a/  \;
+	  ```
+  
+#### 3.Build the Android Application Project and Install:
++ Execute the installation command:
+
   ```shell
   cd ../apps/MnnLlmApp/
   ./gradlew installDebug
   ```
+  
 
 # Releases
 ## Version 0.2

--- a/project/android/apps/MnnLlmApp/README_CN.md
+++ b/project/android/apps/MnnLlmApp/README_CN.md
@@ -39,17 +39,45 @@
   ```shell
     git clone https://github.com/alibaba/MNN.git
   ```
-+ 构建库：
-  ```shell
-  cd project/android
-  mkdir build_64
-  ../build_64.sh "-DMNN_LOW_MEMORY=true -DMNN_CPU_WEIGHT_DEQUANT_GEMM=true -DMNN_BUILD_LLM=true -DMNN_SUPPORT_TRANSFORMER_FUSE=true -DMNN_ARM82=true -DMNN_USE_LOGCAT=true -DMNN_OPENCL=true -DLLM_SUPPORT_VISION=true -DMNN_BUILD_OPENCV=true -DMNN_IMGCODECS=true -DLLM_SUPPORT_AUDIO=true -DMNN_BUILD_AUDIO=true -DMNN_BUILD_DIFFUSION=ON -DMNN_SEP_BUILD=ON"
-  ```
-+ 复制到 LLM Android 应用项目：
-  ```shell
-  find . -name "*.so" -exec cp {} ../apps/MnnLlmApp/app/src/main/jniLibs/arm64-v8a/  \;
-  ```
-+ 构建 Android 应用项目并安装：
+  
+#### 1.构建库 64位：
+
+1. 构建库arm64：
+
+	  ```shell
+	  cd project/android
+	  mkdir build_64
+	  cd build_64
+	  ../build_64.sh "-DMNN_LOW_MEMORY=true -DMNN_CPU_WEIGHT_DEQUANT_GEMM=true -DMNN_BUILD_LLM=true -DMNN_SUPPORT_TRANSFORMER_FUSE=true -DMNN_ARM82=true -DMNN_USE_LOGCAT=true -DMNN_OPENCL=true -DLLM_SUPPORT_VISION=true -DMNN_BUILD_OPENCV=true -DMNN_IMGCODECS=true -DLLM_SUPPORT_AUDIO=true -DMNN_BUILD_AUDIO=true -DMNN_BUILD_DIFFUSION=ON -DMNN_SEP_BUILD=ON"
+	  ```
++ 复制arm64-v8a的so库到 LLM Android 应用项目：
+
+	  ```shell
+	  mkdir -p ../apps/MnnLlmApp/app/src/main/jniLibs/arm64-v8a
+	  find . -name "*.so" -exec cp {} ../apps/MnnLlmApp/app/src/main/jniLibs/arm64-v8a/  \;
+	  ```
+  
+#### 2.构建库 32位（可选）：
+
+1. 构建库armeabi-v7a:
+
+	  ```shell
+	  cd project/android
+	  mkdir build_32
+	  cd build_32
+	  ../build_32.sh "-DMNN_LOW_MEMORY=true -DMNN_CPU_WEIGHT_DEQUANT_GEMM=true -DMNN_BUILD_LLM=true -DMNN_SUPPORT_TRANSFORMER_FUSE=true -DMNN_ARM82=true -DMNN_USE_LOGCAT=true -DMNN_OPENCL=true -DLLM_SUPPORT_VISION=true -DMNN_BUILD_OPENCV=true -DMNN_IMGCODECS=true -DLLM_SUPPORT_AUDIO=true -DMNN_BUILD_AUDIO=true -DMNN_BUILD_DIFFUSION=ON -DMNN_SEP_BUILD=ON"
+	  ```
+	  
++ 复制armeabi-v7a的so库到 LLM Android 应用项目：
+
+	  ```shell
+	  mkdir -p ../apps/MnnLlmApp/app/src/main/jniLibs/armeabi-v7a
+	  find . -name "*.so" -exec cp {} ../apps/MnnLlmApp/app/src/main/jniLibs/armeabi-v7a/  \;
+	  ```
+  
+#### 3.构建 Android 应用项目并安装：
++ 执行安装命令：
+
   ```shell
   cd ../apps/MnnLlmApp/
   ./gradlew installDebug


### PR DESCRIPTION
I found that this Android command was incomplete. Before executing the "../build_64.sh "-DMNN_LOW_MEMORY=true ..."" command, the "cd build_64" command was missing, which caused the system to repeatedly fail to locate the 'build_64.sh' file. Additionally, I improved the compilation command steps required for armeabi-v7a and optimized the formatting.