### PR TITLE
[BugFix] fix a bug in compute mGroupWithComputeRate

### DIFF
--- a/source/backend/cpu/CPUBackend.cpp
+++ b/source/backend/cpu/CPUBackend.cpp
@@ -499,6 +499,7 @@ CPUBackend::CPUBackend(const CPURuntime* runtime, BackendConfig::PrecisionMode p
             currentRate *= decreaseRate;
             totalComputeRate += currentRate * selectSize;
             mGroupWithComputeRate.emplace_back(std::make_pair(currentRate * selectSize, selectSize));
+            groupIndex--;
         }
         for (auto& g : mGroupWithComputeRate) {
             g.first = g.first / totalComputeRate;


### PR DESCRIPTION
测试时发现while循环中少加了一个条件，这样可能一直选中中核的group，应当--才能继续选中小核心