### PR TITLE
Vulkan:Bugfix: Fix bug for radixsort copy sortnumber error

### DIFF
--- a/source/backend/vulkan/buffer/backend/VulkanBackend.hpp
+++ b/source/backend/vulkan/buffer/backend/VulkanBackend.hpp
@@ -92,7 +92,9 @@ public:
     VULKAN_TENSOR getBuffer(const Tensor* tensor) const;
     std::shared_ptr<VulkanBuffer> allocUniform(const void* src = nullptr, int size = 0);
     void recycleUniform(std::shared_ptr<VulkanBuffer> buffer);
+    void copyGPUToGPUBuffer(VkBuffer srcBuffer, VkBuffer dstBuffer, VkDeviceSize size, VkDeviceSize srcOffset, VkDeviceSize dstOffset) const;
     void copyToGPUBuffer(const void* src, VkBuffer buffer, VkDeviceSize size, VkDeviceSize offset) const;
+    std::shared_ptr<VulkanBuffer> createHostBuffer(size_t size) const;
 
     const VulkanDevice& device() const;
 #ifdef ENABLE_VULKAN_TIME_PROFILE

--- a/source/backend/vulkan/buffer/render/VulkanGaussianRender.cpp
+++ b/source/backend/vulkan/buffer/render/VulkanGaussianRender.cpp
@@ -148,7 +148,7 @@ ErrorCode VulkanRasterSort::onEncode(const std::vector<Tensor *> &inputs, const 
         region2.dstOffset = std::get<2>(output);
         region2.srcOffset = pointOffsetSum.second + (pointOffsetBytes / sizeof(uint32_t) - 1) * sizeof(uint32_t);
 
-        vkCmdCopyBuffer(cmdBuffer->get(), ((VulkanBuffer*)pointOffsetSum.first)->buffer(), std::get<0>(output), 1, &region);
+        vkCmdCopyBuffer(cmdBuffer->get(), ((VulkanBuffer*)pointOffsetSum.first)->buffer(), std::get<0>(output), 1, &region2);
 
         cmdBuffer->barrierSource(sortNumber->buffer(), 0, sizeof(uint32_t));
     }

--- a/source/backend/vulkan/component/VulkanCommandPool.cpp
+++ b/source/backend/vulkan/component/VulkanCommandPool.cpp
@@ -24,8 +24,7 @@ VulkanCommandPool::~VulkanCommandPool() {
     mDevice.destroyCommandPool(mPool);
     // FUNC_PRINT(1);
 }
-
-void VulkanCommandPool::submitAndWait(VkCommandBuffer buffer) const {
+std::shared_ptr<VulkanFence> VulkanCommandPool::submit(VkCommandBuffer buffer) const {
     auto b                   = buffer;
     auto fence               = std::make_shared<VulkanFence>(mDevice);
     VkSubmitInfo submit_info = {/* .sType                = */ VK_STRUCTURE_TYPE_SUBMIT_INFO,
@@ -40,6 +39,11 @@ void VulkanCommandPool::submitAndWait(VkCommandBuffer buffer) const {
     auto fenceReal           = fence->get();
     auto queue               = mDevice.acquireDefaultDevQueue();
     CALL_VK(vkQueueSubmit(queue, 1, &submit_info, fenceReal));
+    return fence;
+}
+
+void VulkanCommandPool::submitAndWait(VkCommandBuffer buffer) const {
+    auto fence = submit(buffer);
     fence->wait();
 }
 

--- a/source/backend/vulkan/component/VulkanCommandPool.hpp
+++ b/source/backend/vulkan/component/VulkanCommandPool.hpp
@@ -11,6 +11,7 @@
 
 #include "core/NonCopyable.hpp"
 #include "backend/vulkan/component/VulkanDevice.hpp"
+#include "backend/vulkan/component/VulkanFence.hpp"
 #include "backend/vulkan/vulkan/vulkan_wrapper.h"
 namespace MNN {
 class VulkanImage;
@@ -49,6 +50,7 @@ public:
     }
 
     void submitAndWait(VkCommandBuffer buffer) const;
+    std::shared_ptr<VulkanFence> submit(VkCommandBuffer buffer) const;
 
 private:
     const VulkanDevice& mDevice;

--- a/source/core/Tensor.cpp
+++ b/source/core/Tensor.cpp
@@ -350,7 +350,11 @@ void Tensor::print() const {
 
     // convert to host if needed
     auto printee = this;
-    bool device  = this->buffer().host == NULL && this->buffer().device != 0;
+    auto bnType = MNN_FORWARD_CPU;
+    if (nullptr != mDescribe->getBackend()) {
+        bnType = mDescribe->getBackend()->type();
+    }
+    bool device  = bnType != MNN_FORWARD_CPU;
     if (device) {
         printee = this->createHostTensorFromDevice(this, true);
     }

--- a/source/geometry/ConvertUtils.cpp
+++ b/source/geometry/ConvertUtils.cpp
@@ -105,6 +105,7 @@ void ConvertUtils::broadcastto(Tensor* input, Tensor* output, bool forward) {
         reg.dst.stride[1] = multipler;
         reg.dst.stride[2] = 1;
         reg.origin = input;
+        return;
     }
     int32_t inputShape[MNN_MAX_TENSOR_DIM];
     int32_t outputShape[MNN_MAX_TENSOR_DIM];


### PR DESCRIPTION
修正 tensor->print 在 fp16 或 avx2 时判断错误，导致打印不对的问题
修正 Tf Select 广播出错的问题
修正 Vulkan 初始化时获取 localmemory size 的内存越界问题
修正 Vulkan Buffer 分支 Raster 的C4快速计算模式
优化 Vulkan Buffer 分支 Convolution 加载性能（减少一次 gpu->gpu内存拷贝）
优化 Vulkan Extra 算子的常量初始化过程
修正 Vulkan Radixsort 输出拷贝的 region 不对的问题