### PR TITLE
[LLM:Feature] Support MiniCPM.

### DIFF
--- a/transformers/llm/engine/src/omni.cpp
+++ b/transformers/llm/engine/src/omni.cpp
@@ -123,7 +123,7 @@ void Omni::load() {
 std::vector<int> Omni::defaultVisionProcess(VARP image) {
     mVisionHeight = UP_DIV(mVisionHeight, mVisionSizeUnit) * mVisionSizeUnit;
     mVisionWidth  = UP_DIV(mVisionWidth, mVisionSizeUnit) * mVisionSizeUnit;
-    image = MNN::CV::resize(image, {mVisionHeight, mVisionWidth}, 0, 0,
+    image = MNN::CV::resize(image, {mVisionWidth, mVisionHeight}, 0, 0,
                             MNN::CV::INTER_LINEAR, MNN::CV::COLOR_BGR2RGB,
                             mVisionMean, mVisionNorm);
     image = Express::_Unsqueeze(image, {0});
@@ -146,7 +146,7 @@ std::vector<int> Omni::qwen2VisionProcess(VARP image) {
     // Qwen2-VL / Qwen2.5-VL
     mVisionHeight = round(mVisionHeight / 28.0) * 28;
     mVisionWidth = round(mVisionWidth / 28.0) * 28;
-    image = MNN::CV::resize(image, {mVisionHeight, mVisionWidth}, 0, 0,
+    image = MNN::CV::resize(image, {mVisionWidth, mVisionHeight}, 0, 0,
                             MNN::CV::INTER_LINEAR, MNN::CV::COLOR_BGR2RGB,
                             mVisionMean, mVisionNorm);
     image = Express::_Unsqueeze(image, {0});
@@ -299,7 +299,7 @@ std::vector<int> Omni::smolvlmVisionProcess(VARP image) {
         if (mVisionWidth > mVisionMaxSize) {
             mVisionWidth = mVisionMaxSize;
         }
-        auto patches = MNN::CV::resize(image, {mVisionHeight, mVisionWidth}, 0, 0,
+        auto patches = MNN::CV::resize(image, {mVisionWidth, mVisionHeight}, 0, 0,
                                        MNN::CV::INTER_LINEAR, MNN::CV::COLOR_BGR2RGB,
                                        mVisionMean, mVisionNorm);
         patches = Express::_Unsqueeze(patches, {0});
@@ -358,6 +358,198 @@ std::vector<int> Omni::smolvlmVisionProcess(VARP image) {
     imgIds.push_back(mVisionEnd);
     return imgIds;
 }
+
+std::vector<std::pair<int, int>> minicpmBestSize(std::pair<int, int> original_size, int patch_size) {
+    constexpr int max_slice_nums = 9, scale_resolution = 448;
+    auto _get_target_size =
+        [&](std::pair<int, int> size, bool upscale) -> std::pair<int, int> {
+        int h = size.first;
+        int w = size.second;
+        int target_w, target_h;
+        if (!upscale && (static_cast<long long>(w) * h <= static_cast<long long>(scale_resolution) * scale_resolution)) {
+            target_w = w;
+            target_h = h;
+        } else {
+            double r = (h != 0) ? static_cast<double>(w) / h : 0.0;
+            if (r > 0) {
+                target_h = static_cast<int>(scale_resolution / std::sqrt(r));
+                target_w = static_cast<int>(target_h * r);
+            } else {
+                target_h = 0;
+                target_w = scale_resolution;
+            }
+        }
+        int final_h = std::max(static_cast<int>(std::round(static_cast<double>(target_h) / patch_size)) * patch_size, patch_size);
+        int final_w = std::max(static_cast<int>(std::round(static_cast<double>(target_w) / patch_size)) * patch_size, patch_size);
+        return std::make_pair(final_h, final_w);
+    };
+    int original_height = original_size.first;
+    int original_width = original_size.second;
+    double ratio = (static_cast<double>(original_width) * original_height) / (static_cast<double>(scale_resolution) * scale_resolution);
+    int multiple = std::min(static_cast<int>(std::ceil(ratio)), max_slice_nums);
+    std::vector<std::pair<int, int>> candidates;
+    std::set<int> nums_to_check;
+    if (multiple > 1) nums_to_check.insert(multiple - 1);
+    nums_to_check.insert(multiple);
+    nums_to_check.insert(multiple + 1);
+    for (std::set<int>::iterator it = nums_to_check.begin(); it != nums_to_check.end(); ++it) {
+        int num = *it;
+        if (num >= 1 && num <= max_slice_nums) {
+            for (int m = 1; m * m <= num; ++m) {
+                if (num % m == 0) {
+                    candidates.push_back(std::make_pair(m, num / m));
+                    if (m * m != num) candidates.push_back(std::make_pair(num / m, m));
+                }
+            }
+        }
+    }
+    if (candidates.empty()) { candidates.push_back(std::make_pair(1, 1)); }
+    double log_ratio = std::log(static_cast<double>(original_width) / original_height);
+    std::pair<int, int> best_grid = *std::min_element(candidates.begin(), candidates.end(),
+        [log_ratio](const std::pair<int, int>& g1, const std::pair<int, int>& g2) {
+            auto key = [log_ratio](const std::pair<int, int>& g) -> double {
+                if (g.first == 0) return std::numeric_limits<double>::infinity();
+                return std::abs(log_ratio - std::log(static_cast<double>(g.second) / g.first));
+            };
+            return key(g1) < key(g2);
+        });
+    std::pair<int, int> source_image_size = _get_target_size(original_size, false);
+    double patch_h = static_cast<double>(original_height) / best_grid.first;
+    double patch_w = static_cast<double>(original_width) / best_grid.second;
+    std::pair<int, int> best_patch_size = _get_target_size(std::make_pair(static_cast<int>(patch_h), static_cast<int>(patch_w)), true);
+    std::pair<int, int> refine_image_size = std::make_pair(
+        best_patch_size.first * best_grid.first,
+        best_patch_size.second * best_grid.second
+    );
+    std::vector<std::pair<int, int>> result;
+    result.push_back(source_image_size);
+    result.push_back(refine_image_size);
+    result.push_back(best_grid);
+    return result;
+}
+
+std::vector<int> Omni::minicpmVisionProcess(VARP image) {
+    constexpr int visionLen = 64, patchesPerSide = 70;
+    const int patchSize = mVisionSizeUnit;
+    auto bestSize = minicpmBestSize(std::make_pair(mVisionHeight, mVisionWidth), patchSize);
+    auto globalSize = bestSize[0];
+    auto refineSize = bestSize[1];
+    auto sliceGrids = bestSize[2];
+    auto reoderImage = [this, &patchSize](
+        Express::VARP img, std::pair<int, int> targetSize, std::pair<int,int> grid, std::vector<int>& tgtSize) {
+        auto patches = MNN::CV::resize(img, {targetSize.second, targetSize.first}, 0, 0,
+                                    MNN::CV::INTER_LINEAR, MNN::CV::COLOR_BGR2RGB,
+                                    mVisionMean, mVisionNorm);
+        patches = Express::_Unsqueeze(patches, {0});
+        patches = Express::_Convert(patches, NCHW);
+        auto imageDims = patches->getInfo()->dim;
+        int batch   = imageDims[0];
+        int channel = imageDims[1];
+        int height  = imageDims[2];
+        int width   = imageDims[3];
+        int gridH   = grid.first;
+        int gridW   = grid.second;
+        int subHeight = height / gridH;
+        int subWidth = width / gridW;
+        int numPatchesH = subHeight / patchSize;
+        int numPatchesW = subWidth / patchSize;
+        patches = Express::_Reshape(patches, {
+            channel,
+            gridH,
+            numPatchesH,
+            patchSize,
+            gridW,
+            numPatchesW,
+            patchSize
+        });
+        patches = Express::_Permute(patches, {1, 4, 0, 3, 2, 5, 6});
+        patches = Express::_Reshape(patches, {
+            gridH * gridW,
+            channel,
+            patchSize,
+            numPatchesH * numPatchesW * patchSize
+        });
+        for (int i = 0; i < gridH * gridW; i++) {
+            tgtSize.push_back(numPatchesH);
+            tgtSize.push_back(numPatchesW);
+        }
+        return patches;
+    };
+    // pixel values
+    std::vector<int> tgtSize;
+    auto globalImage = reoderImage(image, globalSize, std::make_pair(1, 1), tgtSize);
+    auto refineImage = reoderImage(image, refineSize, sliceGrids, tgtSize);
+    int globleDim = globalImage->getInfo()->dim[3];
+    int refineDim = refineImage->getInfo()->dim[3];
+    globalImage = _Pad(globalImage, _var<int>({0, 0, 0, 0, 0, 0, 0, refineDim - globleDim}, {8}), CONSTANT);
+    auto pixel_values = _Concat({globalImage, refineImage}, 0);
+    // position ids
+    int B = tgtSize.size() / 2;
+    int S = tgtSize[0] * tgtSize[1];
+    int L = tgtSize[2] * tgtSize[3];
+    auto position_ids = Express::_Input({B, L}, NCHW, halide_type_of<int>());
+    auto posPtr = position_ids->writeMap<int>();
+    memset(posPtr, 0, B * L * sizeof(int));
+    for (int i = 0; i < B; ++i) {
+        int nb_patches_h = tgtSize[i * 2];
+        int nb_patches_w = tgtSize[i * 2 + 1];
+        for (int h_idx = 0; h_idx < nb_patches_h; ++h_idx) {
+            long bucket_h = static_cast<long>(std::floor(
+                (static_cast<float>(h_idx) / nb_patches_h) * patchesPerSide
+            ));
+            for (int w_idx = 0; w_idx < nb_patches_w; ++w_idx) {
+                long bucket_w = static_cast<long>(std::floor(
+                    (static_cast<float>(w_idx) / nb_patches_w) * patchesPerSide
+                ));
+                long pos_id = bucket_h * patchesPerSide + bucket_w;
+                long patch_idx = h_idx * nb_patches_w + w_idx;
+                posPtr[i * L + patch_idx] = static_cast<int>(pos_id);
+            }
+        }
+    }
+    // attention mask
+    auto attention_mask = Express::_Input({B, L}, NCHW);
+    auto maskPtr = attention_mask->writeMap<float>();
+    memset(maskPtr, 0, B * L * sizeof(float));
+    for (int i = S; i < L; i++) {
+        maskPtr[i] = std::numeric_limits<float>::lowest();
+    }
+    // tgt size
+    auto tgt_sizes = Express::_Input({B, 2}, NCHW, halide_type_of<int>());
+    ::memcpy(tgt_sizes->writeMap<int>(), tgtSize.data(), tgtSize.size() * sizeof(int));
+    auto imageEmbedding = mVisionModule->onForward({pixel_values, position_ids, attention_mask, tgt_sizes})[0];
+    for (int i = 0; i < B; i++) {
+        auto embedding = _Permute(_GatherV2(imageEmbedding, _var<int>({i}, {1}), _var<int>({0}, {1})), {1, 0, 2});
+        mVisionEmbeddings.push_back(embedding);
+    }
+    int visionSliceStart = mConfig->config_.value("vision_slice_start_id", 111);
+    int visionSliceEnd = mConfig->config_.value("vision_slice_end_id", 112);
+    int visionIdStart = mConfig->config_.value("vision_id_start_id", 113);
+    int visionIdEnd = mConfig->config_.value("vision_id_end_id", 114);
+    std::vector<int> imgIds;
+    // image id
+    imgIds.push_back(visionIdStart);
+    auto visionIdxIds = tokenizer_encode(std::to_string(mVisionNum));
+    for (auto idx : visionIdxIds) {
+        imgIds.push_back(idx);
+    }
+    imgIds.push_back(visionIdEnd);
+    // global image
+    imgIds.push_back(mVisionStart);
+    for (int p = 0; p < visionLen; p++) {
+        imgIds.push_back(mVisionPad);
+    }
+    imgIds.push_back(mVisionEnd);
+    // slice images
+    for (int i = 0; i < B - 1; i++) {
+        imgIds.push_back(visionSliceStart);
+        for (int p = 0; p < visionLen; p++) {
+            imgIds.push_back(mVisionPad);
+        }
+        imgIds.push_back(visionSliceEnd);
+    }
+    return imgIds;
+}
 #endif
 
 std::vector<int> Omni::visionProcess(const std::string& file) {
@@ -373,11 +565,17 @@ std::vector<int> Omni::visionProcess(const std::string& file) {
     if (inputNames.size() >= 3 && inputNames[0] == "patches") {
         imgIds = qwen2VisionProcess(image);
     } else if (inputNames[0] == "pixel_values") {
-        imgIds = smolvlmVisionProcess(image);
+        if (inputNames.size() == 1) {
+            imgIds = smolvlmVisionProcess(image);
+        } else {
+            imgIds = minicpmVisionProcess(image);
+        }
     } else {
         imgIds = defaultVisionProcess(image);
     }
     mContext->vision_us = _t.durationInUs();
+    // set vision number for image idx
+    mVisionNum += 1;
     return imgIds;
 #else
     return std::vector<int>(0);

--- a/transformers/llm/engine/src/omni.hpp
+++ b/transformers/llm/engine/src/omni.hpp
@@ -114,11 +114,13 @@ public:
     std::vector<int> defaultVisionProcess(VARP image);
     std::vector<int> qwen2VisionProcess(VARP image);
     std::vector<int> smolvlmVisionProcess(VARP image);
+    std::vector<int> minicpmVisionProcess(VARP image);
 private:
     int mVisionHeight = 448, mVisionWidth = 448, mVisionStart = 151857,
         mVisionEnd = 151858, mVisionPad = 151859, mAudioPad = 151646;
     int mVisionGlobal = 49152;
     int mVisionSizeUnit = 1, mVisionMaxSize = 2048;
+    int mVisionNum = 0;
     std::vector<float> mVisionMean{122.7709383, 116.7460125, 104.09373615};
     std::vector<float> mVisionNorm{0.01459843, 0.01500777, 0.01422007};
     std::vector<int> multimodeProcess(const std::string& mode, std::string info);

--- a/transformers/llm/export/utils/model_mapper.py
+++ b/transformers/llm/export/utils/model_mapper.py
@@ -446,6 +446,8 @@ class ModelMapper:
                 'eos_token_id': 'eos_token_id',
                 'max_position_embeddings': 'max_position_embeddings',
                 'pad_token_id': 'pad_token_id',
+                'layer_types': 'layer_types',
+                'sliding_window': 'sliding_window'
             },
             'model': {
                 'lm_': 'lm_head',
@@ -612,6 +614,38 @@ class ModelMapper:
         }
         self.regist('gpt_oss', gpt_osss_map)
 
+    def regist_minicpm(self):
+        minicpm_config = copy.deepcopy(self.default_config)
+        minicpm_config['scale_emb'] = 'scale_emb'
+        minicpm_decoder = copy.deepcopy(self.default_decoder)
+        minicpm_decoder['scale_depth'] = 'scale_depth'
+        minicpm_map = {
+            'config': minicpm_config,
+            'model': self.defualt_model,
+            'decoder': minicpm_decoder,
+            'attention': self.default_attention
+        }
+        self.regist('minicpm', minicpm_map)
+
+    def regist_minicpmv(self):
+        minicpmv_config = copy.deepcopy(self.default_config)
+        minicpmv_config['scale_emb'] = 'scale_emb'
+        minicpmv_model = {
+            'lm_': 'llm.lm_head',
+            'embed_': 'llm.model.embed_tokens',
+            'blocks_': 'llm.model.layers',
+            'final_layernorm_': 'llm.model.norm',
+            'visual': 'vpm',
+            'resampler': 'resampler'
+        }
+        minicpmv_map = {
+            'config': minicpmv_config,
+            'model': minicpmv_model,
+            'decoder': self.default_decoder,
+            'attention': self.default_attention
+        }
+        self.regist('minicpmv', minicpmv_map)
+
     def defualt_map(self):
         # default map is `LlamaForCausalLM`
         self.config_key = 'config'
@@ -625,7 +659,8 @@ class ModelMapper:
             'num_hidden_layers': 'num_hidden_layers',
             'num_key_value_heads': 'num_key_value_heads',
             'rope_theta': 'rope_theta',
-            'rope_scaling': 'rope_scaling'
+            'rope_scaling': 'rope_scaling',
+            'max_position_embeddings': 'max_position_embeddings'
         }
         self.defualt_model = {
             'lm_': 'lm_head',

--- a/transformers/llm/export/utils/transformers.py
+++ b/transformers/llm/export/utils/transformers.py
@@ -11,7 +11,7 @@ class Embedding(torch.nn.Module):
         self.hidden_size = config.hidden_size
         self.embed = embed
         self.embed_scale = 1.0
-        if config.model_type == 'gemma2':
+        if config.model_type == 'gemma' or config.model_type == 'gemma2':
             self.embed_scale = self.hidden_size**0.5
         if hasattr(embed, 'embed_scale'):
             self.embed_scale = embed.embed_scale
@@ -250,7 +250,6 @@ class Rotary(torch.nn.Module):
     def __init__(self, config):
         super().__init__()
         if config is None: return
-
         self.rope_theta = config.rope_theta
         self.rope_ratio = config.rope_ratio
         self.rope_theta *= self.rope_ratio
@@ -267,6 +266,7 @@ class Rotary(torch.nn.Module):
 
         def get_theta():
             return 1.0 / (self.rope_theta ** (torch.arange(0, self.rotary_dim, 2, dtype=torch.float32) / self.rotary_dim))
+
         # default rope type's theta
         self.theta = get_theta()
         # other type
@@ -278,14 +278,15 @@ class Rotary(torch.nn.Module):
                 rope_type = config.rope_scaling['type']
             elif 'rope_type' in config.rope_scaling:
                 rope_type = config.rope_scaling['rope_type']
+
             # gen theta for rope_type
             if rope_type == 'dynamic': # NTK
-                if 'alpha' in config.rope_scaling: # NTKAlpha
+                if 'alpha' in config.rope_scaling: # NTKAlpha in Hunyuan
                     self.rope_theta *= (config.rope_scaling['alpha'] ** (self.rotary_dim / (self.rotary_dim - 2)))
                 else: # NTKScaling
                     pass
                 self.theta = get_theta()
-            elif rope_type == 'yarn':
+            elif rope_type == 'yarn': # YaRN in gpt-oss
                 self.is_scaled = True
                 self.theta, self.attention_scaling = _compute_yarn_parameters(
                     rotary_dim=self.rotary_dim,
@@ -293,6 +294,15 @@ class Rotary(torch.nn.Module):
                     scaling_config=scaling_config,
                     max_position_embeddings=config.max_position_embeddings
                 )
+            elif rope_type == 'longrope': # longrope in MiniCPM
+                self.is_scaled = True
+                original_max_position_embeddings = config.rope_scaling['original_max_position_embeddings']
+                scale = (config.max_position_embeddings / original_max_position_embeddings)
+                self.attention_scaling = math.sqrt(1 + math.log(scale) / math.log(original_max_position_embeddings))
+                # long_factor = config.rope_scaling['long_factor']
+                short_factor = config.rope_scaling['short_factor']
+                self.theta = get_theta() / torch.tensor(short_factor, dtype=torch.float32)
+
             # mrope for multimode
             if 'mrope_section' in scaling_config:
                 self.mrope_section = scaling_config['mrope_section']
@@ -539,8 +549,11 @@ class Decoder(torch.nn.Module):
         else:
             self.self_attn = Attention(self.self_attn, layer_id, config)
         self.hidden_size = config.hidden_size
-        # chatglm
-        self.alpha = (2 * config.num_hidden_layers) ** 0.5 if config.model_type == 'chatglm' else 1.0
+        if hasattr(config, 'num_hidden_layers'):
+            # minicpm
+            self.num_hidden_layers = config.num_hidden_layers
+            # chatglm
+            self.alpha = (2 * config.num_hidden_layers) ** 0.5 if config.model_type == 'chatglm' else 1.0
 
     def forward(
         self,
@@ -568,7 +581,7 @@ class Decoder(torch.nn.Module):
             # phi
             feed_forward_hidden_states = self.mlp(norm_hidden_states)
             hidden_states = hidden_states + feed_forward_hidden_states + residual
-        elif self.alpha != 1.0:
+        elif hasattr(self, 'alpha') and self.alpha != 1.0:
             # chatglm-6b
             hidden_states = norm_hidden_states * self.alpha + hidden_states
             mlp_input = self.post_attention_layernorm(hidden_states)
@@ -590,6 +603,13 @@ class Decoder(torch.nn.Module):
             hidden_states = self.mlp(hidden_states)
             hidden_states = cross_attention_mask * hidden_states
             hidden_states = residual + self.cross_attn_mlp_gate.tanh() * hidden_states
+        elif hasattr(self, 'scale_depth'):
+            # minicpm
+            hidden_states = residual + hidden_states * (self.scale_depth / math.sqrt(self.num_hidden_layers))
+            residual = hidden_states
+            hidden_states = self.post_attention_layernorm(hidden_states)
+            hidden_states = self.mlp(hidden_states)
+            hidden_states = residual + hidden_states * (self.scale_depth / math.sqrt(self.num_hidden_layers))
         else:
             # general
             hidden_states = residual + hidden_states


### PR DESCRIPTION
## PR 修改细节

### 1. 核心功能
- 为 MNN 框架添加了对 MiniCPM 和 MiniCPM-V 模型的支持，包括基础模型和多模态视觉功能

### 2. 代码变更明细

#### 2.1 Vision 模型支持 (transformers/llm/export/utils/vision.py)
- 新增了 `MiniCPMVision` 类，实现了 MiniCPM 的视觉模型支持
- 主要功能包括：
  - 实现了图像分片处理逻辑，根据输入求最佳分片大小以及对应的缩放尺寸
  - 实现了动态图像尺寸缩放和补丁（patch）生成
  - 添加了特定的图像标记处理（如 `<image>`, `<slice>` 等）
  - 实现了位置编码和注意力掩码的生成
  - 重写`SiglipVisionTransformer`和`Resampler`以便导出计算图

#### 2.2 推理核心改进 (transformers/llm/engine/src/omni.cpp)
- 新增 `minicpmVisionProcess` 函数实现视觉数据预处理
- 修复了图像处理中的尺寸处理问题，修正了 resize 操作中的宽高参数顺序
- 添加了多分片图像处理支持，包括：
  - 全局图像处理
  - 局部图像分片处理
  - 位置编码生成
  - 注意力掩码计算

#### 2.3 模型结构支持 (transformers/llm/export/utils/model_mapper.py)
- 添加了 MiniCPM 相关的配置映射：
  ```python
  def regist_minicpm(self):
      minicpm_config = copy.deepcopy(self.default_config)
      minicpm_config['scale_emb'] = 'scale_emb'
      # ...
  ```
- 新增了 MiniCPM-V 多模态模型的配置支持：
  ```python
  def regist_minicpmv(self):
      minicpmv_config = copy.deepcopy(self.default_config)
      minicpmv_config['scale_emb'] = 'scale_emb'
      minicpmv_model = {
          'lm_': 'llm.lm_head',
          'embed_': 'llm.model.embed_tokens',
          # ...
      }
  ```

#### 2.4 模型导出优化 (transformers/llm/export/llmexport.py)
- 改进了模型导出逻辑，支持 MiniCPM 特有的缩放嵌入
- 添加了对 chat template 的支持
- 优化了特殊 token 的处理机制

#### 2.5 Transformer 组件增强 (transformers/llm/export/utils/transformers.py)
- 添加了 LongRoP 位置编码支持
- 实现了深度缩放功能，用于优化深层网络的训练
- 改进了注意力机制的实现

### 3. 关键实现细节

#### 视觉处理流程
1. 图像预处理：
```python
def calculate_image_processing_plan(
    self,
    original_size: Tuple[int, int],
    max_slice_nums: int = 9,
    scale_resolution: int = 448,
    patch_size: int = 14,
):
```

2. 分片策略：
- 支持动态分片数量计算
- 自适应分片大小调整
- 全局和局部特征融合

3. 位置编码：
```python
def gen_position_ids(self, tgt_sizes: torch.Tensor, num_patches_per_side: int):
    # 生成图像patch的位置编码
    batch_size = tgt_sizes.size(0)
    num_patches = (tgt_sizes[:, 0] * tgt_sizes[:, 1]).long()
    # ...
```