### PR TITLE
opt(RVV): Optimize max and min float functions with intrinsics

### DIFF
--- a/source/backend/cpu/riscv/rvv/MNNMaxFloat.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNMaxFloat.cpp
@@ -1,0 +1,25 @@
+#include <riscv_vector.h>
+#include <cfloat>
+
+#define UNIT 4
+
+void MNNMaxFloat(float *input, float *maxBuffer, int32_t inputCountUnit) {
+    const float init = -FLT_MAX;
+    for (int j = 0; j < UNIT; ++j) {
+        float local = init;
+        size_t i = 0;
+
+        while (i < (size_t)inputCountUnit) {
+            size_t vl = __riscv_vsetvl_e32m8(inputCountUnit - i);
+            float *p0 = input + (i * UNIT * 2) + j * 2;
+            float *p1 = p0 + 1;
+            vfloat32m8_t v0 = __riscv_vlse32_v_f32m8(p0, UNIT * 2 * sizeof(float), vl);
+            vfloat32m8_t v1 = __riscv_vlse32_v_f32m8(p1, UNIT * 2 * sizeof(float), vl);
+            vfloat32m8_t vmax = __riscv_vfmax_vv_f32m8(v0, v1, vl);
+            vfloat32m1_t vred = __riscv_vfredmax_vs_f32m8_f32m1(vmax, __riscv_vfmv_s_f_f32m1(local, 1), vl);
+            local = __riscv_vfmv_f_s_f32m1_f32(vred);
+            i += vl;
+        }
+        maxBuffer[j] = local;
+    }
+}

--- a/source/backend/cpu/riscv/rvv/MNNMinFloat.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNMinFloat.cpp
@@ -1,0 +1,25 @@
+#include <riscv_vector.h>
+#include <cfloat>
+
+#define UNIT 4
+
+void MNNMinFloat(float *input, float *minBuffer, int32_t inputCountUnit) {
+    const float init = FLT_MAX;
+    for (int j = 0; j < UNIT; ++j) {
+        float local = init;
+        size_t i = 0;
+
+        while (i < (size_t)inputCountUnit) {
+            size_t vl = __riscv_vsetvl_e32m8(inputCountUnit - i);
+            float *p0 = input + (i * UNIT * 2) + j * 2;
+            float *p1 = p0 + 1;
+            vfloat32m8_t v0 = __riscv_vlse32_v_f32m8(p0, UNIT * 2 * sizeof(float), vl);
+            vfloat32m8_t v1 = __riscv_vlse32_v_f32m8(p1, UNIT * 2 * sizeof(float), vl);
+            vfloat32m8_t vmin = __riscv_vfmin_vv_f32m8(v0, v1, vl);
+            vfloat32m1_t vred = __riscv_vfredmin_vs_f32m8_f32m1(vmin, __riscv_vfmv_s_f_f32m1(local, 1), vl);
+            local = __riscv_vfmv_f_s_f32m1_f32(vred);
+            i += vl;
+        }
+        minBuffer[j] = local;
+    }
+}


### PR DESCRIPTION
## Summary

Optimize MNNMaxFloat and MNNMinFloat using RVV intrinsics.

## Environment

* **Platform**: sg2044
* **OS**: EulixOS 3.0

## Benchmark

<details>
<summary>Click to expand full test logs</summary>

```text
[root@openeuler-riscv64 hebo]# ./test_max_float
inputCountUnit=4
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.04x
Test inputCountUnit=4: PASSED
inputCountUnit=1
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.00x
Test inputCountUnit=1: PASSED
inputCountUnit=3
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.00x
Test inputCountUnit=3: PASSED
inputCountUnit=65536
Scalar time: 0.0086 sec
RVV time   : 0.0017 sec
Speedup    : 5.02x
Test inputCountUnit=65536: PASSED
inputCountUnit=1000000
Scalar time: 0.1321 sec
RVV time   : 0.0338 sec
Speedup    : 3.91x
Test inputCountUnit=1000000: PASSED
inputCountUnit=10000000
Scalar time: 1.3309 sec
RVV time   : 0.3729 sec
Speedup    : 3.57x
Test inputCountUnit=10000000: PASSED

All tests PASSED
[root@openeuler-riscv64 hebo]# ./test_min_float
inputCountUnit=4
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.08x
Test inputCountUnit=4: PASSED
inputCountUnit=1
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.00x
Test inputCountUnit=1: PASSED
inputCountUnit=3
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 1.00x
Test inputCountUnit=3: PASSED
inputCountUnit=65536
Scalar time: 0.0105 sec
RVV time   : 0.0017 sec
Speedup    : 6.34x
Test inputCountUnit=65536: PASSED
inputCountUnit=1000000
Scalar time: 0.1587 sec
RVV time   : 0.0340 sec
Speedup    : 4.67x
Test inputCountUnit=1000000: PASSED
inputCountUnit=10000000
Scalar time: 1.5811 sec
RVV time   : 0.3776 sec
Speedup    : 4.19x
Test inputCountUnit=10000000: PASSED

All tests PASSED
````

\</details\>