### PR TITLE
Fix out-of-bounds crash & support FILLED for rectangle

### DIFF
--- a/tools/cv/source/imgproc/draw.cpp
+++ b/tools/cv/source/imgproc/draw.cpp
@@ -905,14 +905,20 @@ void line(VARP& img, Point pt1, Point pt2, const Scalar& color,
 
 void rectangle(VARP& img, Point pt1, Point pt2, const Scalar& color,
                int thickness, int lineType, int shift) {
-    // top
-    line(img, pt1, {pt2.fX, pt1.fY}, color, thickness, lineType);
-    // left
-    line(img, pt1, {pt1.fX, pt2.fY}, color, thickness, lineType);
-    // right
-    line(img, {pt2.fX, pt1.fY}, pt2, color, thickness, lineType);
-    // bottom
-    line(img, {pt1.fX, pt2.fY}, pt2, color, thickness, lineType);
+    int h, w, c; getVARPSize(img, &h, &w, &c);
+    Size size(w, h);
+    std::vector<Point2l> pt(4);
+    pt[0] = {static_cast<int64_t>(pt1.fX), static_cast<int64_t>(pt1.fY)};
+    pt[1] = {static_cast<int64_t>(pt2.fX), static_cast<int64_t>(pt1.fY)};
+    pt[2] = {static_cast<int64_t>(pt2.fX), static_cast<int64_t>(pt2.fY)};
+    pt[3] = {static_cast<int64_t>(pt1.fX), static_cast<int64_t>(pt2.fY)};
+    std::vector<Region> regions;
+    if (thickness >= 0) {
+        PolyLine(regions, size, pt.data(), 4, true, thickness, lineType, shift);
+    } else {
+        FillConvexPoly(regions, size, pt.data(), 4, lineType, shift);
+    }
+    doDraw(img, regions, color);
 }
 
 void drawContours(VARP& img, std::vector<std::vector<Point>> _contours, int contourIdx, const Scalar& color, int thickness, int lineType) {

--- a/tools/cv/source/imgproc/draw.cpp
+++ b/tools/cv/source/imgproc/draw.cpp
@@ -82,6 +82,13 @@ bool clipLine(Size img_size, Point2i& pt1, Point2i& pt2) {
 }
 
 enum { XY_SHIFT = 16, XY_ONE = 1 << XY_SHIFT, DRAWING_STORAGE_BLOCK = (1<<12) - 256 };
+
+static inline void PutPoint(std::vector<Region>& regions, Size size, int x, int y) {
+    if( 0 <= x && x < size.width && 0 <= y && y < size.height) {
+        regions.emplace_back(Region{y, x});
+    }
+}
+
 static void Line(std::vector<Region>& regions, Size size, Point2i pt1_, Point2i pt2_, int connectivity = 8) {
     if (connectivity == 0) {
         connectivity = 8;
@@ -152,13 +159,13 @@ static void Line(std::vector<Region>& regions, Size size, Point2i pt1_, Point2i 
         std::swap(minusStep, minusShift);
     }
     p = pt1;
-    regions.emplace_back(Region{p.y, p.x});
+    PutPoint(regions, size, p.x, p.y);
     for(int i = 1; i < count; i++) {
         int mask = err < 0 ? -1 : 0;
         err += minusDelta + (plusDelta & mask);
         p.y += minusStep + (plusStep & mask);
         p.x += minusShift + (plusShift & mask);
-        regions.emplace_back(Region{p.y, p.x});
+        PutPoint(regions, size, p.x, p.y);
     }
 }
 
@@ -207,11 +214,11 @@ static void Line2(std::vector<Region>& regions, Size size, Point2l pt1, Point2l 
     }
     pt1.x += (XY_ONE >> 1);
     pt1.y += (XY_ONE >> 1);
-    regions.emplace_back(Region{(int)((pt2.y + (XY_ONE >> 1)) >> XY_SHIFT), (int)((pt2.x + (XY_ONE >> 1)) >> XY_SHIFT)});
+    PutPoint(regions, size, (pt2.x + (XY_ONE >> 1)) >> XY_SHIFT, (pt2.y + (XY_ONE >> 1)) >> XY_SHIFT);
     if (ax > ay) {
         pt1.x >>= XY_SHIFT;
         while(ecount >= 0) {
-            regions.emplace_back(Region{(int)(pt1.y >> XY_SHIFT), (int)(pt1.x)});
+            PutPoint(regions, size, pt1.x, pt1.y >> XY_SHIFT);
             pt1.x++;
             pt1.y += y_step;
             ecount--;
@@ -219,7 +226,7 @@ static void Line2(std::vector<Region>& regions, Size size, Point2l pt1, Point2l 
     } else {
         pt1.y >>= XY_SHIFT;
         while(ecount >= 0) {
-            regions.emplace_back(Region{(int)(pt1.y), (int)(pt1.x >> XY_SHIFT)});
+            PutPoint(regions, size, pt1.x >> XY_SHIFT, pt1.y);
             pt1.x += x_step;
             pt1.y++;
             ecount--;

--- a/tools/cv/test/imgproc/draw_test.cpp
+++ b/tools/cv/test/imgproc/draw_test.cpp
@@ -89,6 +89,13 @@ TEST(rectangle, basic) {
     rectangle(testEnv.mnnSrc, {10, 10}, {200, 300}, {0, 0, 255}, 1);
     EXPECT_TRUE(testEnv.equal(testEnv.cvSrc, testEnv.mnnSrc));
 }
+
+TEST(rectangle, fill) {
+    cv::rectangle(testEnv.cvSrc, {10, 10}, {200, 300}, {200, 20, 2}, -1);
+    rectangle(testEnv.mnnSrc, {10, 10}, {200, 300}, {200, 20, 2}, -1);
+    EXPECT_TRUE(testEnv.equal(testEnv.cvSrc, testEnv.mnnSrc));
+}
+
 // drawContours
 TEST(drawContours, basic) {
     cv::Mat gray, binary;


### PR DESCRIPTION
This PR includes two changes. Both are in imitation of [4.x version of OpenCV official](https://github.com/opencv/opencv/blob/4.x/modules/imgproc/src/drawing.cpp) .

1. Fix Out-of-Bounds Crash in MNNCV Drawing
Previously, the MNNCV drawing function did not properly clip shapes exceeding image boundaries, which could lead to a crash, especially on Windows. Commit 30bf2f5 ensures proper clipping while calculating regions.

2. Add **FILLED** Support for Rectangle Drawing
In previous versions, circle and ellipse supported thickness < 1 to render filled shapes, similar to OpenCV. However, rectangle lacked this behavior. Commit 4226ec0 extends the rectangle function to support filled rendering when thickness < 1. Attached images demonstrate that test added a filled rectangle drawing failed. With this new commit, unit tests confirm the expected behavior.
![f0072a735cac4186d979f936a8f6065](https://github.com/user-attachments/assets/cd9fce23-cc6b-4e80-84b9-8c29fbc248cc)
![f64dd7f9dada7d16fcdab3c086ff9a8](https://github.com/user-attachments/assets/880d31c0-89c5-4467-adbe-a4a46cc2539b)
