### PR TITLE
[Fix] missing first output token in llm.cpp generate function

### DIFF
--- a/transformers/llm/engine/src/llm.cpp
+++ b/transformers/llm/engine/src/llm.cpp
@@ -625,10 +625,12 @@ std::vector<int> Llm::generate(MNN::Express::VARP input_embeds, int max_tokens) 
     _t.reset();
     mContext->current_token = sample(logits);
     mContext->sample_us += _t.durationInUs();
+    mContext->history_tokens.push_back(mContext->current_token);
+    mContext->output_tokens.push_back(mContext->current_token);
     logits = nullptr;
 
     // call generation function
-    mGenerateParam->max_new_tokens = max_tokens;
+    mGenerateParam->max_new_tokens = max_tokens - 1;
     mGenerationStrategy->generate(*mGenerateParam);
     return mContext->output_tokens;
 }


### PR DESCRIPTION
Fixed an issue where the generate function would skip the first token during generation. The problem occurred because the function wasn't properly handling the initial token sampling phase. 