### PR TITLE
Fix sherpa-mnn-jni bugs

### DIFF
--- a/apps/frameworks/sherpa-mnn/sherpa-mnn/jni/audio-tagging.cc
+++ b/apps/frameworks/sherpa-mnn/sherpa-mnn/jni/audio-tagging.cc
@@ -15,13 +15,13 @@ static AudioTaggingConfig GetAudioTaggingConfig(JNIEnv *env, jobject config) {
   jclass cls = env->GetObjectClass(config);
 
   jfieldID fid = env->GetFieldID(
-      cls, "model", "Lcom/k2fsa/sherpa/onnx/AudioTaggingModelConfig;");
+      cls, "model", "Lcom/k2fsa/sherpa/mnn/AudioTaggingModelConfig;");
   jobject model = env->GetObjectField(config, fid);
   jclass model_cls = env->GetObjectClass(model);
 
   fid = env->GetFieldID(
       model_cls, "zipformer",
-      "Lcom/k2fsa/sherpa/onnx/OfflineZipformerAudioTaggingModelConfig;");
+      "Lcom/k2fsa/sherpa/mnn/OfflineZipformerAudioTaggingModelConfig;");
   jobject zipformer = env->GetObjectField(model, fid);
   jclass zipformer_cls = env->GetObjectClass(zipformer);
 

--- a/apps/frameworks/sherpa-mnn/sherpa-mnn/jni/keyword-spotter.cc
+++ b/apps/frameworks/sherpa-mnn/sherpa-mnn/jni/keyword-spotter.cc
@@ -39,7 +39,7 @@ static KeywordSpotterConfig GetKwsConfig(JNIEnv *env, jobject config) {
 
   //---------- feat config ----------
   fid = env->GetFieldID(cls, "featConfig",
-                        "Lcom/k2fsa/sherpa/onnx/FeatureConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/FeatureConfig;");
   jobject feat_config = env->GetObjectField(config, fid);
   jclass feat_config_cls = env->GetObjectClass(feat_config);
 
@@ -51,13 +51,13 @@ static KeywordSpotterConfig GetKwsConfig(JNIEnv *env, jobject config) {
 
   //---------- model config ----------
   fid = env->GetFieldID(cls, "modelConfig",
-                        "Lcom/k2fsa/sherpa/onnx/OnlineModelConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/OnlineModelConfig;");
   jobject model_config = env->GetObjectField(config, fid);
   jclass model_config_cls = env->GetObjectClass(model_config);
 
   // transducer
   fid = env->GetFieldID(model_config_cls, "transducer",
-                        "Lcom/k2fsa/sherpa/onnx/OnlineTransducerModelConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/OnlineTransducerModelConfig;");
   jobject transducer_config = env->GetObjectField(model_config, fid);
   jclass transducer_config_cls = env->GetObjectClass(transducer_config);
 

--- a/apps/frameworks/sherpa-mnn/sherpa-mnn/jni/offline-punctuation.cc
+++ b/apps/frameworks/sherpa-mnn/sherpa-mnn/jni/offline-punctuation.cc
@@ -17,7 +17,7 @@ static OfflinePunctuationConfig GetOfflinePunctuationConfig(JNIEnv *env,
   jfieldID fid;
 
   fid = env->GetFieldID(
-      cls, "model", "Lcom/k2fsa/sherpa/onnx/OfflinePunctuationModelConfig;");
+      cls, "model", "Lcom/k2fsa/sherpa/mnn/OfflinePunctuationModelConfig;");
   jobject model_config = env->GetObjectField(config, fid);
   jclass model_config_cls = env->GetObjectClass(model_config);
 

--- a/apps/frameworks/sherpa-mnn/sherpa-mnn/jni/offline-recognizer.cc
+++ b/apps/frameworks/sherpa-mnn/sherpa-mnn/jni/offline-recognizer.cc
@@ -51,7 +51,7 @@ static OfflineRecognizerConfig GetOfflineConfig(JNIEnv *env, jobject config) {
 
   //---------- feat config ----------
   fid = env->GetFieldID(cls, "featConfig",
-                        "Lcom/k2fsa/sherpa/onnx/FeatureConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/FeatureConfig;");
   jobject feat_config = env->GetObjectField(config, fid);
   jclass feat_config_cls = env->GetObjectClass(feat_config);
 
@@ -63,7 +63,7 @@ static OfflineRecognizerConfig GetOfflineConfig(JNIEnv *env, jobject config) {
 
   //---------- model config ----------
   fid = env->GetFieldID(cls, "modelConfig",
-                        "Lcom/k2fsa/sherpa/onnx/OfflineModelConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/OfflineModelConfig;");
   jobject model_config = env->GetObjectField(config, fid);
   jclass model_config_cls = env->GetObjectClass(model_config);
 
@@ -105,7 +105,7 @@ static OfflineRecognizerConfig GetOfflineConfig(JNIEnv *env, jobject config) {
 
   // transducer
   fid = env->GetFieldID(model_config_cls, "transducer",
-                        "Lcom/k2fsa/sherpa/onnx/OfflineTransducerModelConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/OfflineTransducerModelConfig;");
   jobject transducer_config = env->GetObjectField(model_config, fid);
   jclass transducer_config_cls = env->GetObjectClass(transducer_config);
 
@@ -129,7 +129,7 @@ static OfflineRecognizerConfig GetOfflineConfig(JNIEnv *env, jobject config) {
 
   // paraformer
   fid = env->GetFieldID(model_config_cls, "paraformer",
-                        "Lcom/k2fsa/sherpa/onnx/OfflineParaformerModelConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/OfflineParaformerModelConfig;");
   jobject paraformer_config = env->GetObjectField(model_config, fid);
   jclass paraformer_config_cls = env->GetObjectClass(paraformer_config);
 
@@ -142,7 +142,7 @@ static OfflineRecognizerConfig GetOfflineConfig(JNIEnv *env, jobject config) {
 
   // whisper
   fid = env->GetFieldID(model_config_cls, "whisper",
-                        "Lcom/k2fsa/sherpa/onnx/OfflineWhisperModelConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/OfflineWhisperModelConfig;");
   jobject whisper_config = env->GetObjectField(model_config, fid);
   jclass whisper_config_cls = env->GetObjectClass(whisper_config);
 
@@ -176,7 +176,7 @@ static OfflineRecognizerConfig GetOfflineConfig(JNIEnv *env, jobject config) {
 
   // FireRedAsr
   fid = env->GetFieldID(model_config_cls, "fireRedAsr",
-                        "Lcom/k2fsa/sherpa/onnx/OfflineFireRedAsrModelConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/OfflineFireRedAsrModelConfig;");
   jobject fire_red_asr_config = env->GetObjectField(model_config, fid);
   jclass fire_red_asr_config_cls = env->GetObjectClass(fire_red_asr_config);
 
@@ -196,7 +196,7 @@ static OfflineRecognizerConfig GetOfflineConfig(JNIEnv *env, jobject config) {
 
   // moonshine
   fid = env->GetFieldID(model_config_cls, "moonshine",
-                        "Lcom/k2fsa/sherpa/onnx/OfflineMoonshineModelConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/OfflineMoonshineModelConfig;");
   jobject moonshine_config = env->GetObjectField(model_config, fid);
   jclass moonshine_config_cls = env->GetObjectClass(moonshine_config);
 
@@ -229,7 +229,7 @@ static OfflineRecognizerConfig GetOfflineConfig(JNIEnv *env, jobject config) {
 
   // sense voice
   fid = env->GetFieldID(model_config_cls, "senseVoice",
-                        "Lcom/k2fsa/sherpa/onnx/OfflineSenseVoiceModelConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/OfflineSenseVoiceModelConfig;");
   jobject sense_voice_config = env->GetObjectField(model_config, fid);
   jclass sense_voice_config_cls = env->GetObjectClass(sense_voice_config);
 
@@ -254,7 +254,7 @@ static OfflineRecognizerConfig GetOfflineConfig(JNIEnv *env, jobject config) {
   // nemo
   fid = env->GetFieldID(
       model_config_cls, "nemo",
-      "Lcom/k2fsa/sherpa/onnx/OfflineNemoEncDecCtcModelConfig;");
+      "Lcom/k2fsa/sherpa/mnn/OfflineNemoEncDecCtcModelConfig;");
   jobject nemo_config = env->GetObjectField(model_config, fid);
   jclass nemo_config_cls = env->GetObjectClass(nemo_config);
 

--- a/apps/frameworks/sherpa-mnn/sherpa-mnn/jni/offline-speaker-diarization.cc
+++ b/apps/frameworks/sherpa-mnn/sherpa-mnn/jni/offline-speaker-diarization.cc
@@ -19,13 +19,13 @@ static OfflineSpeakerDiarizationConfig GetOfflineSpeakerDiarizationConfig(
   //---------- segmentation ----------
   fid = env->GetFieldID(
       cls, "segmentation",
-      "Lcom/k2fsa/sherpa/onnx/OfflineSpeakerSegmentationModelConfig;");
+      "Lcom/k2fsa/sherpa/mnn/OfflineSpeakerSegmentationModelConfig;");
   jobject segmentation_config = env->GetObjectField(config, fid);
   jclass segmentation_config_cls = env->GetObjectClass(segmentation_config);
 
   fid = env->GetFieldID(
       segmentation_config_cls, "pyannote",
-      "Lcom/k2fsa/sherpa/onnx/OfflineSpeakerSegmentationPyannoteModelConfig;");
+      "Lcom/k2fsa/sherpa/mnn/OfflineSpeakerSegmentationPyannoteModelConfig;");
   jobject pyannote_config = env->GetObjectField(segmentation_config, fid);
   jclass pyannote_config_cls = env->GetObjectClass(pyannote_config);
 
@@ -51,7 +51,7 @@ static OfflineSpeakerDiarizationConfig GetOfflineSpeakerDiarizationConfig(
   //---------- embedding ----------
   fid = env->GetFieldID(
       cls, "embedding",
-      "Lcom/k2fsa/sherpa/onnx/SpeakerEmbeddingExtractorConfig;");
+      "Lcom/k2fsa/sherpa/mnn/SpeakerEmbeddingExtractorConfig;");
   jobject embedding_config = env->GetObjectField(config, fid);
   jclass embedding_config_cls = env->GetObjectClass(embedding_config);
 
@@ -75,7 +75,7 @@ static OfflineSpeakerDiarizationConfig GetOfflineSpeakerDiarizationConfig(
 
   //---------- clustering ----------
   fid = env->GetFieldID(cls, "clustering",
-                        "Lcom/k2fsa/sherpa/onnx/FastClusteringConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/FastClusteringConfig;");
   jobject clustering_config = env->GetObjectField(config, fid);
   jclass clustering_config_cls = env->GetObjectClass(clustering_config);
 
@@ -162,7 +162,7 @@ static jobjectArray ProcessImpl(
     const std::vector<sherpa_mnn::OfflineSpeakerDiarizationSegment>
         &segments) {
   jclass cls =
-      env->FindClass("com/k2fsa/sherpa/onnx/OfflineSpeakerDiarizationSegment");
+      env->FindClass("com/k2fsa/sherpa/mnn/OfflineSpeakerDiarizationSegment");
 
   jobjectArray obj_arr =
       (jobjectArray)env->NewObjectArray(segments.size(), cls, nullptr);

--- a/apps/frameworks/sherpa-mnn/sherpa-mnn/jni/online-punctuation.cc
+++ b/apps/frameworks/sherpa-mnn/sherpa-mnn/jni/online-punctuation.cc
@@ -17,7 +17,7 @@ static OnlinePunctuationConfig GetOnlinePunctuationConfig(JNIEnv *env,
   jfieldID fid;
 
   fid = env->GetFieldID(cls, "model",
-                        "Lcom/k2fsa/sherpa/onnx/OnlinePunctuationModelConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/OnlinePunctuationModelConfig;");
   jobject model_config = env->GetObjectField(config, fid);
   jclass model_config_cls = env->GetObjectClass(model_config);
 

--- a/apps/frameworks/sherpa-mnn/sherpa-mnn/jni/online-recognizer.cc
+++ b/apps/frameworks/sherpa-mnn/sherpa-mnn/jni/online-recognizer.cc
@@ -54,7 +54,7 @@ static OnlineRecognizerConfig GetConfig(JNIEnv *env, jobject config) {
 
   //---------- feat config ----------
   fid = env->GetFieldID(cls, "featConfig",
-                        "Lcom/k2fsa/sherpa/onnx/FeatureConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/FeatureConfig;");
   jobject feat_config = env->GetObjectField(config, fid);
   jclass feat_config_cls = env->GetObjectClass(feat_config);
 
@@ -71,21 +71,21 @@ static OnlineRecognizerConfig GetConfig(JNIEnv *env, jobject config) {
   //---------- endpoint_config ----------
 
   fid = env->GetFieldID(cls, "endpointConfig",
-                        "Lcom/k2fsa/sherpa/onnx/EndpointConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/EndpointConfig;");
   jobject endpoint_config = env->GetObjectField(config, fid);
   jclass endpoint_config_cls = env->GetObjectClass(endpoint_config);
 
   fid = env->GetFieldID(endpoint_config_cls, "rule1",
-                        "Lcom/k2fsa/sherpa/onnx/EndpointRule;");
+                        "Lcom/k2fsa/sherpa/mnn/EndpointRule;");
   jobject rule1 = env->GetObjectField(endpoint_config, fid);
   jclass rule_class = env->GetObjectClass(rule1);
 
   fid = env->GetFieldID(endpoint_config_cls, "rule2",
-                        "Lcom/k2fsa/sherpa/onnx/EndpointRule;");
+                        "Lcom/k2fsa/sherpa/mnn/EndpointRule;");
   jobject rule2 = env->GetObjectField(endpoint_config, fid);
 
   fid = env->GetFieldID(endpoint_config_cls, "rule3",
-                        "Lcom/k2fsa/sherpa/onnx/EndpointRule;");
+                        "Lcom/k2fsa/sherpa/mnn/EndpointRule;");
   jobject rule3 = env->GetObjectField(endpoint_config, fid);
 
   fid = env->GetFieldID(rule_class, "mustContainNonSilence", "Z");
@@ -114,13 +114,13 @@ static OnlineRecognizerConfig GetConfig(JNIEnv *env, jobject config) {
 
   //---------- model config ----------
   fid = env->GetFieldID(cls, "modelConfig",
-                        "Lcom/k2fsa/sherpa/onnx/OnlineModelConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/OnlineModelConfig;");
   jobject model_config = env->GetObjectField(config, fid);
   jclass model_config_cls = env->GetObjectClass(model_config);
 
   // transducer
   fid = env->GetFieldID(model_config_cls, "transducer",
-                        "Lcom/k2fsa/sherpa/onnx/OnlineTransducerModelConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/OnlineTransducerModelConfig;");
   jobject transducer_config = env->GetObjectField(model_config, fid);
   jclass transducer_config_cls = env->GetObjectClass(transducer_config);
 
@@ -144,7 +144,7 @@ static OnlineRecognizerConfig GetConfig(JNIEnv *env, jobject config) {
 
   // paraformer
   fid = env->GetFieldID(model_config_cls, "paraformer",
-                        "Lcom/k2fsa/sherpa/onnx/OnlineParaformerModelConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/OnlineParaformerModelConfig;");
   jobject paraformer_config = env->GetObjectField(model_config, fid);
   jclass paraformer_config_cls = env->GetObjectClass(paraformer_config);
 
@@ -163,7 +163,7 @@ static OnlineRecognizerConfig GetConfig(JNIEnv *env, jobject config) {
   // streaming zipformer2 CTC
   fid =
       env->GetFieldID(model_config_cls, "zipformer2Ctc",
-                      "Lcom/k2fsa/sherpa/onnx/OnlineZipformer2CtcModelConfig;");
+                      "Lcom/k2fsa/sherpa/mnn/OnlineZipformer2CtcModelConfig;");
   jobject zipformer2_ctc_config = env->GetObjectField(model_config, fid);
   jclass zipformer2_ctc_config_cls = env->GetObjectClass(zipformer2_ctc_config);
 
@@ -176,7 +176,7 @@ static OnlineRecognizerConfig GetConfig(JNIEnv *env, jobject config) {
 
   // streaming NeMo CTC
   fid = env->GetFieldID(model_config_cls, "neMoCtc",
-                        "Lcom/k2fsa/sherpa/onnx/OnlineNeMoCtcModelConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/OnlineNeMoCtcModelConfig;");
   jobject nemo_ctc_config = env->GetObjectField(model_config, fid);
   jclass nemo_ctc_config_cls = env->GetObjectClass(nemo_ctc_config);
 
@@ -224,7 +224,7 @@ static OnlineRecognizerConfig GetConfig(JNIEnv *env, jobject config) {
 
   //---------- rnn lm model config ----------
   fid = env->GetFieldID(cls, "lmConfig",
-                        "Lcom/k2fsa/sherpa/onnx/OnlineLMConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/OnlineLMConfig;");
   jobject lm_model_config = env->GetObjectField(config, fid);
   jclass lm_model_config_cls = env->GetObjectClass(lm_model_config);
 
@@ -238,7 +238,7 @@ static OnlineRecognizerConfig GetConfig(JNIEnv *env, jobject config) {
   ans.lm_config.scale = env->GetFloatField(lm_model_config, fid);
 
   fid = env->GetFieldID(cls, "ctcFstDecoderConfig",
-                        "Lcom/k2fsa/sherpa/onnx/OnlineCtcFstDecoderConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/OnlineCtcFstDecoderConfig;");
 
   jobject fst_decoder_config = env->GetObjectField(config, fid);
   jclass fst_decoder_config_cls = env->GetObjectClass(fst_decoder_config);

--- a/apps/frameworks/sherpa-mnn/sherpa-mnn/jni/spoken-language-identification.cc
+++ b/apps/frameworks/sherpa-mnn/sherpa-mnn/jni/spoken-language-identification.cc
@@ -16,7 +16,7 @@ static SpokenLanguageIdentificationConfig GetSpokenLanguageIdentificationConfig(
   jclass cls = env->GetObjectClass(config);
   jfieldID fid = env->GetFieldID(
       cls, "whisper",
-      "Lcom/k2fsa/sherpa/onnx/SpokenLanguageIdentificationWhisperConfig;");
+      "Lcom/k2fsa/sherpa/mnn/SpokenLanguageIdentificationWhisperConfig;");
 
   jobject whisper = env->GetObjectField(config, fid);
   jclass whisper_cls = env->GetObjectClass(whisper);

--- a/apps/frameworks/sherpa-mnn/sherpa-mnn/jni/voice-activity-detector.cc
+++ b/apps/frameworks/sherpa-mnn/sherpa-mnn/jni/voice-activity-detector.cc
@@ -16,7 +16,7 @@ static VadModelConfig GetVadModelConfig(JNIEnv *env, jobject config) {
 
   // silero_vad
   fid = env->GetFieldID(cls, "sileroVadModelConfig",
-                        "Lcom/k2fsa/sherpa/onnx/SileroVadModelConfig;");
+                        "Lcom/k2fsa/sherpa/mnn/SileroVadModelConfig;");
   jobject silero_vad_config = env->GetObjectField(config, fid);
   jclass silero_vad_config_cls = env->GetObjectClass(silero_vad_config);
 


### PR DESCRIPTION
当编译并替换主分支最新版本的libMNN.so后，原始的MnnTaoAvatar应用出现initService失败，调查原因发现sherpa-mnn库没有运行起来，后本地编译sherpa-mnn库发现JNI接口文件中包名声明错误，导致编译出来的sherpa-mnn运行是会提示找不到对应的文件，因为包名不同。