### PR TITLE
[LLM:Bugfix] Fix incorrect kv_seq_len in gen_attention_mask() for autoregressive decoding

### DIFF
--- a/transformers/llm/engine/src/llm.cpp
+++ b/transformers/llm/engine/src/llm.cpp
@@ -720,9 +720,7 @@ std::string Llm::tokenizer_decode(int id) {
 
 VARP Llm::gen_attention_mask(int seq_len) {
     int kv_seq_len = mContext->all_seq_len + seq_len;
-    if (seq_len == 1) {
-        kv_seq_len = seq_len;
-    }
+
     if (mConfig->attention_mask() == "float") {
         if (needNewVar(attentionMask, 2, seq_len)) {
             attentionMask = _Input({1, 1, seq_len, kv_seq_len}, NCHW, halide_type_of<float>());


### PR DESCRIPTION
During the **decoding** phase (auto-regressive generation), `Llm::generate()` calls `forward(input_ids, is_prefill)` with `input_ids.size() == 1`. The current logic in `Llm::gen_attention_mask()` sets `kv_seq_len = seq_len` (where `seq_len=1` for decoding), which is incorrect.  This ignores the accumulated history length（`mContext->all_seq_len`）, leading to mismatched attention masks and affecting the calculation of attention scores, thereby influencing the model's inference results.