### PR TITLE
opt(RVV): Optimize core math and stride functions with intrinsics

### DIFF
--- a/source/backend/cpu/riscv/rvv/MNNAddC4WithStride.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNAddC4WithStride.cpp
@@ -1,0 +1,29 @@
+#include <riscv_vector.h>
+
+void MNNAddC4WithStride(const float* source, float* dest, size_t srcStride, size_t dstStride, size_t count) {
+    ptrdiff_t srcStrideByte = srcStride * sizeof(float);
+    ptrdiff_t dstStrideByte = dstStride * sizeof(float);
+    size_t vl;
+
+    for (size_t i = count; i > 0; i -= vl) {
+        vl = __riscv_vsetvl_e32m8(i);
+        vfloat32m8_t vs = __riscv_vlse32_v_f32m8(source + 0, srcStrideByte, vl);
+        vfloat32m8_t vd = __riscv_vlse32_v_f32m8(dest + 0, dstStrideByte, vl);
+        vd = __riscv_vfadd_vv_f32m8(vd, vs, vl);
+        __riscv_vsse32_v_f32m8(dest + 0, dstStrideByte, vd, vl);
+        vs = __riscv_vlse32_v_f32m8(source + 1, srcStrideByte, vl);
+        vd = __riscv_vlse32_v_f32m8(dest + 1, dstStrideByte, vl);
+        vd = __riscv_vfadd_vv_f32m8(vd, vs, vl);
+        __riscv_vsse32_v_f32m8(dest + 1, dstStrideByte, vd, vl);
+        vs = __riscv_vlse32_v_f32m8(source + 2, srcStrideByte, vl);
+        vd = __riscv_vlse32_v_f32m8(dest + 2, dstStrideByte, vl);
+        vd = __riscv_vfadd_vv_f32m8(vd, vs, vl);
+        __riscv_vsse32_v_f32m8(dest + 2, dstStrideByte, vd, vl);
+        vs = __riscv_vlse32_v_f32m8(source + 3, srcStrideByte, vl);
+        vd = __riscv_vlse32_v_f32m8(dest + 3, dstStrideByte, vl);
+        vd = __riscv_vfadd_vv_f32m8(vd, vs, vl);
+        __riscv_vsse32_v_f32m8(dest + 3, dstStrideByte, vd, vl);
+        source += vl * srcStride;
+        dest   += vl * dstStride;
+    }
+}

--- a/source/backend/cpu/riscv/rvv/MNNAxByClampBroadcastUnit.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNAxByClampBroadcastUnit.cpp
@@ -1,0 +1,52 @@
+#include <riscv_vector.h>
+
+void MNNAxByClampBroadcastUnit(float* C, const float* A, const float* B, size_t width, size_t cStride, size_t aStride, size_t height, const float* parameters) {
+    float beta = parameters[1];
+    float minF = parameters[2];
+    float maxF = parameters[3];
+    const ptrdiff_t stride = 4 * sizeof(float);
+
+    for (int y = 0; y < height; ++y) {
+        auto a = A + aStride * y;
+        auto b = B + 4 * y;
+        auto c = C + cStride * y;
+        float b0Beta = b[0] * beta;
+        float b1Beta = b[1] * beta;
+        float b2Beta = b[2] * beta;
+        float b3Beta = b[3] * beta;
+        size_t w = width;
+
+        while (w > 0) {
+            size_t vl = __riscv_vsetvl_e32m8(w);
+
+            vfloat32m8_t data = __riscv_vlse32_v_f32m8(a + 0, stride, vl);
+                        data = __riscv_vfadd_vf_f32m8(data, b0Beta, vl);
+                        data = __riscv_vfmax_vf_f32m8(data, minF, vl);
+            data = __riscv_vfmin_vf_f32m8(data, maxF, vl);
+                        __riscv_vsse32_v_f32m8(c + 0, stride, data, vl);
+
+            data = __riscv_vlse32_v_f32m8(a + 1, stride, vl);
+            data = __riscv_vfadd_vf_f32m8(data, b1Beta, vl);
+            data = __riscv_vfmax_vf_f32m8(data, minF, vl);
+            data = __riscv_vfmin_vf_f32m8(data, maxF, vl);
+            __riscv_vsse32_v_f32m8(c + 1, stride, data, vl);
+
+            data = __riscv_vlse32_v_f32m8(a + 2, stride, vl);
+            data = __riscv_vfadd_vf_f32m8(data, b2Beta, vl);
+            data = __riscv_vfmax_vf_f32m8(data, minF, vl);
+            data = __riscv_vfmin_vf_f32m8(data, maxF, vl);
+            __riscv_vsse32_v_f32m8(c + 2, stride, data, vl);
+
+            data = __riscv_vlse32_v_f32m8(a + 3, stride, vl);
+            data = __riscv_vfadd_vf_f32m8(data, b3Beta, vl);
+            data = __riscv_vfmax_vf_f32m8(data, minF, vl);
+            data = __riscv_vfmin_vf_f32m8(data, maxF, vl);
+            __riscv_vsse32_v_f32m8(c + 3, stride, data, vl);
+
+            a += 4 * vl;
+            c += 4 * vl;
+            w -= vl;
+        }
+    }
+}
+

--- a/source/backend/cpu/riscv/rvv/MNNCopyC4WithStride.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNCopyC4WithStride.cpp
@@ -1,0 +1,22 @@
+#include <riscv_vector.h>
+
+void MNNCopyC4WithStride(const float* source, float* dest, size_t srcStride, size_t dstStride, size_t count) {
+    ptrdiff_t srcStrideByte = srcStride * sizeof(float);
+    ptrdiff_t dstStrideByte = dstStride * sizeof(float);
+size_t vl;
+
+    for (size_t i = count; i > 0; i -= vl) {
+        vl = __riscv_vsetvl_e32m8(i);
+        vfloat32m8_t data = __riscv_vlse32_v_f32m8(source + 0, srcStrideByte, vl);
+        __riscv_vsse32_v_f32m8(dest + 0, dstStrideByte, data, vl);
+        data = __riscv_vlse32_v_f32m8(source + 1, srcStrideByte, vl);
+        __riscv_vsse32_v_f32m8(dest + 1, dstStrideByte, data, vl);
+        data = __riscv_vlse32_v_f32m8(source + 2, srcStrideByte, vl);
+        __riscv_vsse32_v_f32m8(dest + 2, dstStrideByte, data, vl);
+        data = __riscv_vlse32_v_f32m8(source + 3, srcStrideByte, vl);
+        __riscv_vsse32_v_f32m8(dest + 3, dstStrideByte, data, vl);
+        source += vl * srcStride;
+        dest   += vl * dstStride;
+    }
+}
+

--- a/source/backend/cpu/riscv/rvv/MNNScaleAndAddBias.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNScaleAndAddBias.cpp
@@ -1,0 +1,42 @@
+#include <riscv_vector.h>
+
+void MNNScaleAndAddBias(float *dst, const float *src, const float *bias, const float *alpha, size_t planeNumber, size_t biasNumber) {
+    const ptrdiff_t stride = 4 * sizeof(float);
+
+    for (size_t z = 0; z < biasNumber; ++z) {
+        float *dstZ = dst + z * planeNumber * 4;
+        const float *srcZ = src + z * planeNumber * 4;
+        const float *biasZ = bias + 4 * z;
+        const float *alphaZ = alpha + 4 * z;
+                float b0 = biasZ[0], b1 = biasZ[1], b2 = biasZ[2], b3 = biasZ[3];
+        float a0 = alphaZ[0], a1 = alphaZ[1], a2 = alphaZ[2], a3 = alphaZ[3];
+
+        size_t n = planeNumber;
+        while (n > 0) {
+            size_t vl = __riscv_vsetvl_e32m8(n);
+            vfloat32m8_t data = __riscv_vlse32_v_f32m8(srcZ + 0, stride, vl);
+            data = __riscv_vfmul_vf_f32m8(data, a0, vl);
+            data = __riscv_vfadd_vf_f32m8(data, b0, vl);
+            __riscv_vsse32_v_f32m8(dstZ + 0, stride, data, vl);
+
+            data = __riscv_vlse32_v_f32m8(srcZ + 1, stride, vl);
+            data = __riscv_vfmul_vf_f32m8(data, a1, vl);
+            data = __riscv_vfadd_vf_f32m8(data, b1, vl);
+            __riscv_vsse32_v_f32m8(dstZ + 1, stride, data, vl);
+
+            data = __riscv_vlse32_v_f32m8(srcZ + 2, stride, vl);
+            data = __riscv_vfmul_vf_f32m8(data, a2, vl);
+            data = __riscv_vfadd_vf_f32m8(data, b2, vl);
+            __riscv_vsse32_v_f32m8(dstZ + 2, stride, data, vl);
+
+            data = __riscv_vlse32_v_f32m8(srcZ + 3, stride, vl);
+            data = __riscv_vfmul_vf_f32m8(data, a3, vl);
+            data = __riscv_vfadd_vf_f32m8(data, b3, vl);
+            __riscv_vsse32_v_f32m8(dstZ + 3, stride, data, vl);
+
+            srcZ += vl * 4;
+            dstZ += vl * 4;
+            n -= vl;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Optimize the following functions using RVV intrinsics: MNNAxByClampBroadcastUnit, MNNScaleAndAddBias, MNNCopyC4WithStride, MNNAddC4WithStride

## Environment

* **Platform**: Banana PI BPI-F3
* **OS**: EulixOS 3.0

## Benchmark

<details>
<summary>Click to expand full test logs</summary>

```text
[root@EulixOS ~]# ./test_scale_and_add_bias
planeNumber=4, biasNumber=4
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.24x
Test planeNumber=4, biasNumber=4: PASSED
planeNumber=1, biasNumber=1
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.00x
Test planeNumber=1, biasNumber=1: PASSED
planeNumber=8, biasNumber=3
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.75x
Test planeNumber=8, biasNumber=3: PASSED
planeNumber=4, biasNumber=8
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.45x
Test planeNumber=4, biasNumber=8: PASSED
planeNumber=0, biasNumber=4
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.80x
Test planeNumber=0, biasNumber=4: PASSED
planeNumber=4, biasNumber=0
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.00x
Test planeNumber=4, biasNumber=0: PASSED
planeNumber=65536, biasNumber=4
Scalar time: 0.0137 sec
RVV time   : 0.0062 sec
Speedup    : 2.22x
Test planeNumber=65536, biasNumber=4: PASSED

planeNumber=1048576, biasNumber=16
Scalar time: 0.8715 sec
RVV time   : 0.4023 sec
Speedup    : 2.17x
Test planeNumber=1048576, biasNumber=16: PASSED
planeNumber=16, biasNumber=1048576
Scalar time: 0.9608 sec
RVV time   : 1.0270 sec
Speedup    : 0.94x
Test planeNumber=16, biasNumber=1048576: PASSED
planeNumber=1, biasNumber=1048576
Scalar time: 0.1521 sec
RVV time   : 1.0211 sec
Speedup    : 0.15x
Test planeNumber=1, biasNumber=1048576: PASSED
planeNumber=1048576, biasNumber=1
Scalar time: 0.0544 sec
RVV time   : 0.0242 sec
Speedup    : 2.25x
Test planeNumber=1048576, biasNumber=1: PASSED
planeNumber=0, biasNumber=0
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.44x
Test planeNumber=0, biasNumber=0: PASSED
planeNumber=256, biasNumber=256
Scalar time: 0.0034 sec
RVV time   : 0.0016 sec
Speedup    : 2.12x
Test planeNumber=256, biasNumber=256: PASSED
planeNumber=997, biasNumber=997
Scalar time: 0.0524 sec
RVV time   : 0.0236 sec
Speedup    : 2.21x
Test planeNumber=997, biasNumber=997: PASSED

All tests PASSED 
[root@EulixOS ~]# ./test_add_c4_with_stride
srcStride=4, dstStride=4, count=4
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.05x
Test srcStride=4, dstStride=4, count=4: PASSED
srcStride=4, dstStride=4, count=1
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.00x
Test srcStride=4, dstStride=4, count=1: PASSED
srcStride=8, dstStride=8, count=3
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 1.00x
Test srcStride=8, dstStride=8, count=3: PASSED
srcStride=4, dstStride=8, count=5
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 1.00x
Test srcStride=4, dstStride=8, count=5: PASSED
srcStride=8, dstStride=4, count=7
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.44x
Test srcStride=8, dstStride=4, count=7: PASSED
srcStride=4, dstStride=4, count=0
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.00x
Test srcStride=4, dstStride=4, count=0: PASSED
srcStride=4, dstStride=4, count=65536
Scalar time: 0.0071 sec
RVV time   : 0.0016 sec
Speedup    : 4.39x
Test srcStride=4, dstStride=4, count=65536: PASSED
srcStride=4, dstStride=4, count=1024
Scalar time: 0.0001 sec
RVV time   : 0.0000 sec
Speedup    : 4.39x
Test srcStride=4, dstStride=4, count=1024: PASSED
srcStride=4, dstStride=4, count=2048
Scalar time: 0.0002 sec
RVV time   : 0.0000 sec
Speedup    : 4.86x
Test srcStride=4, dstStride=4, count=2048: PASSED
srcStride=8, dstStride=8, count=8192
Scalar time: 0.0009 sec
RVV time   : 0.0003 sec
Speedup    : 3.27x
Test srcStride=8, dstStride=8, count=8192: PASSED

srcStride=16, dstStride=16, count=1000000
Scalar time: 0.1086 sec
RVV time   : 0.0780 sec
Speedup    : 1.39x
Test srcStride=16, dstStride=16, count=1000000: PASSED

All tests PASSED 
[root@EulixOS ~]# ./test_ax
width=4, cStride=16, aStride=16, height=4
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.63x
Test Result: PASSED
width=7, cStride=32, aStride=32, height=4
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 1.95x
Test Result: PASSED
width=16, cStride=64, aStride=64, height=1
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 6.25x
Test Result: PASSED
width=4, cStride=20, aStride=16, height=8
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 1.35x
Test Result: PASSED
width=10, cStride=40, aStride=40, height=0
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.00x
Test Result: PASSED
width=0, cStride=40, aStride=40, height=10
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 1.25x
Test Result: PASSED
width=128, cStride=512, aStride=512, height=128
Scalar time: 0.0052 sec
RVV time   : 0.0005 sec
Speedup    : 11.40x
Test Result: PASSED
width=1024, cStride=4096, aStride=4096, height=512
Scalar time: 0.1691 sec
RVV time   : 0.0137 sec
Speedup    : 12.34x
Test Result: PASSED

All tests PASSED 
[root@EulixOS ~]# ./test_copy_c4_with_stride
srcStride=4, dstStride=4, count=4
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.06x
Test srcStride=4, dstStride=4, count=4: PASSED
srcStride=4, dstStride=4, count=1
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.00x
Test srcStride=4, dstStride=4, count=1: PASSED
srcStride=8, dstStride=8, count=3
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 1.00x
Test srcStride=8, dstStride=8, count=3: PASSED
srcStride=4, dstStride=8, count=5
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.00x
Test srcStride=4, dstStride=8, count=5: PASSED
srcStride=8, dstStride=4, count=7
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 1.00x
Test srcStride=8, dstStride=4, count=7: PASSED
srcStride=4, dstStride=4, count=0
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.00x
Test srcStride=4, dstStride=4, count=0: PASSED
srcStride=4, dstStride=4, count=65536
Scalar time: 0.0060 sec
RVV time   : 0.0013 sec
Speedup    : 4.61x
Test srcStride=4, dstStride=4, count=65536: PASSED
srcStride=4, dstStride=4, count=1024
Scalar time: 0.0001 sec
RVV time   : 0.0000 sec
Speedup    : 5.76x
Test srcStride=4, dstStride=4, count=1024: PASSED
srcStride=4, dstStride=4, count=2048
Scalar time: 0.0002 sec
RVV time   : 0.0000 sec
Speedup    : 5.41x
Test srcStride=4, dstStride=4, count=2048: PASSED
srcStride=8, dstStride=8, count=8192
Scalar time: 0.0007 sec
RVV time   : 0.0003 sec
Speedup    : 2.84x
Test srcStride=8, dstStride=8, count=8192: PASSED
srcStride=16, dstStride=16, count=1000000
Scalar time: 0.0921 sec
RVV time   : 0.0550 sec
Speedup    : 1.67x
Test srcStride=16, dstStride=16, count=1000000: PASSED

All tests PASSED 
````

\</details\>