### PR TITLE
build: Use try_compile for robust RVV toolchain detection

### DIFF
--- a/source/backend/cpu/riscv/CMakeLists.txt
+++ b/source/backend/cpu/riscv/CMakeLists.txt
@@ -4,6 +4,46 @@ ENDIF()
 
 FILE(GLOB MNN_RVV_SRC ${CMAKE_CURRENT_LIST_DIR}/rvv/*.cpp)
 
+if (MNN_USE_RVV AND (CMAKE_SYSTEM_PROCESSOR MATCHES "^riscv64" OR ARCHS STREQUAL "riscv64"))
+    message(STATUS "MNN_USE_RVV is ON. Checking for RVV support in user-provided compiler flags...")
+
+    set(RVV_CHECK_SOURCE_CONTENT
+      "
+      #ifndef __riscv_v
+      #error \"Compiler does not define __riscv_v. Check your global CMAKE_C(XX)_FLAGS.\"
+      #endif
+      int main() { return 0; }
+      "
+    )
+    set(TRY_COMPILE_DIR "${CMAKE_BINARY_DIR}/CMakeFiles/CMakeTmp")
+    set(RVV_CHECK_FILE_PATH "${TRY_COMPILE_DIR}/rvv_check.cpp")
+    file(WRITE "${RVV_CHECK_FILE_PATH}" "${RVV_CHECK_SOURCE_CONTENT}")
+
+    try_compile(
+        TOOLCHAIN_SUPPORTS_RVV
+        SOURCES "${RVV_CHECK_FILE_PATH}"
+    )
+    
+    file(REMOVE_RECURSE "${TRY_COMPILE_DIR}")
+
+    if(TOOLCHAIN_SUPPORTS_RVV)
+        message(STATUS "Toolchain check passed. Enabling RVV source files.")
+        add_library(MNNRVV OBJECT ${MNN_RVV_SRC})
+        target_include_directories(MNNRVV PRIVATE ${CMAKE_CURRENT_LIST_DIR}/rvv/)
+        list(APPEND MNN_OBJECTS_TO_LINK $<TARGET_OBJECTS:MNNRVV>)
+        list(APPEND MNN_TARGETS MNNRVV)
+        add_definitions(-DMNN_USE_RVV)
+    else()
+        message(FATAL_ERROR "MNN_USE_RVV is ON, but the provided compiler flags do not support RVV. Please provide correct '-march=...v...' and '-mabi=...' flags in CMAKE_C_FLAGS and CMAKE_CXX_FLAGS.")
+    endif()
+else()
+    message(STATUS "RVV optimizations are disabled (MNN_USE_RVV is OFF or target is not riscv64).")
+endif()IF(NOT DEFINED ARCHS)
+  set(ARCHS ${CMAKE_SYSTEM_PROCESSOR})
+ENDIF()
+
+FILE(GLOB MNN_RVV_SRC ${CMAKE_CURRENT_LIST_DIR}/rvv/*.cpp)
+
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "^riscv64" OR ARCHS STREQUAL "riscv64")
     message(STATUS "Target is riscv64. Performing fine-grained toolchain check for RVV support...")
     set(RVV_TEST_FLAGS "-march=rv64gcv -mabi=lp64d")

--- a/source/backend/cpu/riscv/CMakeLists.txt
+++ b/source/backend/cpu/riscv/CMakeLists.txt
@@ -5,13 +5,41 @@ ENDIF()
 FILE(GLOB MNN_RVV_SRC ${CMAKE_CURRENT_LIST_DIR}/rvv/*.cpp)
 
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "^riscv64" OR ARCHS STREQUAL "riscv64")
-    message(STATUS "Enabling RVV Optimizations")
-    add_library(MNNRVV OBJECT ${MNN_RVV_SRC})
-    target_include_directories(MNNRVV PRIVATE ${CMAKE_CURRENT_LIST_DIR}/rvv/)
-    list(APPEND MNN_OBJECTS_TO_LINK $<TARGET_OBJECTS:MNNRVV>)
-    list(APPEND MNN_TARGETS MNNRVV)
-    add_definitions(-DMNN_USE_RVV)
-    target_compile_options(MNNRVV PRIVATE -march=rv64gcv -mabi=lp64d)
+    message(STATUS "Target is riscv64. Performing fine-grained toolchain check for RVV support...")
+    set(RVV_TEST_FLAGS "-march=rv64gcv -mabi=lp64d")
+
+    set(RVV_CHECK_SOURCE_CONTENT
+      "
+      #ifndef __riscv_v
+      #error \"Compiler does not define __riscv_v. RVV is not properly supported.\"
+      #endif
+      int main() { return 0; }
+      "
+    )
+    set(TRY_COMPILE_DIR "${CMAKE_BINARY_DIR}/CMakeFiles/CMakeTmp")
+    set(RVV_CHECK_FILE_PATH "${TRY_COMPILE_DIR}/rvv_check.cpp")
+    file(WRITE "${RVV_CHECK_FILE_PATH}" "${RVV_CHECK_SOURCE_CONTENT}")
+
+    try_compile(
+        TOOLCHAIN_SUPPORTS_RVV
+        SOURCES "${RVV_CHECK_FILE_PATH}"
+        CMAKE_FLAGS "-DCMAKE_CXX_FLAGS=${RVV_TEST_FLAGS}"
+    )
+
+    message(STATUS "Cleaning up temporary compile directory...")
+    file(REMOVE_RECURSE "${TRY_COMPILE_DIR}")
+
+    if(TOOLCHAIN_SUPPORTS_RVV)
+        message(STATUS "Toolchain check passed. Enabling RVV Optimizations.")
+        add_library(MNNRVV OBJECT ${MNN_RVV_SRC})
+        target_include_directories(MNNRVV PRIVATE ${CMAKE_CURRENT_LIST_DIR}/rvv/)
+        list(APPEND MNN_OBJECTS_TO_LINK $<TARGET_OBJECTS:MNNRVV>)
+        list(APPEND MNN_TARGETS MNNRVV)
+        add_definitions(-DMNN_USE_RVV)
+        target_compile_options(MNNRVV PRIVATE ${RVV_TEST_FLAGS})
+    else()
+        message(WARNING "Target is riscv64, but the toolchain check failed with flags (${RVV_TEST_FLAGS}). Please check if your compiler version supports the 'V' extension. RVV optimizations will be disabled.")
+    endif()
 else()
-    message(WARNING "RVV optimizations are only supported on riscv64 architecture")
+    message(STATUS "RVV optimizations are skipped for non-riscv64 targets.")
 endif()


### PR DESCRIPTION
### Description

This PR significantly improves the reliability of the RISC-V Vector (RVV) feature detection in the CMake build system. It replaces the previous brittle architecture name check with a robust `try_compile`-based toolchain validation.

### Motivation and Context

The existing method for enabling RVV optimizations relied solely on checking if the target architecture string matched `riscv64`. This approach is fragile and can cause the build to fail in several common scenarios:

  * Using an older RISC-V toolchain that does not support the 'V' extension.
  * Using a modern toolchain that was configured and built without vector support.
  * Incorrectly configured cross-compilation environments.

The goal of this PR is to prevent these build failures by verifying the compiler's capabilities directly, ensuring a smoother and more reliable experience for developers targeting RISC-V.

### Key Changes

1.  **Replaced Architecture String Check:** The simple `if (... MATCHES "riscv64")` logic has been replaced with a more intelligent `try_compile` block.
2.  **Robust Toolchain Validation:** The new check compiles a small test program to ensure the toolchain can correctly handle the `-march=rv64gcv` flag and defines the `__riscv_v` macro, which is the standard-compliant way to verify vector support.
3.  **Cross-Compilation Safe:** This method works seamlessly for both native and cross-compilation, as it tests the configured target compiler, not the host compiler.
4.  **Improved Diagnostic Messages:** Clear `STATUS` and `WARNING` messages are now provided to inform the user about the result of the toolchain check.
5.  **Automatic Cleanup:** The entire temporary directory (`CMakeFiles/CMakeTmp`) used by `try_compile` is now removed after the check, ensuring a clean build directory.

### How Has This Been Tested?

I have tested this new logic on my development environment:

  * **OS:** EulixOS 3.0
  * **Compiler:** gcc15.1
  * **Platform:** sg2044
  * **Scenarios:**
      * Successfully configured and built the project with the RVV backend enabled, using a capable toolchain.

This change should make the build process much more robust for all developers working with the RISC-V backend.