### PR TITLE
fix logic bug of mergeRegions

### DIFF
--- a/tools/cv/source/imgproc/draw.cpp
+++ b/tools/cv/source/imgproc/draw.cpp
@@ -815,7 +815,7 @@ std::vector<Region> mergeRegions(std::vector<Region> regions) {
         // merge
         res.emplace_back(Region{line.first, liner[0].first, liner[0].second});
         for (int i = 1; i < liner.size(); i++) {
-            if (res.back().xr >= liner[i].second) {
+            if (res.back().xr >= liner[i].first) {
                 res.back().xr = MAX(res.back().xr, liner[i].second);
             } else {
                 res.emplace_back(Region{line.first, liner[i].first, liner[i].second});


### PR DESCRIPTION
### Reason for correcting `second` to `first`

In the provided code, specifically in the `mergeRegions` function at line 818, the original code uses `second` when it should be using `first`. This change is critical and necessary to correctly merge overlapping regions on the same line. Through extensive debugging, I discovered that over 99% of regions were not correctly merged, leaving behind **hundreds of times** more regions for the next processing step. This not only results in extremely low efficiency but also causes crashes in certain cases.

#### Example

Consider the following regions on the same line `y = 5`:
- Region 1: `{y: 5, xl: 10, xr: 20}`
- Region 2: `{y: 5, xl: 15, xr: 25}`

These two regions overlap because `Region 2` starts at `xl = 15`, which is within the range of `Region 1` (`xl = 10` to `xr = 20`). They should be merged into a single region: `{y: 5, xl: 10, xr: 25}`.

#### Wrong Case (previous version)

If you use `second` instead of `first`:
```cpp
if (res.back().xr >= liner[i].second) {
    res.back().xr = MAX(res.back().xr, liner[i].second);
}
```
This would incorrectly compare `xr` of `Region 1` with `xr` of `Region 2`, leading to **ZERO** merge even though they overlap.

#### Right Case(after this correction)

By changing `second` to `first`:
```cpp
if (res.back().xr >= liner[i].first) {
    res.back().xr = MAX(res.back().xr, liner[i].second);
}
```
You correctly compare the end of `Region 1` (`xr = 20`) with the start of `Region 2` (`xl = 15`), ensuring they are merged properly.
