### PR TITLE
Fix: resolve compilation warnings on macOS

### DIFF
--- a/source/core/Pipeline.cpp
+++ b/source/core/Pipeline.cpp
@@ -964,7 +964,7 @@ ErrorCode Pipeline::fixResizeCache() {
 
     mInfo.first.cache.first->onSelectDynamicAllocator(0, 2);
     res && mInfo.first.cache.second->onSelectDynamicAllocator(0, 2);
-    MNN_PRINT("Fix: %d - Total: %d, rate = %f\n", fixNumber, totalNumber, (float)fixNumber / (float)totalNumber);
+    MNN_PRINT("Fix: %zu - Total: %zu, rate = %f\n", fixNumber, totalNumber, (float)fixNumber / (float)totalNumber);
 #endif
     return NO_ERROR;
 }

--- a/source/core/Pipeline.cpp
+++ b/source/core/Pipeline.cpp
@@ -181,11 +181,11 @@ void Pipeline::UnitInfo::setUp(const Command& command, int index, const Op* orig
     } else {
         if (nullptr != originOp && nullptr != originOp->name()) {
             char buffer[20];
-            sprintf(buffer, "%d", index);
+            snprintf(buffer, sizeof(buffer), "%d", index);
             mContent->name = originOp->name()->str() + "_raster_" + buffer;
         } else {
             char buffer[20];
-            sprintf(buffer, "_raster_%d", totalIndex);
+            snprintf(buffer, sizeof(buffer), "_raster_%d", totalIndex);
             mContent->name = buffer;
         }
     }

--- a/tools/cpp/ModuleBasic.cpp
+++ b/tools/cpp/ModuleBasic.cpp
@@ -34,7 +34,7 @@ static bool compareOutput(VARP output, const std::string& directName, const std:
     }
 
     if (nullptr == info || nullptr == ptr) {
-        MNN_ERROR("TESTERROR name:%s, info:%p, ptr:%p. size:%d\n", name.c_str(), info, ptr, info->size);
+        MNN_ERROR("TESTERROR name:%s, info:%p, ptr:%p. size:%zu\n", name.c_str(), info, ptr, info->size);
         return false;
     }
 

--- a/tools/cpp/Profiler.cpp
+++ b/tools/cpp/Profiler.cpp
@@ -42,7 +42,7 @@ static inline int64_t getTime() {
 
 static std::string toString(float value) {
     char typeString[100] = {};
-    sprintf(typeString, "%f", value);
+    snprintf(typeString, sizeof(typeString),"%f", value);
     return std::string(typeString);
 }
 
@@ -50,7 +50,7 @@ static std::string toString(const std::vector<int>& shape) {
     char content[100] = {};
     auto current      = content;
     for (auto s : shape) {
-        current = current + sprintf(current, "%d,", s);
+        current = current + snprintf(current, sizeof(current), "%d,", s);
     }
     return std::string(current);
 }

--- a/tools/cpp/getPerformance.cpp
+++ b/tools/cpp/getPerformance.cpp
@@ -64,7 +64,7 @@ void getFreqKhz(int cpuid, std::vector<int>& freqVector) {
     char path[256];
     int freqKhz = -1;
     // max
-    sprintf(path, "/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_max_freq", cpuid);
+    snprintf(path, sizeof(path), "/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_max_freq", cpuid);
     FILE* fp = fopen(path, "rb");
     if (nullptr == fp) {
         MNN_PRINT("cpuinfo_max_freq fopen error ! \n");
@@ -76,7 +76,7 @@ void getFreqKhz(int cpuid, std::vector<int>& freqVector) {
     }
 
     // min
-    sprintf(path, "/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_min_freq", cpuid);
+    snprintf(path, sizeof(path),"/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_min_freq", cpuid);
     fp = fopen(path, "rb");
     if (nullptr == fp) {
         MNN_PRINT("cpuinfo_min_freq fopen error ! \n");


### PR DESCRIPTION
1. **Correct printf format specifiers**  
   Use `%zu` instead of `%d` for `unsigned int`.

2. **Replace sprintf with snprintf for safety**
