### PR TITLE
llm 支持输入参数为input_embeds

### DIFF
--- a/transformers/llm/engine/include/llm/llm.hpp
+++ b/transformers/llm/engine/include/llm/llm.hpp
@@ -79,6 +79,7 @@ public:
     virtual Express::VARP gen_position_ids(int seq_len);
     virtual Express::VARP embedding(const std::vector<int>& input_ids);
     Express::VARP forward(const std::vector<int>& input_ids, bool is_prefill = true);
+    Express::VARP forward(MNN::Express::VARP input_embeds, bool is_prefill = true);
     virtual Express::VARP forwardRaw(Express::VARP hiddenState, Express::VARP mask, Express::VARP inputPos);
     virtual int sample(Express::VARP logits, int offset = 0, int size = 0);
     void reset();
@@ -90,9 +91,11 @@ public:
     virtual void response(const std::vector<int>& input_ids, std::ostream* os = &std::cout, const char* end_with = nullptr, int max_new_tokens = -1);
     void response(const std::string& user_content, std::ostream* os = &std::cout, const char* end_with = nullptr, int max_new_tokens = -1);
     void response(const ChatMessages& chat_prompts, std::ostream* os = &std::cout, const char* end_with = nullptr, int max_new_tokens = -1);
+    void response(MNN::Express::VARP input_embeds, std::ostream* os = &std::cout, const char* end_with = nullptr, int max_new_tokens = -1);
     virtual void generate_init(std::ostream* os = nullptr, const char* end_with = nullptr);
     void generate(int max_token);
     std::vector<int> generate(const std::vector<int>& input_ids, int max_new_tokens = -1);
+    std::vector<int> generate(MNN::Express::VARP input_embeds, int max_tokens = -1);
     bool stoped();
     bool reuse_kv();
     // config function

--- a/transformers/llm/engine/include/llm/llm.hpp
+++ b/transformers/llm/engine/include/llm/llm.hpp
@@ -79,7 +79,7 @@ public:
     virtual Express::VARP gen_position_ids(int seq_len);
     virtual Express::VARP embedding(const std::vector<int>& input_ids);
     Express::VARP forward(const std::vector<int>& input_ids, bool is_prefill = true);
-    Express::VARP forward(MNN::Express::VARP input_embeds, bool is_prefill = true);
+    Express::VARP forward(MNN::Express::VARP input_embeds);
     virtual Express::VARP forwardRaw(Express::VARP hiddenState, Express::VARP mask, Express::VARP inputPos);
     virtual int sample(Express::VARP logits, int offset = 0, int size = 0);
     void reset();

--- a/transformers/llm/engine/src/llm.cpp
+++ b/transformers/llm/engine/src/llm.cpp
@@ -316,15 +316,8 @@ Express::VARP Llm::forwardRaw(Express::VARP hiddenState, Express::VARP mask, Exp
 }
 
 VARP Llm::forward(const std::vector<int>& input_ids, bool is_prefill) {
-    int seq_len         = input_ids.size();
-    mMeta->add          = seq_len;
-    auto attention_mask = gen_attention_mask(seq_len);
-    auto position_ids = gen_position_ids(seq_len);
     auto hidden_states = embedding(input_ids);
-    auto logits = forwardRaw(hidden_states, attention_mask, position_ids);
-    mContext->all_seq_len += seq_len;
-    mContext->gen_seq_len++;
-    return logits;
+    return forward(hidden_states);
 }
 
 VARP Llm::forward(MNN::Express::VARP input_embeds) {

--- a/transformers/llm/engine/src/llm.cpp
+++ b/transformers/llm/engine/src/llm.cpp
@@ -327,7 +327,7 @@ VARP Llm::forward(const std::vector<int>& input_ids, bool is_prefill) {
     return logits;
 }
 
-VARP Llm::forward(MNN::Express::VARP input_embeds, bool is_prefill) {
+VARP Llm::forward(MNN::Express::VARP input_embeds) {
     int seq_len         = input_embeds->getInfo()->dim[0]; 
     mMeta->add          = seq_len;
     auto attention_mask = gen_attention_mask(seq_len);


### PR DESCRIPTION
本次以新增接口的方式修改的。
![image](https://github.com/user-attachments/assets/8fc53fb4-2ec7-4c52-88f3-08c36491537f)

hf transformer的Qwen2的forward函数 参数中既支持input_ids形式，同时也支持inputs_embeds 形式。 这样其实通用性更高。 比如我的这个场景： 我自定义模型 VIT + LLM， VIT部分的输出给LLM作为输入时，已经是inputs_embeds的结果了而不是input_ids， 但是咱们的MNN的LLM的forward接口是没有这个参数的 
hf transformer这两个参数使用方式和逻辑都是很清晰的，我想参考hf代码，优化下咱们MNN的forward接口
