### PR TITLE
fix(ModelDownloadManager): Update download progress check method

### DIFF
--- a/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mls/api/download/ModelDownloadManager.kt
+++ b/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mls/api/download/ModelDownloadManager.kt
@@ -181,7 +181,7 @@ class ModelDownloadManager private constructor(private val context: Context) {
             if (getDownloadedFile(modelId) != null) {
                 downloadInfo.downlodaState = DownloadInfo.DownloadSate.COMPLETED
                 downloadInfo.progress = 1.0
-            } else if (getDownloadSizeTotal(ApplicationProvider.get(), modelId) > 0) {
+            } else if (getDownloadSizeSaved(ApplicationProvider.get(), modelId) > 0) {
                 val totalSize = getDownloadSizeTotal(ApplicationProvider.get(), modelId)
                 val savedSize = getDownloadSizeSaved(ApplicationProvider.get(), modelId)
                 downloadInfo.totalSize = totalSize


### PR DESCRIPTION
Change the download progress check from `getDownloadSizeTotal` to `getDownloadSizeSaved` to more accurately reflect the saved download data size.


**before:**
![before](https://github.com/user-attachments/assets/563ab735-5d34-4609-953a-2207517a219e)

**fixed:**
![fixed](https://github.com/user-attachments/assets/8571d5d1-4768-4a81-a691-15082dc1ec60)
