### PR TITLE
opt(RVV): Optimize pack and unpack functions with intrinsics

### DIFF
--- a/source/backend/cpu/riscv/rvv/MNNPackC2.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNPackC2.cpp
@@ -1,0 +1,74 @@
+#include <riscv_vector.h>
+
+void MNNPackC2(float *dst, const float *src, size_t area, size_t depth, int *areaOffset) {
+    int depthC2 = depth / 2;
+    int depthRemain = depthC2 * 2;
+    int remain = depth - depthRemain;
+    const float *srcOffset = src;
+    const float *srcChannel[2];
+
+    for (int z = 0; z < depthC2; ++z) {
+        float *dstZ = dst + z * areaOffset[1] * 2;
+
+        for (int y = 0; y < 2; ++y) {
+            srcChannel[y] = srcOffset + areaOffset[0] * y;
+        }
+
+        size_t x = 0;
+        size_t vl = __riscv_vsetvl_e32m8(area);
+
+        for (; x + vl <= area; x += vl) {
+            float *dstPtr = dstZ + x * 2;
+            vfloat32m8_t vec = __riscv_vle32_v_f32m8(srcChannel[0] + x, vl);
+            __riscv_vsse32_v_f32m8(dstPtr + 0, 2 * sizeof(float), vec, vl);
+            vec = __riscv_vle32_v_f32m8(srcChannel[1] + x, vl);
+            __riscv_vsse32_v_f32m8(dstPtr + 1, 2 * sizeof(float), vec, vl);
+        }
+
+        for (; x < area; ++x) {
+            float *dstPtr = dstZ + x * 2;
+            dstPtr[0] = srcChannel[0][x];
+            dstPtr[1] = srcChannel[1][x];
+        }
+
+        srcOffset += areaOffset[0] * 2;
+    }
+
+    if (remain > 0) {
+        float *dstZ = dst + depthC2 * areaOffset[1] * 2;
+
+        for (int y = 0; y < remain; ++y) {
+            srcChannel[y] = srcOffset + areaOffset[0] * y;
+        }
+
+        size_t x = 0;
+        size_t vl = __riscv_vsetvl_e32m8(area);
+
+        for (; x + vl <= area; x += vl) {
+            float *dstPtr = dstZ + x * 2;
+
+            for (int y = 0; y < remain; ++y) {
+                vfloat32m8_t vec = __riscv_vle32_v_f32m8(srcChannel[y] + x, vl);
+                __riscv_vsse32_v_f32m8(dstPtr + y, 2 * sizeof(float), vec, vl);
+            }
+
+            vfloat32m8_t zero = __riscv_vfmv_v_f_f32m8(0.0f, vl);
+            for (int y = remain; y < 2; ++y) {
+                __riscv_vsse32_v_f32m8(dstPtr + y, 2 * sizeof(float), zero, vl);
+            }
+        }
+
+        for (; x < area; ++x) {
+            float *dstPtr = dstZ + x * 2;
+
+            for (int y = 0; y < remain; ++y) {
+                dstPtr[y] = srcChannel[y][x];
+            }
+
+            for (int y = remain; y < 2; ++y) {
+                dstPtr[y] = 0.0f;
+            }
+        }
+    }
+}
+

--- a/source/backend/cpu/riscv/rvv/MNNPackC4.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNPackC4.cpp
@@ -1,0 +1,80 @@
+#include <riscv_vector.h>
+
+void MNNPackC4(float *dst, const float *src, size_t area, size_t depth, int *areaOffset) {
+    int depthC4 = depth / 4;
+    int depthRemain = depthC4 * 4;
+    int remain = depth - depthRemain;
+    const float *srcOffset = src;
+    const float *srcChannel[4];
+
+    for (int z = 0; z < depthC4; ++z) {
+        float *dstZ = dst + z * areaOffset[1] * 4;
+
+        for (int y = 0; y < 4; ++y) {
+            srcChannel[y] = srcOffset + areaOffset[0] * y;
+        }
+
+        size_t x = 0;
+        size_t vl = __riscv_vsetvl_e32m8(area);
+
+        for (; x + vl <= area; x += vl) {
+            float *dstPtr = dstZ + x * 4;
+            vfloat32m8_t vec = __riscv_vle32_v_f32m8(srcChannel[0] + x, vl);
+            __riscv_vsse32_v_f32m8(dstPtr + 0, 4 * sizeof(float), vec, vl);
+            vec = __riscv_vle32_v_f32m8(srcChannel[1] + x, vl);
+            __riscv_vsse32_v_f32m8(dstPtr + 1, 4 * sizeof(float), vec, vl);
+            vec = __riscv_vle32_v_f32m8(srcChannel[2] + x, vl);
+            __riscv_vsse32_v_f32m8(dstPtr + 2, 4 * sizeof(float), vec, vl);
+            vec = __riscv_vle32_v_f32m8(srcChannel[3] + x, vl);
+            __riscv_vsse32_v_f32m8(dstPtr + 3, 4 * sizeof(float), vec, vl);
+        }
+
+        for (; x < area; ++x) {
+            float *dstPtr = dstZ + x * 4;
+            dstPtr[0] = srcChannel[0][x];
+            dstPtr[1] = srcChannel[1][x];
+            dstPtr[2] = srcChannel[2][x];
+            dstPtr[3] = srcChannel[3][x];
+        }
+
+        srcOffset += areaOffset[0] * 4;
+    }
+
+    if (remain > 0) {
+        float *dstZ = dst + depthC4 * areaOffset[1] * 4;
+
+        for (int y = 0; y < remain; ++y) {
+            srcChannel[y] = srcOffset + areaOffset[0] * y;
+        }
+
+        size_t x = 0;
+        size_t vl = __riscv_vsetvl_e32m8(area);
+
+        for (; x + vl <= area; x += vl) {
+            float *dstPtr = dstZ + x * 4;
+
+            for (int y = 0; y < remain; ++y) {
+                vfloat32m8_t vec = __riscv_vle32_v_f32m8(srcChannel[y] + x, vl);
+                __riscv_vsse32_v_f32m8(dstPtr + y, 4 * sizeof(float), vec, vl);
+            }
+
+            vfloat32m8_t zero = __riscv_vfmv_v_f_f32m8(0.0f, vl);
+            for (int y = remain; y < 4; ++y) {
+                __riscv_vsse32_v_f32m8(dstPtr + y, 4 * sizeof(float), zero, vl);
+            }
+        }
+
+        for (; x < area; ++x) {
+            float *dstPtr = dstZ + x * 4;
+
+            for (int y = 0; y < remain; ++y) {
+                dstPtr[y] = srcChannel[y][x];
+            }
+
+            for (int y = remain; y < 4; ++y) {
+                dstPtr[y] = 0.0f;
+            }
+        }
+    }
+}
+

--- a/source/backend/cpu/riscv/rvv/MNNUnpackC4.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNUnpackC4.cpp
@@ -1,0 +1,55 @@
+#include <riscv_vector.h>
+
+void MNNUnpackC4(float *dst, const float *src, size_t area, size_t depth, int *areaOffset) {
+    int depthC4 = depth / 4;        
+    int depthRemain = depthC4 * 4;  
+    int remain = depth - depthRemain;
+    const float *srcOffset = src;
+
+    for (int z = 0; z < depthC4; ++z) {
+        float *dstZ[4];
+
+        for (int y = 0; y < 4; ++y) {
+            dstZ[y] = dst + (z * 4 + y) * areaOffset[1];
+        }
+
+        size_t x = 0;
+        size_t vl = __riscv_vsetvl_e32m8(area);
+
+        for (; x + vl <= area; x += vl) {
+            vfloat32m8_t vec = __riscv_vlse32_v_f32m8(srcOffset + 0, 4 * sizeof(float), vl);
+            __riscv_vse32_v_f32m8(dstZ[0] + x, vec, vl);
+            vec = __riscv_vlse32_v_f32m8(srcOffset + 1, 4 * sizeof(float), vl);
+            __riscv_vse32_v_f32m8(dstZ[1] + x, vec, vl);
+            vec = __riscv_vlse32_v_f32m8(srcOffset + 2, 4 * sizeof(float), vl);
+            __riscv_vse32_v_f32m8(dstZ[2] + x, vec, vl);
+            vec = __riscv_vlse32_v_f32m8(srcOffset + 3, 4 * sizeof(float), vl);
+            __riscv_vse32_v_f32m8(dstZ[3] + x, vec, vl);
+            srcOffset += 4 * vl;
+        }
+
+        for (; x < area; ++x) {
+            dstZ[0][x] = srcOffset[0];
+            dstZ[1][x] = srcOffset[1];
+            dstZ[2][x] = srcOffset[2];
+            dstZ[3][x] = srcOffset[3];
+            srcOffset += (areaOffset[0] - area) * 4;
+        }
+    }
+
+    if (remain > 0) {
+        float *dstZ = dst + depthC4 * areaOffset[1] * 4;
+        const float *srcBase = srcOffset;
+
+        for (int y = 0; y < remain; ++y) {
+            float *dstChannel = dstZ + y * areaOffset[1];
+            const float *srcChannel = srcBase + y;
+
+            for (size_t x = 0; x < area; ++x) {
+                dstChannel[x] = srcChannel[0];
+                srcChannel += 4;
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary

Optimize `MNNPackC4`, `MNNPackC2`, and `MNNUnpackC4` using RVV intrinsics.

## Environment

* **Platform**: Banana PI BPI-F3
* **OS**: EulixOS 3.0

## Benchmark

| Case | Size (area, depth) | Speedup |
| :--- | :--- | :--- |
| PackC2 | 1024, 1024 | 6.74x |
| PackC4 | 1024, 1024 | 6.75x |
| UnpackC4 | 256, 32 | 9.96x |

<details>
<summary>Click to expand full test logs</summary>

```text
[root@EulixOS ~]# ./test_pack_c2
area=4, depth=4
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.11x
Test area=4, depth=4: PASSED
area=7, depth=3
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 1.62x
Test area=7, depth=3: PASSED
area=1, depth=1
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.00x
Test area=1, depth=1: PASSED
area=10, depth=15
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 1.62x
Test area=10, depth=15: PASSED
area=256, depth=32
Scalar time: 0.0002 sec
RVV time   : 0.0000 sec
Speedup    : 7.09x
Test area=256, depth=32: PASSED
area=256, depth=256
Scalar time: 0.0020 sec
RVV time   : 0.0004 sec
Speedup    : 4.75x
Test area=256, depth=256: PASSED
area=512, depth=512
Scalar time: 0.0082 sec
RVV time   : 0.0014 sec
Speedup    : 5.73x
Test area=512, depth=512: PASSED
area=1024, depth=1024
Scalar time: 0.0456 sec
RVV time   : 0.0068 sec
Speedup    : 6.74x
Test area=1024, depth=1024: PASSED
area=32, depth=256
Scalar time: 0.0002 sec
RVV time   : 0.0000 sec
Speedup    : 5.09x
Test area=32, depth=256: PASSED

All tests PASSED 
[root@EulixOS ~]# ./test_pack_c4
area=4, depth=4
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.17x
Test area=4, depth=4: PASSED
area=7, depth=3
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.89x
Test area=7, depth=3: PASSED
area=1, depth=1
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.80x
Test area=1, depth=1: PASSED
area=10, depth=15
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 1.75x
Test area=10, depth=15: PASSED
area=256, depth=32
Scalar time: 0.0002 sec
RVV time   : 0.0000 sec
Speedup    : 5.25x
Test area=256, depth=32: PASSED
area=256, depth=256
Scalar time: 0.0016 sec
RVV time   : 0.0004 sec
Speedup    : 3.94x
Test area=256, depth=256: PASSED
area=512, depth=512
Scalar time: 0.0084 sec
RVV time   : 0.0014 sec
Speedup    : 6.14x
Test area=512, depth=512: PASSED
area=1024, depth=1024
Scalar time: 0.0401 sec
RVV time   : 0.0059 sec
Speedup    : 6.75x
Test area=1024, depth=1024: PASSED
area=32, depth=256
Scalar time: 0.0002 sec
RVV time   : 0.0000 sec
Speedup    : 4.20x
Test area=32, depth=256: PASSED

All tests PASSED 
[root@EulixOS ~]# ./test_unpack_c4
area=4, depth=4
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.17x
Test area=4, depth=4: PASSED
area=7, depth=3
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 1.25x
Test area=7, depth=3: PASSED
area=1, depth=1
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.00x
Test area=1, depth=1: PASSED
area=10, depth=15
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 1.31x
Test area=10, depth=15: PASSED
area=256, depth=32
Scalar time: 0.0002 sec
RVV time   : 0.0000 sec
Speedup    : 9.96x
Test area=256, depth=32: PASSED
area=256, depth=256
Scalar time: 0.0018 sec
RVV time   : 0.0002 sec
Speedup    : 9.75x
Test area=256, depth=256: PASSED
area=512, depth=512
Scalar time: 0.0062 sec
RVV time   : 0.0008 sec
Speedup    : 7.73x
Test area=512, depth=512: PASSED
area=1024, depth=1024
Scalar time: 0.0251 sec
RVV time   : 0.0035 sec
Speedup    : 7.20x
Test area=1024, depth=1024: PASSED
area=32, depth=256
Scalar time: 0.0002 sec
RVV time   : 0.0000 sec
Speedup    : 4.96x
Test area=32, depth=256: PASSED

All tests PASSED 
````

\</details\>