### PR TITLE
opt(RVV): Optimize conv and strassen functions with intrinsics

### DIFF
--- a/source/backend/cpu/riscv/rvv/MNNConvRunForLineDepthwise.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNConvRunForLineDepthwise.cpp
@@ -1,0 +1,48 @@
+#include <riscv_vector.h>
+
+void MNNConvRunForLineDepthwise(
+    float* dst, const float* src, const float* weight, 
+    size_t width, size_t src_w_setup,
+    size_t fw, size_t fh, size_t dilateX_step, size_t dilateY_step, 
+    size_t height, size_t srcHStep, size_t dstHStep, 
+    const float* bias, const float* parameters) {
+    float minV = parameters[0];
+    float maxV = parameters[1];
+        ptrdiff_t srcByteStride = src_w_setup * sizeof(float);
+    ptrdiff_t dstByteStride = 4 * sizeof(float);
+    
+    for (size_t y = 0; y < height; ++y) {
+        const float* srcY = src + y * srcHStep;
+        float* dstY = dst + y * dstHStep;
+        size_t dx = 0;
+        
+        while (dx < width) {
+            size_t vl = __riscv_vsetvl_e32m8(width - dx);
+            
+            for (int c = 0; c < 4; ++c) {
+                vfloat32m8_t acc = __riscv_vfmv_v_f_f32m8(bias[c], vl);
+                const float* srcBase = srcY + dx * src_w_setup + c;
+                const float* weightPtr = weight + c;
+                
+                for (size_t fy = 0; fy < fh; ++fy) {
+                    const float* srcFy = srcBase + fy * dilateY_step;
+                    
+                    for (size_t fx = 0; fx < fw; ++fx) {
+                        float w = *weightPtr;
+                        weightPtr += 4;
+                        const float* srcFx = srcFy + fx * dilateX_step;
+                        vfloat32m8_t s = __riscv_vlse32_v_f32m8(srcFx, srcByteStride, vl);
+                        acc = __riscv_vfmacc_vf_f32m8(acc, w, s, vl);
+                    }
+                }
+                
+                acc = __riscv_vfmax_vf_f32m8(acc, minV, vl);
+                acc = __riscv_vfmin_vf_f32m8(acc, maxV, vl);
+                float* dstAddr = dstY + dx * 4 + c;
+                __riscv_vsse32_v_f32m8(dstAddr, dstByteStride, acc, vl);
+            }
+            
+            dx += vl;
+        }
+    }
+}

--- a/source/backend/cpu/riscv/rvv/MNNDeconvRunForUnitDepthWise.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNDeconvRunForUnitDepthWise.cpp
@@ -1,0 +1,42 @@
+#include <riscv_vector.h>
+
+void MNNDeconvRunForUnitDepthWise(
+    const float* dst, float* src, const float* weight, 
+    size_t fw, size_t fh,
+    size_t weightY_step, size_t dilateX_step, size_t dilateY_step) {    
+    const ptrdiff_t wStride = 4 * sizeof(float);
+    const ptrdiff_t sStride = dilateX_step * sizeof(float);
+    float d0 = dst[0], d1 = dst[1], d2 = dst[2], d3 = dst[3];
+    
+    for (size_t fy = 0; fy < fh; ++fy) {
+        float* srcY = src + fy * dilateY_step;
+        const float* weightY = weight + fy * weightY_step;
+        
+        size_t fx = 0;
+        while (fx < fw) {
+            size_t vl = __riscv_vsetvl_e32m8(fw - fx);
+            
+            vfloat32m8_t w = __riscv_vlse32_v_f32m8(weightY + 0 + fx * 4, wStride, vl);
+            vfloat32m8_t s = __riscv_vlse32_v_f32m8(srcY + 0 + fx * dilateX_step, sStride, vl);
+            s = __riscv_vfmacc_vf_f32m8(s, d0, w, vl);
+            __riscv_vsse32_v_f32m8(srcY + 0 + fx * dilateX_step, sStride, s, vl);
+            
+            w = __riscv_vlse32_v_f32m8(weightY + 1 + fx * 4, wStride, vl);
+            s = __riscv_vlse32_v_f32m8(srcY + 1 + fx * dilateX_step, sStride, vl);
+            s = __riscv_vfmacc_vf_f32m8(s, d1, w, vl);
+            __riscv_vsse32_v_f32m8(srcY + 1 + fx * dilateX_step, sStride, s, vl);
+            
+            w = __riscv_vlse32_v_f32m8(weightY + 2 + fx * 4, wStride, vl);
+            s = __riscv_vlse32_v_f32m8(srcY + 2 + fx * dilateX_step, sStride, vl);
+            s = __riscv_vfmacc_vf_f32m8(s, d2, w, vl);
+            __riscv_vsse32_v_f32m8(srcY + 2 + fx * dilateX_step, sStride, s, vl);
+            
+            w = __riscv_vlse32_v_f32m8(weightY + 3 + fx * 4, wStride, vl);
+            s = __riscv_vlse32_v_f32m8(srcY + 3 + fx * dilateX_step, sStride, vl);
+            s = __riscv_vfmacc_vf_f32m8(s, d3, w, vl);
+            __riscv_vsse32_v_f32m8(srcY + 3 + fx * dilateX_step, sStride, s, vl);
+            
+            fx += vl;
+        }
+    }
+}

--- a/source/backend/cpu/riscv/rvv/MNNStrassenMergeCFunction.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNStrassenMergeCFunction.cpp
@@ -1,0 +1,36 @@
+#include <riscv_vector.h>
+
+void MNNStrassenMergeCFunction(float *c11, float *c12, float *c21, float *c22, 
+                                float *xAddr, size_t cStride, size_t eSub, size_t hSub) {
+    for (int y = 0; y < hSub; ++y) {
+        float *c11Y = c11 + y * cStride;
+        float *c12Y = c12 + y * cStride;
+        float *c22Y = c22 + y * cStride;
+        float *c21Y = c21 + y * cStride;
+        float *xY = xAddr + y * eSub * 4;        
+        size_t totalElements = eSub * 4;
+        size_t p = 0;
+
+        while (p < totalElements) {
+            size_t vl = __riscv_vsetvl_e32m8(totalElements - p);
+            vfloat32m8_t t = __riscv_vle32_v_f32m8(xY + p, vl);
+            vfloat32m8_t tmp = __riscv_vle32_v_f32m8(c12Y + p, vl);
+            t = __riscv_vfadd_vv_f32m8(t, tmp, vl);
+            vfloat32m8_t c22v = __riscv_vle32_v_f32m8(c22Y + p, vl);
+
+            tmp = __riscv_vle32_v_f32m8(c11Y + p, vl);
+            tmp = __riscv_vfadd_vv_f32m8(tmp, c22v, vl);
+            tmp = __riscv_vfadd_vv_f32m8(tmp, t, vl);
+            __riscv_vse32_v_f32m8(c12Y + p, tmp, vl);
+            
+            tmp = __riscv_vle32_v_f32m8(c21Y + p, vl);
+            tmp = __riscv_vfadd_vv_f32m8(t, tmp, vl);
+            __riscv_vse32_v_f32m8(c21Y + p, tmp, vl);
+            
+            c22v = __riscv_vfadd_vv_f32m8(c22v, tmp, vl);
+            __riscv_vse32_v_f32m8(c22Y + p, c22v, vl);
+            
+            p += vl;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Optimize MNNConvRunForLineDepthwise, MNNDeconvRunForUnitDepthWise and MNNStrassenMergeCFunction using RVV intrinsics.

## Environment

* **Platform**: Banana PI BPI-F3
* **OS**: EulixOS 3.0

## Benchmark

<details>
<summary>Click to expand full test logs</summary>

```text
[root@EulixOS ~]# ./test_deconv_run_for_unit_depth_wise
fw=4, fh=4
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.31x
Test fw=4, fh=4: PASSED
fw=1, fh=1
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.00x
Test fw=1, fh=1: PASSED
fw=3, fh=3
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.24x
Test fw=3, fh=3: PASSED
fw=5, fh=5
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.32x
Test fw=5, fh=5: PASSED
fw=7, fh=7
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.42x
Test fw=7, fh=7: PASSED
fw=8, fh=8
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.66x
Test fw=8, fh=8: PASSED
fw=16, fh=1
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.44x
Test fw=16, fh=1: PASSED
fw=1, fh=16
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.11x
Test fw=1, fh=16: PASSED
fw=0, fh=4
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.00x
Test fw=0, fh=4: PASSED
fw=4, fh=0
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.00x
Test fw=4, fh=0: PASSED
fw=32, fh=32
Scalar time: 0.0001 sec
RVV time   : 0.0000 sec
Speedup    : 2.02x
Test fw=32, fh=32: PASSED
fw=128, fh=64
Scalar time: 0.0006 sec
RVV time   : 0.0005 sec
Speedup    : 1.20x
Test fw=128, fh=64: PASSED
fw=1024, fh=4
Scalar time: 0.0003 sec
RVV time   : 0.0001 sec
Speedup    : 3.18x
Test fw=1024, fh=4: PASSED
fw=256, fh=256
Scalar time: 0.0050 sec
RVV time   : 0.0018 sec
Speedup    : 2.81x
Test fw=256, fh=256: PASSED
fw=997, fh=1
Scalar time: 0.0001 sec
RVV time   : 0.0000 sec
Speedup    : 3.36x
Test fw=997, fh=1: PASSED
fw=1024, fh=1024
Scalar time: 0.0801 sec
RVV time   : 0.0279 sec
Speedup    : 2.87x
Test fw=1024, fh=1024: PASSED
fw=2048, fh=2048
Scalar time: 0.3204 sec
RVV time   : 0.1315 sec
Speedup    : 2.44x
Test fw=2048, fh=2048: PASSED
fw=4096, fh=4096
Scalar time: 1.2814 sec
RVV time   : 0.4732 sec
Speedup    : 2.71x
Test fw=4096, fh=4096: PASSED

All tests PASSED 
[root@EulixOS ~]# ./test_conv_run_for_line_depthwise
W=64, H=32, KW=3, KH=3
Scalar time: 0.0031 sec
RVV time   : 0.0002 sec
Speedup    : 13.61x
Test W=64 H=32 K=3x3: PASSED
W=16, H=16, KW=1, KH=1
Scalar time: 0.0001 sec
RVV time   : 0.0000 sec
Speedup    : 4.38x
Test W=16 H=16 K=1x1: PASSED
W=10, H=10, KW=5, KH=5
Scalar time: 0.0003 sec
RVV time   : 0.0002 sec
Speedup    : 2.06x
Test W=10 H=10 K=5x5: PASSED
W=128, H=64, KW=3, KH=3
Scalar time: 0.0126 sec
RVV time   : 0.0009 sec
Speedup    : 14.19x
Test W=128 H=64 K=3x3: PASSED
W=7, H=7, KW=3, KH=3
Scalar time: 0.0001 sec
RVV time   : 0.0000 sec
Speedup    : 1.62x
Test W=7 H=7 K=3x3: PASSED
W=1, H=1, KW=3, KH=3
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.38x
Test W=1 H=1 K=3x3: PASSED
W=32, H=32, KW=1, KH=5
Scalar time: 0.0011 sec
RVV time   : 0.0001 sec
Speedup    : 7.74x
Test W=32 H=32 K=1x5: PASSED
W=32, H=32, KW=5, KH=1
Scalar time: 0.0010 sec
RVV time   : 0.0001 sec
Speedup    : 7.67x
Test W=32 H=32 K=5x1: PASSED
W=256, H=128, KW=3, KH=3
Scalar time: 0.0504 sec
RVV time   : 0.0036 sec
Speedup    : 14.08x
Test W=256 H=128 K=3x3: PASSED
W=1920, H=1, KW=3, KH=3
Scalar time: 0.0029 sec
RVV time   : 0.0002 sec
Speedup    : 12.49x
Test W=1920 H=1 K=3x3: PASSED
W=100, H=100, KW=3, KH=3
Scalar time: 0.0150 sec
RVV time   : 0.0013 sec
Speedup    : 11.22x
Test W=100 H=100 K=3x3: PASSED
W=1024, H=1024, KW=4, KH=4
Scalar time: 2.4305 sec
RVV time   : 0.2001 sec
Speedup    : 12.14x
Test W=1024 H=1024 K=4x4: PASSED
W=2048, H=2048, KW=4, KH=4
Scalar time: 9.7223 sec
RVV time   : 0.8005 sec
Speedup    : 12.15x
Test W=2048 H=2048 K=4x4: PASSED
W=1024, H=1024, KW=10, KH=10
Scalar time: 12.6255 sec
RVV time   : 1.5203 sec
Speedup    : 8.30x
Test W=1024 H=1024 K=10x10: PASSED
W=2048, H=2048, KW=10, KH=10
Scalar time: 50.5326 sec
RVV time   : 6.0553 sec
Speedup    : 8.35x
Test W=2048 H=2048 K=10x10: PASSED
W=1024, H=1024, KW=7, KH=7
Scalar time: 6.4679 sec
RVV time   : 0.5984 sec
Speedup    : 10.81x
Test W=1024 H=1024 K=7x7: PASSED
W=1024, H=1024, KW=1, KH=7
Scalar time: 1.4948 sec
RVV time   : 0.2010 sec
Speedup    : 7.44x
Test W=1024 H=1024 K=1x7: PASSED
W=1024, H=1024, KW=7, KH=1
Scalar time: 1.2625 sec
RVV time   : 0.0920 sec
Speedup    : 13.72x
Test W=1024 H=1024 K=7x1: PASSED

All tests PASSED 
[root@EulixOS ~]# ./test_strassen_merge_c_function
cStride=16, eSub=4, hSub=4
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.41x
Test cStride=16, eSub=4, hSub=4: PASSED
cStride=4, eSub=1, hSub=1
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 2.00x
Test cStride=4, eSub=1, hSub=1: PASSED
cStride=12, eSub=3, hSub=3
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 2.33x
Test cStride=12, eSub=3, hSub=3: PASSED
cStride=16, eSub=4, hSub=5
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 3.50x
Test cStride=16, eSub=4, hSub=5: PASSED
cStride=28, eSub=7, hSub=4
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 7.88x
Test cStride=28, eSub=7, hSub=4: PASSED
cStride=4, eSub=0, hSub=0
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.00x
Test cStride=4, eSub=0, hSub=0: PASSED
cStride=4096, eSub=1024, hSub=1024
Scalar time: 0.5247 sec
RVV time   : 0.0410 sec
Speedup    : 12.81x
Test cStride=4096, eSub=1024, hSub=1024: PASSED
cStride=8192, eSub=2048, hSub=2048
Scalar time: 2.1006 sec
RVV time   : 0.1630 sec
Speedup    : 12.89x
Test cStride=8192, eSub=2048, hSub=2048: PASSED

All tests PASSED 
````

\</details\>