### PR TITLE
修复train demo使用了cpp11以上标准的代码导致无法编译

### DIFF
--- a/tools/train/source/demo/ImageDatasetDemo.cpp
+++ b/tools/train/source/demo/ImageDatasetDemo.cpp
@@ -64,7 +64,7 @@ public:
         auto converImagesToFormat  = CV::RGB;
         int resizeHeight           = 224;
         int resizeWidth            = 224;
-        std::vector<float> scales = {1/255.0, 1/255.0, 1/255.0};
+        std::vector<float> scales = {1/255.0f, 1/255.0f, 1/255.0f};
         std::shared_ptr<ImageDataset::ImageConfig> config(ImageDataset::ImageConfig::create(converImagesToFormat, resizeHeight, resizeWidth, scales));
         bool readAllImagesToMemory = false;
         auto dataset = ImageDataset::create(pathToImages, pathToImageTxt, config.get(), readAllImagesToMemory);

--- a/tools/train/source/demo/distillTrainQuant.cpp
+++ b/tools/train/source/demo/distillTrainQuant.cpp
@@ -84,7 +84,7 @@ void _train(std::shared_ptr<Module> origin, std::shared_ptr<Module> optmized, st
     int resizeHeight           = 224;
     int resizeWidth            = 224;
     std::vector<float> means = {127.5, 127.5, 127.5};
-    std::vector<float> scales = {1/127.5, 1/127.5, 1/127.5};
+    std::vector<float> scales = {1/127.5f, 1/127.5f, 1/127.5f};
     std::vector<float> cropFraction = {0.875, 0.875}; // center crop fraction for height and width
     bool centerOrRandomCrop = false; // true for random crop
     std::shared_ptr<ImageDataset::ImageConfig> datasetConfig(ImageDataset::ImageConfig::create(converImagesToFormat, resizeHeight, resizeWidth, scales, means, cropFraction, centerOrRandomCrop));


### PR DESCRIPTION
like this:

C:\Users\wuyex\Documents\Build\MNN\tools\train\source\demo\distillTrainQuant.cpp(87): error C2398: 元素“1”: 从“double”转换到“float”需要收缩转换
C:\Users\wuyex\Documents\Build\MNN\tools\train\source\demo\distillTrainQuant.cpp(87): error C2398: 元素“2”: 从“double”转换到“float”需要收缩转换
C:\Users\wuyex\Documents\Build\MNN\tools\train\source\demo\distillTrainQuant.cpp(87): error C2398: 元素“3”: 从“double”转换到“float”需要收缩转换