### PR TITLE
new feature to allow user to specify cpu

### DIFF
--- a/docs/inference/session.md
+++ b/docs/inference/session.md
@@ -185,13 +185,10 @@ struct BackendConfig {
         void* sharedContext = nullptr;
         size_t flags; // Valid for CPU Backend
     };
-
-    /** user specified cpu cores */
-    std::vector<int> cpuIds;
 };
 ```
 
-`memory`、`power`、`precision`分别为内存、功耗和精度偏好。支持这些选项的后端会在执行时做出相应调整；若不支持，则忽略选项。`cpuIds`允许用户指定一组CPU核心用于计算，但这些指定会被严格的校验合法性，当线程数量与合法的指定核心数量相同时得到最佳性能。
+`memory`、`power`、`precision`分别为内存、功耗和精度偏好。支持这些选项的后端会在执行时做出相应调整；若不支持，则忽略选项。
 
 示例：
 后端 **OpenCL**

--- a/docs/inference/session.md
+++ b/docs/inference/session.md
@@ -181,11 +181,17 @@ struct BackendConfig {
     PrecisionMode precision = Precision_Normal;
     
     /** user defined context */
-    void* sharedContext = nullptr;
+    union {
+        void* sharedContext = nullptr;
+        size_t flags; // Valid for CPU Backend
+    };
+
+    /** user specified cpu cores */
+    std::vector<int> cpuIds;
 };
 ```
 
-`memory`、`power`、`precision`分别为内存、功耗和精度偏好。支持这些选项的后端会在执行时做出相应调整；若不支持，则忽略选项。
+`memory`、`power`、`precision`分别为内存、功耗和精度偏好。支持这些选项的后端会在执行时做出相应调整；若不支持，则忽略选项。`cpuIds`允许用户指定一组CPU核心用于计算，但这些指定会被严格的校验合法性，当线程数量与合法的指定核心数量相同时得到最佳性能。
 
 示例：
 后端 **OpenCL**

--- a/express/Executor.cpp
+++ b/express/Executor.cpp
@@ -231,6 +231,14 @@ void Executor::RuntimeManager::setHint(Interpreter::HintMode mode, int value) {
         iter.second->setRuntimeHint(mInside->mContent->modes.runtimeHint);
     }
 }
+void Executor::RuntimeManager::setHint(Interpreter::HintMode mode, int* value, size_t size) {
+    mInside->mContent->modes.setHint(mode, value, size);
+    auto current = ExecutorScope::Current();
+    auto rt = current->getRuntime();
+    for (auto& iter : rt.first) {
+        iter.second->setRuntimeHint(mInside->mContent->modes.runtimeHint);
+    }
+}
 void Executor::RuntimeManager::setExternalPath(std::string path, int type) {
     mInside->mContent->modes.setExternalPath(path, type);
 }

--- a/include/MNN/Interpreter.hpp
+++ b/include/MNN/Interpreter.hpp
@@ -245,7 +245,10 @@ public:
         USE_CACHED_MMAP = 12,
         
         // Multi-Thread Load module, default is 0 (don't use other Thread)
-        INIT_THREAD_NUMBER = 13
+        INIT_THREAD_NUMBER = 13,
+
+        // CPU core ids
+        CPU_CORE_IDS = 14,
     };
 
     enum ExternalPathType {
@@ -280,10 +283,12 @@ public:
 
     /**
      * @brief The API shoud be called before create session.
-     * @param mode      Hint type
+     * @param hint      Hint type
      * @param value     Hint value
+     * @param size      Hint value size(when use a ptr)
      */
-    void setSessionHint(HintMode mode, int value);
+    void setSessionHint(HintMode hint, int value);
+    void setSessionHint(HintMode hint, int* value, size_t size);
 public:
     /**
      * @brief create runtimeInfo separately with schedule config.

--- a/include/MNN/MNNForwardType.h
+++ b/include/MNN/MNNForwardType.h
@@ -10,6 +10,7 @@
 #define MNNForwardType_h
 #include <stdint.h>
 #include <stddef.h>
+#include <vector>
 
 typedef enum {
     MNN_FORWARD_CPU = 0,
@@ -92,6 +93,9 @@ struct BackendConfig {
         void* sharedContext = nullptr;
         size_t flags; // Valid for CPU Backend
     };
+
+    /** user specified cpu cores */
+    std::vector<int> cpuIds;
 };
 
     /** acquire runtime status by Runtime::getCurrentStatus with following keys,

--- a/include/MNN/MNNForwardType.h
+++ b/include/MNN/MNNForwardType.h
@@ -10,7 +10,6 @@
 #define MNNForwardType_h
 #include <stdint.h>
 #include <stddef.h>
-#include <vector>
 
 typedef enum {
     MNN_FORWARD_CPU = 0,
@@ -93,9 +92,6 @@ struct BackendConfig {
         void* sharedContext = nullptr;
         size_t flags; // Valid for CPU Backend
     };
-
-    /** user specified cpu cores */
-    std::vector<int> cpuIds;
 };
 
     /** acquire runtime status by Runtime::getCurrentStatus with following keys,

--- a/include/MNN/expr/Executor.hpp
+++ b/include/MNN/expr/Executor.hpp
@@ -126,6 +126,7 @@ public:
         friend class Executor;
         void setMode(Interpreter::SessionMode mode);
         void setHint(Interpreter::HintMode mode, int value);
+        void setHint(Interpreter::HintMode mode, int* value, size_t size);
         void setHintPtr(Interpreter::HintMode mode, void* value);
         bool getInfo(Interpreter::SessionInfoCode code, void* ptr);
         BackendConfig* getBnConfig();

--- a/source/backend/arm82/Arm82Backend.cpp
+++ b/source/backend/arm82/Arm82Backend.cpp
@@ -24,7 +24,7 @@
 
 namespace MNN {
 
-Arm82Backend::Arm82Backend(const CPURuntime* runtime, BackendConfig::MemoryMode memory, int initThreadNumber) : CPUBackend(runtime, BackendConfig::Precision_Low, memory, MNN_FORWARD_CPU_EXTENSION, 0, initThreadNumber) {
+Arm82Backend::Arm82Backend(const CPURuntime* runtime, BackendConfig::MemoryMode memory) : CPUBackend(runtime, BackendConfig::Precision_Low, memory, MNN_FORWARD_CPU_EXTENSION, 0) {
     mCoreFunctions = Arm82Functions::get();
     mInt8CoreFunctions = Arm82Functions::getInt8();
 }

--- a/source/backend/arm82/Arm82Backend.hpp
+++ b/source/backend/arm82/Arm82Backend.hpp
@@ -28,7 +28,7 @@ namespace MNN {
 class Arm82Backend : public CPUBackend {
 public:
     virtual ~Arm82Backend();
-    Arm82Backend(const CPURuntime* runtime, BackendConfig::MemoryMode memory, int initThreadNumber);
+    Arm82Backend(const CPURuntime* runtime, BackendConfig::MemoryMode memory);
     virtual Execution* onCreate(const std::vector<Tensor*>& inputs, const std::vector<Tensor*>& outputs,
                                 const MNN::Op* op) override;
     virtual Backend::MemObj* onAcquire(const Tensor* nativeTensor, StorageType storageType) override;

--- a/source/backend/cpu/CPUBackend.cpp
+++ b/source/backend/cpu/CPUBackend.cpp
@@ -341,25 +341,24 @@ Backend* CPURuntime::onCreate(const BackendConfig* config, Backend* origin) cons
     MNN_PRINT("cpu backend was created by runtime:%p\n", this);
 #endif
     CPUBackend* res = nullptr;
-    auto initThreadNumber = hint().initThreadNumber;
     do {
 #ifdef MNN_USE_ARMV82
         auto core = MNNGetCoreFunctions();
         if (core->supportFp16arith && precision == BackendConfig::Precision_Low) {
-            res = new Arm82Backend(this, memory, initThreadNumber);
+            res = new Arm82Backend(this, memory);
             break;
         }
 #endif
 #ifdef MNN_SUPPORT_BF16
         if (precision == BackendConfig::Precision_Low_BF16 && BF16Functions::get()) {
-            res = new CPUBackend(this, precision, memory, MNN_FORWARD_CPU_EXTENSION, 0, initThreadNumber);
+            res = new CPUBackend(this, precision, memory, MNN_FORWARD_CPU_EXTENSION);
             res->mCoreFunctions = BF16Functions::get();
             break;
         }
 #endif
         if (flags == MNN_CPU_USE_DEFAULT_BACKEND) {
             // Default don't use multi-thread init
-            res = new CPUBackend(this, precision, memory, MNN_FORWARD_CPU, 0, 0);
+            res = new CPUBackend(this, precision, memory, MNN_FORWARD_CPU, 0);
             break;
         }
 #ifdef MNN_USE_SSE
@@ -368,7 +367,7 @@ Backend* CPURuntime::onCreate(const BackendConfig* config, Backend* origin) cons
             break;
         }
 #endif
-        res = new CPUBackend(this, precision, memory, MNN_FORWARD_CPU, flags, initThreadNumber);
+        res = new CPUBackend(this, precision, memory, MNN_FORWARD_CPU, flags);
     } while (false);
     mSharedDmaInfo = nullptr;
     return res;
@@ -460,7 +459,7 @@ BufferAllocator* CPURuntime::createDynamicBufferAlloctor(int index) const {
     }
     return new EagerBufferAllocator(BufferAllocator::Allocator::createRecurse(mStaticAllocator.get()));
 }
-CPUBackend::CPUBackend(const CPURuntime* runtime, BackendConfig::PrecisionMode precision, BackendConfig::MemoryMode memory, MNNForwardType type, size_t flags, int initThreadNumber) : Backend(type) {
+CPUBackend::CPUBackend(const CPURuntime* runtime, BackendConfig::PrecisionMode precision, BackendConfig::MemoryMode memory, MNNForwardType type, size_t flags) : Backend(type) {
 #ifdef LOG_VERBOSE
     MNN_PRINT("cpu backend create\n");
 #endif

--- a/source/backend/cpu/CPUBackend.cpp
+++ b/source/backend/cpu/CPUBackend.cpp
@@ -164,6 +164,7 @@ void CPURuntime::_resetThreadPool() {
 void CPURuntime::onReset(int numberThread, const BackendConfig* config, bool full) {
     if (config != nullptr) {
         mPower = config->power;
+        mCpuIds = config->cpuIds;
         if (full) {
             mPrecision = config->precision;
             mMemory = config->memory;
@@ -185,11 +186,13 @@ CPURuntime::CPURuntime(const Backend::Info& info) {
     mPower   = BackendConfig::Power_Normal;
     mMemory  = BackendConfig::Memory_Normal;
     mPrecision = BackendConfig::Precision_Normal;
+    mCpuIds.clear();
     if (info.user != nullptr) {
         mPrecision = info.user->precision;
         mPower = info.user->power;
         mMemory = info.user->memory;
         mFlags = info.user->flags;
+        mCpuIds = info.user->cpuIds;
     }
     _resetThreadPool();
 #ifdef LOG_VERBOSE

--- a/source/backend/cpu/CPUBackend.hpp
+++ b/source/backend/cpu/CPUBackend.hpp
@@ -105,7 +105,7 @@ private:
 };
 class CPUBackend : public Backend {
 public:
-    CPUBackend(const CPURuntime* runtime, BackendConfig::PrecisionMode precision, BackendConfig::MemoryMode memory, MNNForwardType type = MNN_FORWARD_CPU, size_t flags = 0, int initThreadNumber = 0);
+    CPUBackend(const CPURuntime* runtime, BackendConfig::PrecisionMode precision, BackendConfig::MemoryMode memory, MNNForwardType type = MNN_FORWARD_CPU, size_t flags = 0);
     virtual ~CPUBackend();
 
     // Return sizeDivide, scheduleNumber aligned memory

--- a/source/backend/cpu/CPUBackend.hpp
+++ b/source/backend/cpu/CPUBackend.hpp
@@ -56,6 +56,7 @@ public:
 private:
     void _bindCPUCore() const;
     void _resetThreadPool();
+    void _validateCpuIds();
     mutable std::shared_ptr<EagerBufferAllocator> mStaticAllocator;
     int mThreadNumber;
     std::vector<int> mCpuIds;

--- a/source/backend/cpu/CPUBackend.hpp
+++ b/source/backend/cpu/CPUBackend.hpp
@@ -54,16 +54,16 @@ public:
 
 private:
     void _bindCPUCore() const;
-    void _resetThreadPool();
-    void _validateCpuIds();
+    void _resetThreadPool() const;
+    void _validateCpuIds() const;
     mutable std::shared_ptr<EagerBufferAllocator> mStaticAllocator;
-    int mThreadNumber;
-    std::vector<int> mCpuIds;
-    unsigned long mCpuMask;
+    mutable int mThreadNumber;
+    mutable std::vector<int> mCpuIds;
+    mutable unsigned long mCpuMask;
 #ifdef MNN_USE_THREAD_POOL
     mutable int mTaskIndex = -1;
     mutable int mThreadOpen = 0;
-    ThreadPool* mThreadPool = nullptr;
+    mutable ThreadPool* mThreadPool = nullptr;
 #endif
     BackendConfig::MemoryMode mMemory;
     BackendConfig::PowerMode mPower;

--- a/source/backend/cpu/CPUBackend.hpp
+++ b/source/backend/cpu/CPUBackend.hpp
@@ -58,6 +58,7 @@ private:
     void _resetThreadPool();
     mutable std::shared_ptr<EagerBufferAllocator> mStaticAllocator;
     int mThreadNumber;
+    std::vector<int> mCpuIds;
 #ifdef MNN_USE_THREAD_POOL
     mutable int mTaskIndex = -1;
     mutable int mThreadOpen = 0;

--- a/source/backend/cpu/CPURuntime.cpp
+++ b/source/backend/cpu/CPURuntime.cpp
@@ -148,7 +148,7 @@ int MNNSetSchedAffinity(const int* cpuIDs, int size) {
     return 0;
 }
 
-unsigned long MNNGetCPUMask(const std::vector<int>& cpuIds) {
+cpu_mask_t MNNGetCPUMask(const std::vector<int>& cpuIds) {
     /**
      * [cpu_set_t](https://man7.org/linux/man-pages/man3/CPU_SET.3.html) is a
      * statically-sized CPU set. See `CPU_ALLOC` for dynamically-sized CPU sets.

--- a/source/backend/cpu/CPURuntime.cpp
+++ b/source/backend/cpu/CPURuntime.cpp
@@ -83,6 +83,7 @@ int MNNGetCurrentPid() {
 #endif
 }
 
+#if defined (__linux__)
 // Referenced from: (LINUX) bits/cpu-set.h
 // https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=posix/bits/cpu-set.h;hb=HEAD
 // Copied from: (ANDROID) libc/include/sched.h
@@ -121,7 +122,7 @@ int MNNGetCurrentPid() {
         if (__cpu < 8 * (setsize))                                \
             (set)->__bits[__CPU_ELT(__cpu)] |= __CPU_MASK(__cpu); \
     } while (0)
-
+#endif
 int MNNSetSchedAffinity(const int* cpuIDs, int size) {
 #if defined (__linux__)
     /**
@@ -149,6 +150,7 @@ int MNNSetSchedAffinity(const int* cpuIDs, int size) {
 }
 
 cpu_mask_t MNNGetCPUMask(const std::vector<int>& cpuIds) {
+#if defined (__linux__)
     /**
      * [cpu_set_t](https://man7.org/linux/man-pages/man3/CPU_SET.3.html) is a
      * statically-sized CPU set. See `CPU_ALLOC` for dynamically-sized CPU sets.
@@ -162,6 +164,8 @@ cpu_mask_t MNNGetCPUMask(const std::vector<int>& cpuIds) {
         CPU_SET(i, &cpuMask);
     }
     return cpuMask.__bits[0];
+#endif
+    return 0;
 }
 
 // cpuinfo

--- a/source/backend/cpu/CPURuntime.cpp
+++ b/source/backend/cpu/CPURuntime.cpp
@@ -82,22 +82,55 @@ int MNNGetCurrentPid() {
     return 0;
 #endif
 }
+
+// Referenced from: (LINUX) bits/cpu-set.h
+// https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=posix/bits/cpu-set.h;hb=HEAD
+// Copied from: (ANDROID) libc/include/sched.h
+// https://android.googlesource.com/platform/bionic.git/+/master/libc/include/sched.h
+#ifdef __LP64__
+#define CPU_SETSIZE 1024
+#else
+#define CPU_SETSIZE 32
+#endif
+#define __CPU_BITTYPE  unsigned long int  /* mandated by the kernel  */
+#define __CPU_BITS     (8 * sizeof(__CPU_BITTYPE))
+#define __CPU_ELT(x)   ((x) / __CPU_BITS)
+#define __CPU_MASK(x)  ((__CPU_BITTYPE)1 << ((x) & (__CPU_BITS - 1)))
+/**
+ * [CPU_ZERO](https://man7.org/linux/man-pages/man3/CPU_ZERO.3.html) clears all
+ * bits in a static CPU set.
+ */
+#define CPU_ZERO(set) CPU_ZERO_S(sizeof(cpu_set_t), set)
+/**
+ * [CPU_ZERO_S](https://man7.org/linux/man-pages/man3/CPU_ZERO_S.3.html) clears
+ * all bits in a dynamic CPU set allocated by `CPU_ALLOC`.
+ */
+#define CPU_ZERO_S(setsize, set) __builtin_memset(set, 0, setsize)
+/**
+ * [CPU_SET](https://man7.org/linux/man-pages/man3/CPU_SET.3.html) sets one
+ * bit in a static CPU set.
+ */
+#define CPU_SET(cpu, set) CPU_SET_S(cpu, sizeof(cpu_set_t), set)
+/**
+ * [CPU_SET_S](https://man7.org/linux/man-pages/man3/CPU_SET_S.3.html) sets one
+ * bit in a dynamic CPU set allocated by `CPU_ALLOC`.
+ */
+#define CPU_SET_S(cpu, setsize, set)                              \
+    do {                                                          \
+        size_t __cpu = (cpu);                                     \
+        if (__cpu < 8 * (setsize))                                \
+            (set)->__bits[__CPU_ELT(__cpu)] |= __CPU_MASK(__cpu); \
+    } while (0)
+
 int MNNSetSchedAffinity(const int* cpuIDs, int size) {
 #if defined (__linux__)
-#ifndef CPU_SETSIZE
-#define CPU_SETSIZE 1024
-#endif
-#define __NCPUBITS (8 * sizeof(unsigned long))
+    /**
+     * [cpu_set_t](https://man7.org/linux/man-pages/man3/CPU_SET.3.html) is a
+     * statically-sized CPU set. See `CPU_ALLOC` for dynamically-sized CPU sets.
+     */
     typedef struct {
-        unsigned long __bits[CPU_SETSIZE / __NCPUBITS];
+        __CPU_BITTYPE __bits[CPU_SETSIZE / __CPU_BITS];
     } cpu_set_t;
-
-#ifndef CPU_SET
-#define CPU_SET(cpu, cpusetp) ((cpusetp)->__bits[(cpu) / __NCPUBITS] |= (1UL << ((cpu) % __NCPUBITS)))
-#endif
-#ifndef CPU_ZERO
-#define CPU_ZERO(cpusetp) memset((cpusetp), 0, sizeof(cpu_set_t))
-#endif
     // set affinity for thread
     pid_t pid = MNNGetCurrentPid();
     cpu_set_t mask;
@@ -113,6 +146,22 @@ int MNNSetSchedAffinity(const int* cpuIDs, int size) {
     }
 #endif
     return 0;
+}
+
+unsigned long MNNGetCPUMask(const std::vector<int>& cpuIds) {
+    /**
+     * [cpu_set_t](https://man7.org/linux/man-pages/man3/CPU_SET.3.html) is a
+     * statically-sized CPU set. See `CPU_ALLOC` for dynamically-sized CPU sets.
+     */
+    typedef struct {
+        __CPU_BITTYPE __bits[CPU_SETSIZE / __CPU_BITS];
+    } cpu_set_t;
+    cpu_set_t cpuMask;
+    CPU_ZERO(&cpuMask);
+    for (auto i :cpuIds){
+        CPU_SET(i, &cpuMask);
+    }
+    return cpuMask.__bits[0];
 }
 
 // cpuinfo

--- a/source/backend/cpu/CPURuntime.hpp
+++ b/source/backend/cpu/CPURuntime.hpp
@@ -28,6 +28,7 @@ struct MNNCPUInfo {
 
 int MNNSetSchedAffinity(const int* cpuIDs, int size);
 int MNNGetCurrentPid();
+unsigned long MNNGetCPUMask(const std::vector<int>& cpuIds);
 const MNNCPUInfo* MNNGetCPUInfo();
 
 #endif /* CPUInfo_hpp */

--- a/source/backend/cpu/CPURuntime.hpp
+++ b/source/backend/cpu/CPURuntime.hpp
@@ -25,10 +25,10 @@ struct MNNCPUInfo {
     std::vector<CPUGroup> groups;
     int cpuNumber = 0;
 };
-
+using cpu_mask_t = unsigned long;
 int MNNSetSchedAffinity(const int* cpuIDs, int size);
 int MNNGetCurrentPid();
-unsigned long MNNGetCPUMask(const std::vector<int>& cpuIds);
+cpu_mask_t MNNGetCPUMask(const std::vector<int>& cpuIds);
 const MNNCPUInfo* MNNGetCPUInfo();
 
 #endif /* CPUInfo_hpp */

--- a/source/backend/cpu/ThreadPool.hpp
+++ b/source/backend/cpu/ThreadPool.hpp
@@ -22,25 +22,24 @@ class MNN_PUBLIC ThreadPool {
 public:
     typedef std::pair<std::function<void(int)>, int> TASK;
 
-    int number() const {
+    int numberThread() const {
         return mNumberThread;
     }
-    static void enqueue(TASK&& task, int index, int threadNumber);
+    void enqueue(TASK&& task, int index);
 
-    static void active(int threadNumber);
-    static void deactive(int threadNumber);
+    void active();
+    void deactive();
 
-    static int acquireWorkIndex();
-    static void releaseWorkIndex(int index);
+    int acquireWorkIndex();
+    void releaseWorkIndex(int index);
 
-    static int init(int number);
+    static int init(int numberThread, unsigned long cpuMask, ThreadPool*& threadPool);
     static void destroy();
 
 private:
-    void enqueueInternal(TASK&& task, int index, int threadNumber);
+    void enqueueInternal(TASK&& task, int index);
 
-    static ThreadPool* gInstance;
-    ThreadPool(int number = 0);
+    ThreadPool(int numberThread = 0);
     ~ThreadPool();
 
     std::vector<std::thread> mWorkers;
@@ -52,7 +51,7 @@ private:
     std::mutex mQueueMutex;
 
     int mNumberThread            = 0;
-    std::vector<std::atomic_int*> mActiveCount;
+    std::atomic_int mActiveCount = {0};
 };
 } // namespace MNN
 #endif

--- a/source/core/Backend.hpp
+++ b/source/core/Backend.hpp
@@ -58,6 +58,9 @@ struct RuntimeHint {
     // op encoder number for once commit
     int encorderNumForCommit = 10;
     int initThreadNumber = 0;
+
+    // cpu core ids
+    std::vector<int> cpuIds;
 };
 /** abstract backend */
 class Backend : public NonCopyable {

--- a/source/core/Concurrency.h
+++ b/source/core/Concurrency.h
@@ -28,7 +28,8 @@
     }                                                              \
     ;                                                              \
     auto cpuBn = (CPUBackend*)backend();                           \
-    MNN::ThreadPool::enqueue(std::move(task), cpuBn->taskIndex(), cpuBn->threadOpen() ? cpuBn->threadNumber() : 1); \
+    auto thrPl = cpuBn->threadPool();                              \
+    thrPl->enqueue(std::move(task), cpuBn->taskIndex());           \
     }
 
 #else

--- a/source/core/Interpreter.cpp
+++ b/source/core/Interpreter.cpp
@@ -140,22 +140,26 @@ Interpreter* Interpreter::createFromBufferInternal(Content* net, bool enforceAut
     return new Interpreter(net);
 }
 
-void Interpreter::setSessionHint(HintMode mode, int hint) {
-    mNet->modes.setHint(mode, hint);
+void Interpreter::setSessionHint(HintMode hint, int value) {
+    mNet->modes.setHint(hint, value);
+}
+
+void Interpreter::setSessionHint(HintMode hint, int* value, size_t size) {
+    mNet->modes.setHint(hint, value, size);
 }
 
 void Interpreter::setSessionMode(SessionMode mode) {
-    if (mode == Session_Resize_Check) {
-        for (auto& iter : mNet->sessions) {
-            iter->openResizeCheck();
-        }
-    } else if (mode == Session_Resize_Fix) {
-        for (auto& iter : mNet->sessions) {
-            iter->fixResizeCache();
-        }
-    } else {
-        mNet->modes.setMode(mode);
+  if (mode == Session_Resize_Check) {
+    for (auto& iter : mNet->sessions) {
+      iter->openResizeCheck();
     }
+  } else if (mode == Session_Resize_Fix) {
+    for (auto& iter : mNet->sessions) {
+      iter->fixResizeCache();
+    }
+  } else {
+    mNet->modes.setMode(mode);
+  }
 }
 
 void Interpreter::setCacheFile(const char* cacheFile, size_t keySize) {

--- a/source/core/Session.cpp
+++ b/source/core/Session.cpp
@@ -68,46 +68,55 @@ void Session::ModeGroup::setMode(Interpreter::SessionMode mode) {
         codegenMode = mode;
     }
 }
-void Session::ModeGroup::setHint(Interpreter::HintMode mode, int hint) {
-    switch (mode) {
-        case Interpreter::MAX_TUNING_NUMBER:
-            maxTuningNumber = hint;
+void Session::ModeGroup::setHint(Interpreter::HintMode hint, int value) {
+    switch (hint) {
+        case Interpreter::HintMode::MAX_TUNING_NUMBER:
+            maxTuningNumber = value;
             break;
-        case Interpreter::MEM_ALLOCATOR_TYPE:
-            runtimeHint.memoryAllocatorType = hint;
+        case Interpreter::HintMode::MEM_ALLOCATOR_TYPE:
+            runtimeHint.memoryAllocatorType = value;
             break;
-        case Interpreter::WINOGRAD_MEMORY_LEVEL:
-            runtimeHint.winogradMemoryUsed = hint;
+        case Interpreter::HintMode::WINOGRAD_MEMORY_LEVEL:
+            runtimeHint.winogradMemoryUsed = value;
             break;
-        case Interpreter::CPU_LITTLECORE_DECREASE_RATE:
-            runtimeHint.cpuDecreaseRate = hint;
+        case Interpreter::HintMode::CPU_LITTLECORE_DECREASE_RATE:
+            runtimeHint.cpuDecreaseRate = value;
             break;
-        case Interpreter::GEOMETRY_COMPUTE_MASK:
-            geometryMask = hint;
+        case Interpreter::HintMode::GEOMETRY_COMPUTE_MASK:
+            geometryMask = value;
             break;
-        case Interpreter::STRICT_CHECK_MODEL:
-            checkNetBuffer = hint > 0;
+        case Interpreter::HintMode::STRICT_CHECK_MODEL:
+            checkNetBuffer = value > 0;
             break;
-        case Interpreter::DYNAMIC_QUANT_OPTIONS:
-            runtimeHint.dynamicQuantOption = hint;
+        case Interpreter::HintMode::DYNAMIC_QUANT_OPTIONS:
+            runtimeHint.dynamicQuantOption = value;
             break;
-        case Interpreter::QKV_QUANT_OPTIONS:
-            runtimeHint.qkvQuantOption = hint;
+        case Interpreter::HintMode::QKV_QUANT_OPTIONS:
+            runtimeHint.qkvQuantOption = value;
             break;
-        case Interpreter::KVCACHE_SIZE_LIMIT:
-            runtimeHint.kvcacheSizeLimit = hint;
+        case Interpreter::HintMode::KVCACHE_SIZE_LIMIT:
+            runtimeHint.kvcacheSizeLimit = value;
             break;
-        case Interpreter::OP_ENCODER_NUMBER_FOR_COMMIT:
-            runtimeHint.encorderNumForCommit = hint;
+        case Interpreter::HintMode::OP_ENCODER_NUMBER_FOR_COMMIT:
+            runtimeHint.encorderNumForCommit = value;
             break;
-        case Interpreter::MMAP_FILE_SIZE:
-            runtimeHint.mmapFileSize = hint;
+        case Interpreter::HintMode::MMAP_FILE_SIZE:
+            runtimeHint.mmapFileSize = value;
             break;
-        case Interpreter::USE_CACHED_MMAP:
-            runtimeHint.useCachedMmap = hint;
+        case Interpreter::HintMode::USE_CACHED_MMAP:
+            runtimeHint.useCachedMmap = value;
             break;
-        case Interpreter::INIT_THREAD_NUMBER:
-            runtimeHint.initThreadNumber = hint;
+        case Interpreter::HintMode::INIT_THREAD_NUMBER:
+            runtimeHint.initThreadNumber = value;
+            break;
+        default:
+            break;
+    }
+}
+void Session::ModeGroup::setHint(Interpreter::HintMode hint, int* value, size_t size) {
+    switch (hint) {
+        case Interpreter::HintMode::CPU_CORE_IDS:
+            runtimeHint.cpuIds = std::vector<int>(value, value + size);
             break;
         default:
             break;

--- a/source/core/Session.hpp
+++ b/source/core/Session.hpp
@@ -37,7 +37,9 @@ public:
         int geometryMask = 0xFFFF;
         bool checkNetBuffer = true;
         RuntimeHint runtimeHint;
-        void setHint(Interpreter::HintMode hint, int magic);
+        void setHint(Interpreter::HintMode hint, int value);
+        void setHint(Interpreter::HintMode hint, int* value, size_t size);
+        void setHintPtr(Interpreter::HintMode hint, int value);
         void setMode(Interpreter::SessionMode mode);
         void setExternalPath(std::string path, int type);
     };

--- a/test/core/ThreadPoolTest.cpp
+++ b/test/core/ThreadPoolTest.cpp
@@ -20,18 +20,19 @@ public:
         std::vector<std::thread> threads;
         for (int i = 0; i < 10; ++i) {
             threads.emplace_back([i]() {
-                int number = MNN::ThreadPool::init(10 - i);
+                MNN::ThreadPool* threadPool = nullptr;
+                MNN::ThreadPool::init(10 - i, 0, threadPool);
                 // initializer
-                auto workIndex = ThreadPool::acquireWorkIndex();
+                auto workIndex = threadPool->acquireWorkIndex();
                 FUNC_PRINT(workIndex);
-                ThreadPool::active(number);
+                threadPool->active();
                 auto func = [](int index) {
                     FUNC_PRINT(index);
                     std::this_thread::yield();
                 };
-                ThreadPool::enqueue(std::make_pair(std::move(func), 10), workIndex, number);
-                ThreadPool::deactive(number);
-                ThreadPool::releaseWorkIndex(workIndex);
+                threadPool->enqueue(std::make_pair(std::move(func), 10), workIndex);
+                threadPool->deactive();
+                threadPool->releaseWorkIndex(workIndex);
             });
         }
         for (auto& t : threads) {

--- a/tools/cpp/MNNV2Basic.cpp
+++ b/tools/cpp/MNNV2Basic.cpp
@@ -282,6 +282,7 @@ static int test_main(int argc, const char* argv[]) {
     if (runMask & 32) {
         net->setSessionHint(Interpreter::WINOGRAD_MEMORY_LEVEL, 0);
     }
+    net->setSessionHint(Interpreter::HintMode::CPU_CORE_IDS, cpuIds.data(), cpuIds.size());
 
     // create session
     MNN::ScheduleConfig config;
@@ -295,7 +296,6 @@ static int test_main(int argc, const char* argv[]) {
     // backendConfig.power = BackendConfig::Power_High;
     backendConfig.precision = static_cast<MNN::BackendConfig::PrecisionMode>(precision);
     backendConfig.memory = static_cast<MNN::BackendConfig::MemoryMode>(memory);
-    backendConfig.cpuIds = cpuIds;
     config.backendConfig     = &backendConfig;
     MNN::Session* session    = NULL;
     MNN::Tensor* inputTensor = nullptr;

--- a/tools/cpp/MNNV2Basic.cpp
+++ b/tools/cpp/MNNV2Basic.cpp
@@ -167,11 +167,28 @@ static inline int64_t getTimeInUs() {
     return time;
 }
 
+static inline std::vector<int> parseIntList(const std::string& str, char delim) {
+    std::vector<int> result;
+    std::ptrdiff_t p1 = 0, p2;
+    while (1) {
+        p2 = str.find(delim, p1);
+        if (p2 != std::string::npos) {
+            result.push_back(atoi(str.substr(p1, p2 - p1).c_str()));
+            p1 = p2 + 1;
+        } else {
+            result.push_back(atoi(str.substr(p1).c_str()));
+            break;
+        }
+    }
+    return result;
+}
+
 static int test_main(int argc, const char* argv[]) {
     if (argc < 2) {
-        MNN_PRINT("========================================================================\n");
-        MNN_PRINT("Arguments: model.MNN runLoops runMask forwardType numberThread precision inputSize \n");
-        MNN_PRINT("========================================================================\n");
+        MNN_PRINT("=========================================================================================\n");
+        MNN_PRINT("Arguments: model.MNN runLoops runMask forwardType numberThread precision inputSize cpuIds\n");
+        MNN_PRINT("Example: %s model.MNN 100 0 0 4 0 1x3x224x224 0,1,2,3\n", argv[0]);
+        MNN_PRINT("=========================================================================================\n");
         return -1;
     }
 
@@ -227,22 +244,22 @@ static int test_main(int argc, const char* argv[]) {
     // input dims
     std::vector<int> inputDims;
     if (argc > 7) {
-        std::string inputShape(argv[7]);
-        const char* delim = "x";
-        std::ptrdiff_t p1 = 0, p2;
-        while (1) {
-            p2 = inputShape.find(delim, p1);
-            if (p2 != std::string::npos) {
-                inputDims.push_back(atoi(inputShape.substr(p1, p2 - p1).c_str()));
-                p1 = p2 + 1;
-            } else {
-                inputDims.push_back(atoi(inputShape.substr(p1).c_str()));
-                break;
-            }
-        }
+        inputDims = parseIntList(argv[7], 'x');
     }
+    MNN_PRINT("inputDims: ");
     for (auto dim : inputDims) {
         MNN_PRINT("%d ", dim);
+    }
+    MNN_PRINT("\n");
+
+    // CPU IDs
+    std::vector<int> cpuIds;
+    if (argc > 8) {
+        cpuIds = parseIntList(argv[8], ',');
+    }
+    MNN_PRINT("cpuIds: ");
+    for (auto id : cpuIds) {
+        MNN_PRINT("%d ", id);
     }
     MNN_PRINT("\n");
 
@@ -278,6 +295,7 @@ static int test_main(int argc, const char* argv[]) {
     // backendConfig.power = BackendConfig::Power_High;
     backendConfig.precision = static_cast<MNN::BackendConfig::PrecisionMode>(precision);
     backendConfig.memory = static_cast<MNN::BackendConfig::MemoryMode>(memory);
+    backendConfig.cpuIds = cpuIds;
     config.backendConfig     = &backendConfig;
     MNN::Session* session    = NULL;
     MNN::Tensor* inputTensor = nullptr;

--- a/tools/cpp/ModuleBasic.cpp
+++ b/tools/cpp/ModuleBasic.cpp
@@ -264,7 +264,6 @@ int main(int argc, char *argv[]) {
     backendConfig.power = (BackendConfig::PowerMode)power;
     backendConfig.precision = static_cast<MNN::BackendConfig::PrecisionMode>(precision);
     backendConfig.memory = static_cast<MNN::BackendConfig::MemoryMode>(memory);
-    backendConfig.cpuIds = cpuIds;
     config.backendConfig     = &backendConfig;
 
     MNN::Express::Module::Config mConfig;
@@ -275,6 +274,7 @@ int main(int argc, char *argv[]) {
     std::shared_ptr<Executor::RuntimeManager> rtmgr(Executor::RuntimeManager::createRuntimeManager(config));
     rtmgr->setCache(cacheFileName);
     rtmgr->setHint(MNN::Interpreter::INIT_THREAD_NUMBER, 4);
+    rtmgr->setHint(MNN::Interpreter::HintMode::CPU_CORE_IDS, cpuIds.data(), cpuIds.size());
 
     if (cpuDecreaseRate > 0 && cpuDecreaseRate <= 100) {
         rtmgr->setHint(Interpreter::CPU_LITTLECORE_DECREASE_RATE, cpuDecreaseRate);

--- a/tools/cpp/ModuleBasic.cpp
+++ b/tools/cpp/ModuleBasic.cpp
@@ -90,9 +90,27 @@ static bool compareOutput(VARP output, const std::string& directName, const std:
     }
     return true;
 }
+
+static inline std::vector<int> parseIntList(const std::string& str, char delim) {
+    std::vector<int> result;
+    std::ptrdiff_t p1 = 0, p2;
+    while (1) {
+        p2 = str.find(delim, p1);
+        if (p2 != std::string::npos) {
+            result.push_back(atoi(str.substr(p1, p2 - p1).c_str()));
+            p1 = p2 + 1;
+        } else {
+            result.push_back(atoi(str.substr(p1).c_str()));
+            break;
+        }
+    }
+    return result;
+}
 int main(int argc, char *argv[]) {
     if (argc < 3) {
-        MNN_ERROR("Usage: ./ModuleBasic.out ${test.mnn} ${Dir} [runMask] [forwardType] [runLoops] [numberThread] [precision | memory] [cacheFile]\n");
+        MNN_PRINT("=======================================================================================================================================\n");
+        MNN_ERROR("Usage: ./ModuleBasic.out ${test.mnn} ${Dir} [runMask] [forwardType] [runLoops] [numberThread] [precision | memory] [cacheFile] [cpuIds]\n");
+        MNN_PRINT("=======================================================================================================================================\n");
         return 0;
     }
     BackendConfig backendConfigTmp;
@@ -220,6 +238,16 @@ int main(int argc, char *argv[]) {
     if (argc > 8) {
         cacheFileName = argv[8];
     }
+    // CPU IDs
+    std::vector<int> cpuIds;
+    if (argc > 9) {
+        cpuIds = parseIntList(argv[9], ',');
+    }
+    MNN_PRINT("cpuIds: ");
+    for (auto id : cpuIds) {
+        MNN_PRINT("%d ", id);
+    }
+    MNN_PRINT("\n");
     FUNC_PRINT(precision);
     FUNC_PRINT(memory);
     FUNC_PRINT(power);
@@ -236,6 +264,7 @@ int main(int argc, char *argv[]) {
     backendConfig.power = (BackendConfig::PowerMode)power;
     backendConfig.precision = static_cast<MNN::BackendConfig::PrecisionMode>(precision);
     backendConfig.memory = static_cast<MNN::BackendConfig::MemoryMode>(memory);
+    backendConfig.cpuIds = cpuIds;
     config.backendConfig     = &backendConfig;
 
     MNN::Express::Module::Config mConfig;

--- a/tools/cpp/timeProfile.cpp
+++ b/tools/cpp/timeProfile.cpp
@@ -119,6 +119,7 @@ int main(int argc, const char* argv[]) {
     }
     revertor.reset();
     net->setSessionMode(Interpreter::Session_Debug);
+    net->setSessionHint(Interpreter::HintMode::CPU_CORE_IDS, cpuIds.data(), cpuIds.size());
 
     // create session
     MNN::ScheduleConfig config;
@@ -126,7 +127,6 @@ int main(int argc, const char* argv[]) {
     config.numThread      = threadNumber;
     BackendConfig backendConfig;
     backendConfig.precision = precision;
-    backendConfig.cpuIds = cpuIds;
     config.backendConfig  = &backendConfig;
     MNN::Session* session = NULL;
     session               = net->createSession(config);

--- a/tools/cpp/timeProfile.cpp
+++ b/tools/cpp/timeProfile.cpp
@@ -23,7 +23,30 @@
 
 using namespace MNN;
 
+static inline std::vector<int> parseIntList(const std::string& str, char delim) {
+    std::vector<int> result;
+    std::ptrdiff_t p1 = 0, p2;
+    while (1) {
+        p2 = str.find(delim, p1);
+        if (p2 != std::string::npos) {
+            result.push_back(atoi(str.substr(p1, p2 - p1).c_str()));
+            p1 = p2 + 1;
+        } else {
+            result.push_back(atoi(str.substr(p1).c_str()));
+            break;
+        }
+    }
+    return result;
+}
 int main(int argc, const char* argv[]) {
+    if (argc < 2) {
+        MNN_PRINT("=========================================================================================\n");
+        MNN_PRINT("Arguments: model.MNN runLoops forwardType inputSize numberThread precision sparsity cpuIds\n");
+        MNN_PRINT("Example: %s model.MNN 100 0 1x3x224x224 4 0 0 0,1,2,3\n", argv[0]);
+        MNN_PRINT("=========================================================================================\n");
+        return -1;
+    }
+
     std::string cmd = argv[0];
     std::string pwd = "./";
     auto rslash     = cmd.rfind("/");
@@ -46,20 +69,9 @@ int main(int argc, const char* argv[]) {
     // input dims
     std::vector<int> inputDims;
     if (argc > 4) {
-        std::string inputShape(argv[4]);
-        const char* delim = "x";
-        std::ptrdiff_t p1 = 0, p2;
-        while (1) {
-            p2 = inputShape.find(delim, p1);
-            if (p2 != std::string::npos) {
-                inputDims.push_back(atoi(inputShape.substr(p1, p2 - p1).c_str()));
-                p1 = p2 + 1;
-            } else {
-                inputDims.push_back(atoi(inputShape.substr(p1).c_str()));
-                break;
-            }
-        }
+        inputDims = parseIntList(argv[4], 'x');
     }
+    MNN_PRINT("inputDims: ");
     for (auto dim : inputDims) {
         MNN_PRINT("%d ", dim);
     }
@@ -77,9 +89,20 @@ int main(int argc, const char* argv[]) {
     }
 
     float sparsity = 0.0f;
-    if(argc >= 8) {
+    if(argc > 7) {
         sparsity = atof(argv[7]);
     }
+    
+    // CPU IDs
+    std::vector<int> cpuIds;
+    if (argc > 8) {
+        cpuIds = parseIntList(argv[8], ',');
+    }
+    MNN_PRINT("cpuIds: ");
+    for (auto id : cpuIds) {
+        MNN_PRINT("%d ", id);
+    }
+    MNN_PRINT("\n");
 
 
     // revert MNN model if necessary
@@ -103,6 +126,7 @@ int main(int argc, const char* argv[]) {
     config.numThread      = threadNumber;
     BackendConfig backendConfig;
     backendConfig.precision = precision;
+    backendConfig.cpuIds = cpuIds;
     config.backendConfig  = &backendConfig;
     MNN::Session* session = NULL;
     session               = net->createSession(config);


### PR DESCRIPTION
I’m submitting this PR to introduce a new configuration option: `MNN::BackendConfig::cpuIds`. This allows users to explicitly specify CPU core IDs to maximize multi-threaded performance by core assignment.

This idea comes from various situations we’ve observed while using MNN in our AI development. In recent years, models have become increasingly large, multi-model collaboration (often referred to as workflows) has become more common, and devices now feature more and more CPU cores — even mobile devices are starting to offer double-digit core counts. However, as the number of threads exceeds four, the performance gains from MNN’s multi-threading start to diminish.

In version 2.9.3 (c6f25cafc63cc89996709a2ec1cb2ddca96ca5a5), MNN added a `threadNumber` parameter to its thread pool, enabling multiple instances to share the thread pool while using different thread counts. However, I believe this is a poor practice for two reasons:
1. The initialization of thread count relies on querying the number of CPU cores, which sometimes fails (e.g., on Windows), rendering this feature ineffective in many cases.
2. When two instances/sessions share a thread pool (counting on the instance with fewer threads), resource contention is inevitable.

Therefore, this PR can also be seen as a bugfix addressing these issues.

With this PR, you can expect improvements in more than following scenarios:

- Multi-process use: You can assign your UI and backend algorithms to separate CPU cores, reducing context-switching overhead.
- Multi-instance use: You can allocate cores based on each instance’s QPS demands. For example, in a shipped product, our face detection model requires 25 FPS for real-time performance, while face recognition only needs 1 FPS. Without explicit core binding, both models would compete for resources uncontrollably.
- Multi-session use: For throughput-sensitive workloads, you can now run four single-threaded instances, each pinned to a different core — providing better throughput than a single four-threaded model.
- On high-core-count devices: I have a 64-core server. Previous versions of MNN would spawn 64 threads, with most sitting idle. Once a second instance starts, it competes for the only and few active threads. This PR resolves that by giving precise control over core and thread placement.