### PR TITLE
Use n_gen from context, fix tps mismatch in gemma3

### DIFF
--- a/transformers/llm/engine/tools/llm_bench.cpp
+++ b/transformers/llm/engine/tools/llm_bench.cpp
@@ -154,6 +154,7 @@ struct TestInstance {
     bool                     useMmap;
     int                      nPrompt;
     int                      nGenerate;
+    std::vector<int64_t>     nGenerates;
     std::vector<int64_t>     prefillUs;
     std::vector<int64_t>     decodeUs;
     std::vector<int64_t>     samplesUs;
@@ -181,6 +182,14 @@ struct TestInstance {
     std::vector<double> getTokensPerSecond(int n_tokens, std::vector<int64_t> cost_us) const {
         std::vector<double> ts;
         std::transform(cost_us.begin(), cost_us.end(), std::back_inserter(ts), [n_tokens](int64_t t) { return 1e6 * n_tokens / t; });
+        return ts;
+    }
+
+    std::vector<double> getTokensPerSecond(std::vector<int64_t> n_tokens, std::vector<int64_t> cost_us) const {
+        std::vector<double> ts(n_tokens.size());
+        for (int i = 0; i < n_tokens.size(); ++i) {
+            ts[i] = 1e6 * n_tokens[i] / cost_us[i];
+        }
         return ts;
     }
 
@@ -354,7 +363,7 @@ struct markdownPrinter : public Printer {
                 snprintf(buf, sizeof(buf), "%.2f ± %.2f", t.getAvgUs(spd), t.getStdevUs(spd));
                 value = buf;
             } else if (field == "speed(tok/s)") {
-                auto decode_speed = t.getTokensPerSecond(t.nGenerate, t.decodeUs);
+                auto decode_speed = t.getTokensPerSecond(t.nGenerates, t.decodeUs);
                 auto prefill_speed = t.getTokensPerSecond(t.nPrompt, t.prefillUs);
                 snprintf(buf, sizeof(buf), "%.2f ± %.2f<br>%.2f ± %.2f", t.getAvgUs(prefill_speed), t.getStdevUs(prefill_speed), t.getAvgUs(decode_speed), t.getStdevUs(decode_speed));
                 value = buf;
@@ -899,6 +908,11 @@ int main(int argc, char ** argv) {
                 if (i > 0) { // Exclude the first performance value.
                     t.prefillUs.push_back(prefillTime);
                     t.decodeUs.push_back(decodeTime);
+                    if (llm->stoped()) {
+                        t.nGenerates.push_back(context->gen_seq_len - 1);
+                    } else {
+                        t.nGenerates.push_back(context->gen_seq_len);
+                    }
                 }
             }
             if (printHeader) {


### PR DESCRIPTION
This PR is trying to address #3947 . When benchmarking gemma3, this model generates eos token very quick, i.e. 3~4 tokens, but we still calculate the decoding tps by 128. So this model displays a very high decoding speed.

before fix:

| model                          |  modelSize | backend    | threads | precision  | llm_demo   | speed(tok/s) |
| ------------------------------ | ---------: | ---------- | ----: | ---------- | ---------- | ------------ |
| gemma-3-1b-it-qat-q4_0-gguf-MNN | 994.65 MiB | CPU        |     4 | Low        | prompt=128<br>decode=128 | 45.88 ± 0.54<br>316.10 ± 2.58 |
| gemma-3-1b-it-qat-q4_0-gguf-MNN | 994.65 MiB | CPU        |     4 | Low        | prompt=256<br>decode=128 | 45.63 ± 0.53<br>311.16 ± 1.67 |
| gemma-3-1b-it-qat-q4_0-gguf-MNN | 994.65 MiB | CPU        |     4 | Low        | prompt=512<br>decode=128 | 45.00 ± 0.34<br>11.91 ± 0.14 |

after fix:

| model                          |  modelSize | backend    | threads | precision  | llm_demo   | speed(tok/s) |
| ------------------------------ | ---------: | ---------- | ----: | ---------- | ---------- | ------------ |
| gemma-3-1b-it-qat-q4_0-gguf-MNN | 994.65 MiB | CPU        |     4 | Low        | prompt=128<br>decode=128 | 44.90 ± 0.46<br>12.28 ± 0.22 |
| gemma-3-1b-it-qat-q4_0-gguf-MNN | 994.65 MiB | CPU        |     4 | Low        | prompt=256<br>decode=128 | 45.41 ± 0.14<br>12.22 ± 0.04 |
| gemma-3-1b-it-qat-q4_0-gguf-MNN | 994.65 MiB | CPU        |     4 | Low        | prompt=512<br>decode=128 | 45.00 ± 0.08<br>12.04 ± 0.02 |