### PR TITLE
Fixed: Sherpa-MNN could not load TTS models

### DIFF
--- a/apps/frameworks/sherpa-mnn/sherpa-mnn/csrc/offline-tts-kokoro-model.cc
+++ b/apps/frameworks/sherpa-mnn/sherpa-mnn/csrc/offline-tts-kokoro-model.cc
@@ -32,9 +32,9 @@ class OfflineTtsKokoroModel::Impl {
       : config_(config),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto model_buf = ReadFile(config.kokoro.model);
+    auto model_path = config.kokoro.model.c_str();
     auto voices_buf = ReadFile(config.kokoro.voices);
-    Init(model_buf.data(), model_buf.size(), voices_buf.data(),
+    Init(model_path, voices_buf.data(),
          voices_buf.size());
   }
 
@@ -43,9 +43,9 @@ class OfflineTtsKokoroModel::Impl {
       : config_(config),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto model_buf = ReadFile(mgr, config.kokoro.model);
+    auto model_path = config.kokoro.model.c_str();
     auto voices_buf = ReadFile(mgr, config.kokoro.voices);
-    Init(model_buf.data(), model_buf.size(), voices_buf.data(),
+    Init(model_path, voices_buf.data(),
          voices_buf.size());
   }
 
@@ -96,9 +96,9 @@ class OfflineTtsKokoroModel::Impl {
   }
 
  private:
-  void Init(void *model_data, size_t model_data_length, const char *voices_data,
+  void Init(const char *model_path, const char *voices_data,
             size_t voices_data_length) {
-    sess_ = std::unique_ptr<MNN::Express::Module>(MNN::Express::Module::load({}, {}, (const uint8_t*)model_data, model_data_length,
+    sess_ = std::unique_ptr<MNN::Express::Module>(MNN::Express::Module::load({}, {}, model_path,
                                            sess_opts_.pManager, &sess_opts_.pConfig));
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);

--- a/apps/frameworks/sherpa-mnn/sherpa-mnn/csrc/offline-tts-matcha-model.cc
+++ b/apps/frameworks/sherpa-mnn/sherpa-mnn/csrc/offline-tts-matcha-model.cc
@@ -31,8 +31,8 @@ class OfflineTtsMatchaModel::Impl {
       : config_(config),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto buf = ReadFile(config.matcha.acoustic_model);
-    Init(buf.data(), buf.size());
+    auto model_path = config.matcha.acoustic_model.c_str();
+    Init(model_path);
   }
 
   template <typename Manager>
@@ -40,8 +40,8 @@ class OfflineTtsMatchaModel::Impl {
       : config_(config),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto buf = ReadFile(mgr, config.matcha.acoustic_model);
-    Init(buf.data(), buf.size());
+    auto model_path = config.matcha.acoustic_model.c_str();
+    Init(model_path);
   }
 
   const OfflineTtsMatchaModelMetaData &GetMetaData() const {
@@ -117,8 +117,8 @@ class OfflineTtsMatchaModel::Impl {
   }
 
  private:
-  void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::unique_ptr<MNN::Express::Module>(MNN::Express::Module::load({}, {}, (const uint8_t*)model_data, model_data_length,
+  void Init(const char *model_path) {
+    sess_ = std::unique_ptr<MNN::Express::Module>(MNN::Express::Module::load({}, {}, model_path,
                                            sess_opts_.pManager, &sess_opts_.pConfig));
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);

--- a/apps/frameworks/sherpa-mnn/sherpa-mnn/csrc/offline-tts-vits-model.cc
+++ b/apps/frameworks/sherpa-mnn/sherpa-mnn/csrc/offline-tts-vits-model.cc
@@ -31,8 +31,8 @@ class OfflineTtsVitsModel::Impl {
       : config_(config),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto buf = ReadFile(config.vits.model);
-    Init(buf.data(), buf.size());
+    auto model_path = config.vits.model.c_str();
+    Init(model_path);
   }
 
   template <typename Manager>
@@ -40,8 +40,8 @@ class OfflineTtsVitsModel::Impl {
       : config_(config),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto buf = ReadFile(mgr, config.vits.model);
-    Init(buf.data(), buf.size());
+    auto model_path = config.vits.model.c_str();
+    Init(model_path);
   }
 
   MNN::Express::VARP Run(MNN::Express::VARP x, int sid, float speed) {
@@ -114,8 +114,8 @@ class OfflineTtsVitsModel::Impl {
   const OfflineTtsVitsModelMetaData &GetMetaData() const { return meta_data_; }
 
  private:
-  void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::unique_ptr<MNN::Express::Module>(MNN::Express::Module::load({}, {}, (const uint8_t*)model_data, model_data_length,
+  void Init(const char *model_path) {
+    sess_ = std::unique_ptr<MNN::Express::Module>(MNN::Express::Module::load({}, {}, model_path,
                                            sess_opts_.pManager, &sess_opts_.pConfig));
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);

--- a/apps/frameworks/sherpa-mnn/sherpa-mnn/jni/offline-tts.cc
+++ b/apps/frameworks/sherpa-mnn/sherpa-mnn/jni/offline-tts.cc
@@ -16,13 +16,13 @@ static OfflineTtsConfig GetOfflineTtsConfig(JNIEnv *env, jobject config) {
   jfieldID fid;
 
   fid = env->GetFieldID(cls, "model",
-                        "Lcom/k2fsa/sherpa/onnx/OfflineTtsModelConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/OfflineTtsModelConfig;");
   jobject model = env->GetObjectField(config, fid);
   jclass model_config_cls = env->GetObjectClass(model);
 
   // vits
   fid = env->GetFieldID(model_config_cls, "vits",
-                        "Lcom/k2fsa/sherpa/onnx/OfflineTtsVitsModelConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/OfflineTtsVitsModelConfig;");
   jobject vits = env->GetObjectField(model, fid);
   jclass vits_cls = env->GetObjectClass(vits);
 
@@ -67,7 +67,7 @@ static OfflineTtsConfig GetOfflineTtsConfig(JNIEnv *env, jobject config) {
 
   // matcha
   fid = env->GetFieldID(model_config_cls, "matcha",
-                        "Lcom/k2fsa/sherpa/onnx/OfflineTtsMatchaModelConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/OfflineTtsMatchaModelConfig;");
   jobject matcha = env->GetObjectField(model, fid);
   jclass matcha_cls = env->GetObjectClass(matcha);
 
@@ -115,7 +115,7 @@ static OfflineTtsConfig GetOfflineTtsConfig(JNIEnv *env, jobject config) {
 
   // kokoro
   fid = env->GetFieldID(model_config_cls, "kokoro",
-                        "Lcom/k2fsa/sherpa/onnx/OfflineTtsKokoroModelConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/OfflineTtsKokoroModelConfig;");
   jobject kokoro = env->GetObjectField(model, fid);
   jclass kokoro_cls = env->GetObjectClass(kokoro);
 


### PR DESCRIPTION
Sherpa-MNN目前无法在Android设备上加载TTS模型（kokoro、vits等）。原因包括通过buf读取模型时无法加载mnn.weight文件等。这个PR使用比较简单的方式修复这一问题，即通过path方式加载模型，即可修复这一问题，正常加载和使用。
【修复前】
加载TTS模型时提示：Can't open file:，位于FileLoader::_init()方法，原因为mnn.weight为空
【修复后】
测试了sherpa-vits和sherpa-kokoro，在Android设备上均可正常加载
测试模型见 https://huggingface.co/KindBrave/kokoro-multi-lang-v1_1-MNN-Custom 和 https://huggingface.co/KindBrave/sherpa-vits-zh-ll-MNN-Custom

我已经在测试APP上进行了验证，如果需要详细测试内容可继续与我联系 :)

[For English]
Sherpa-MNN is currently unable to load TTS models (kokoro, vits, etc.) on Android devices. Reasons include the inability to load the mnn.weight file when reading the model via buf, etc. This PR fixes this problem in a relatively simple way, that is, by loading the model in the path mode, this problem can be fixed, and it can be loaded and used normally.
[Before]
When loading a TTS model, the following message is displayed: Can't open file:, which is located in the FileLoader::_init() method, because mnn.weight is empty
[After]
Tested both sherpa-vits and sherpa-kokoro, both load fine on Android devices
See https://huggingface.co/KindBrave/kokoro-multi-lang-v1_1-MNN-Custom and https://huggingface.co/KindBrave/sherpa-vits-zh-ll-MNN-Custom for testing models

I have verified on the test app, please continue to contact me if you need more details:)