### PR TITLE
ENH: Optimize MNNPackC4ForMatMul_A with RVV implementation

### DIFF
--- a/source/backend/cpu/riscv/rvv/MNNPackC4ForMatMul_A.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNPackC4ForMatMul_A.cpp
@@ -1,0 +1,68 @@
+#include <riscv_vector.h>
+#include <algorithm>
+
+#define TILE_E_SIZE 1024
+
+void MNNPackC4ForMatMul_A(float *destOrigin, float const **sourceGroup, const int32_t *info, const int32_t *el) {
+    int number = info[0];
+    int eReal = info[1];
+    int eDest = info[2];
+    int offset = info[3];
+
+    for (int n = 0; n < number; ++n) {
+        int e = el[4 * n + 0];
+        int l = el[4 * n + 1];
+        int eOffset = el[4 * n + 2];
+        int lOffset = el[4 * n + 3];
+        auto destBase = destOrigin + lOffset * eDest + eOffset;
+        auto source = sourceGroup[n];        
+        int limit = l / 4 * 4; 
+        int x = 0;
+
+        for (; x < limit; x += 4) {
+            auto xC = x / 4;
+            const float *sourcePtrBase = source + xC * eReal * 4;
+            float *destPtrCol0 = destBase + (x + 0) * eDest;
+            float *destPtrCol1 = destBase + (x + 1) * eDest;
+            float *destPtrCol2 = destBase + (x + 2) * eDest;
+            float *destPtrCol3 = destBase + (x + 3) * eDest;
+
+            for (int yBase = 0; yBase < e; yBase += TILE_E_SIZE) {
+                int eBlock = std::min(e - yBase, TILE_E_SIZE);
+
+                for (int yOffset = 0; yOffset < eBlock; ) {
+                    size_t vl = __riscv_vsetvl_e32m8(eBlock - yOffset);                    
+                    const float *sourceYPtr = sourcePtrBase + (yBase + yOffset) * 4 * offset;
+                    const size_t sourceStride = 4 * offset * sizeof(float);
+
+                    vfloat32m8_t col0 = __riscv_vlse32_v_f32m8(sourceYPtr + 0, sourceStride, vl);
+                    vfloat32m8_t col1 = __riscv_vlse32_v_f32m8(sourceYPtr + 1, sourceStride, vl);
+                    vfloat32m8_t col2 = __riscv_vlse32_v_f32m8(sourceYPtr + 2, sourceStride, vl);
+                    vfloat32m8_t col3 = __riscv_vlse32_v_f32m8(sourceYPtr + 3, sourceStride, vl);
+                    
+                    __riscv_vse32_v_f32m8(destPtrCol0 + yBase + yOffset, col0, vl);
+                    __riscv_vse32_v_f32m8(destPtrCol1 + yBase + yOffset, col1, vl);
+                    __riscv_vse32_v_f32m8(destPtrCol2 + yBase + yOffset, col2, vl);
+                    __riscv_vse32_v_f32m8(destPtrCol3 + yBase + yOffset, col3, vl);
+
+                    yOffset += vl;
+                }
+            }
+        }
+        
+        for (; x < l; ++x) {
+            auto xC = x / 4;
+            auto xR = x % 4;
+            const float* sourcePtrBase = source + xC * eReal * 4 + xR;
+            float* destPtrCol = destBase + x * eDest;
+
+            for (int yBase = 0; yBase < e; yBase += TILE_E_SIZE) {
+                int eBlock = std::min(e - yBase, TILE_E_SIZE);
+                for (int yOffset = 0; yOffset < eBlock; ++yOffset) {
+                    int y = yBase + yOffset;
+                    destPtrCol[y] = sourcePtrBase[y * 4 * offset];
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces RISC-V Vector Extension (RVV) optimizations for the `MNNPackC4ForMatMul_A` function. By leveraging RVV intrinsics, this enhancement significantly accelerates the data packing stage for matrix multiplication, which is a critical preprocessing step for GEMM operations on compatible RISC-V hardware.

The implementation focuses on using vector instructions to efficiently load, rearrange, and store data according to the C4 packing format, leading to substantial performance gains over the original scalar implementation, especially for large matrices.

-----

### Performance Benchmark

The following benchmark results were obtained by running the `test_pack_c4_for_mat_mul_a` unit test. The tests compare the execution time of the original scalar code against the new RVV-optimized version.

As the data shows, the optimization yields significant speedups, **reaching up to \~63x** for larger problem sizes.

#### Key Results (`eReal = 1024`):

| `eReal` | `l`       | Scalar Time (sec) | RVV Time (sec) | Speedup |
| :------ | :-------- | :---------------- | :------------- | :------ |
| 1024    | 128       | 0.0169            | 0.0005         | **33.16x** |
| 1024    | 1024      | 0.2516            | 0.0042         | **59.32x** |
| 1024    | 4096      | 1.0135            | 0.0169         | **60.05x** |
| 1024    | 8192      | 2.0294            | 0.0335         | **60.56x** |
| 1024    | 16384     | 4.0641            | 0.0668         | **60.82x** |
| 1024    | 32768     | 8.4874            | 0.1338         | **63.42x** |

#### Large-Scale and Asymmetric Test Cases:

The implementation was further validated on test cases with very large or asymmetric dimensions to ensure robustness and performance under extreme conditions.

| `eReal`   | `l`       | Scalar Time (sec) | RVV Time (sec) | Speedup |
| :-------- | :-------- | :---------------- | :------------- | :------ |
| 65536     | 128       | 2.0693            | 0.0415         | **49.88x** |
| 1000000   | 64        | 4.0197            | 0.2316         | **17.36x** |
| 16        | 1000000   | 0.8604            | 0.1407         | **6.12x** |
| 1         | 65536     | 0.0029            | 0.0088         | 0.33x  |

*Note: For extremely "thin" matrices (e.g., `eReal=1`), the overhead of vectorization can be higher than the computational savings, which is an expected outcome.*

-----

### Testing Environment

  * **Hardware**: Banana Pi BPI-F3
  * **OS**: EulixOS 3.0
