### PR TITLE
compile issue fix:add gradle.properties to enable AndroidX feature

### DIFF
--- a/apps/Android/MnnTaoAvatar/gradle.properties
+++ b/apps/Android/MnnTaoAvatar/gradle.properties
@@ -1,0 +1,23 @@
+# Project-wide Gradle settings.
+# IDE (e.g. Android Studio) users:
+# Gradle settings configured through the IDE *will override*
+# any settings specified in this file.
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+# AndroidX package structure to make it clearer which packages are bundled with the
+# Android operating system, and which are packaged with your app's APK
+# https://developer.android.com/topic/libraries/support-library/androidx-rn
+android.useAndroidX=true
+# Kotlin code style for this project: "official" or "obsolete":
+kotlin.code.style=official
+# Enables namespacing of each library's R class so that its R class includes only the
+# resources declared in the library itself and none from the library's dependencies,
+# thereby reducing the size of the R class for that library
+android.nonTransitiveRClass=true


### PR DESCRIPTION
Hi MNN developers,  
I’m trying to compile `MnnTaoAvatar` by myself, but I encountered an issue during the APK build process:    
```  
Configuration `:app:debugRuntimeClasspath` contains AndroidX dependencies, but the `android.useAndroidX` property is not enabled, which may cause runtime issues.
Set `android.useAndroidX=true` in the `gradle.properties` file and retry.
The following AndroidX dependencies are detected:
:app:debugRuntimeClasspath -> androidx.core:core-ktx:1.15.0
:app:debugRuntimeClasspath -> com.google.android.material:material:1.12.0 -> androidx.annotation:annotation:1.8.1
:app:debugRuntimeClasspath -> com.google.android.material:material:1.12.0 -> androidx.annotation:annotation:1.8.1 -> androidx.annotation:annotation-jvm:1.8.1
:app:debugRuntimeClasspath -> com.google.android.material:material:1.12.0 -> androidx.core:core:1.15.0
```    
I noticed that your project didn’t include the necessary configuration file, so I added one that enables the AndroidX feature. After making this change, the project can be compiled successfully.