### PR TITLE
fix numberThread parameter in newExecutor not taking effect

### DIFF
--- a/express/Executor.cpp
+++ b/express/Executor.cpp
@@ -85,6 +85,7 @@ Executor::Executor(std::shared_ptr<Runtime> runtime, MNNForwardType type, int nu
     mRuntimeInfo.first.insert(std::make_pair(type, runtime));
     mAttr.reset(new ExecutorAttr);
     mAttr->firstType = type;
+    mAttr->numThread = numberThread;
     if (type == MNN_FORWARD_CPU) {
         mRuntimeInfo.second = runtime;
     } else {


### PR DESCRIPTION
While using the module API recently, I noticed that the `numberThread` parameter in the function
`static std::shared_ptr<Executor> newExecutor(MNNForwardType type, const BackendConfig& config, int numberThread);`
had no effect. After a quick check, I found that this was because the `Executor` constructor didn’t take this parameter into account. This PR fixes the issue.