### PR TITLE
opt(RVV): Optimize resize functions with intrinsics

### DIFF
--- a/source/backend/cpu/riscv/rvv/CPUBilinearLineC4.cpp
+++ b/source/backend/cpu/riscv/rvv/CPUBilinearLineC4.cpp
@@ -1,0 +1,19 @@
+#include <riscv_vector.h>
+
+void CPUBilinearLineC4(float* dst, const float* A, const float* B, 
+                       const float* t, int8_t* zeroPoint, size_t number) {
+    float tf = *t;
+    float sf = 1.0f - tf;
+    size_t total = number << 2;
+    
+    size_t i = 0;
+    while (i < total) {
+        size_t vl = __riscv_vsetvl_e32m8(total - i);
+        vfloat32m8_t v = __riscv_vle32_v_f32m8(A + i, vl);
+        vfloat32m8_t result = __riscv_vfmul_vf_f32m8(v, sf, vl);
+        v = __riscv_vle32_v_f32m8(B + i, vl);
+        result = __riscv_vfmacc_vf_f32m8(result, tf, v, vl);
+        __riscv_vse32_v_f32m8(dst + i, result, vl);
+        i += vl;
+    }
+}

--- a/source/backend/cpu/riscv/rvv/CPUBilinearSampleC4.cpp
+++ b/source/backend/cpu/riscv/rvv/CPUBilinearSampleC4.cpp
@@ -1,0 +1,33 @@
+#include <riscv_vector.h>
+
+void CPUBilinearSampleC4(const float* src, float* dst, 
+                         const int32_t* position, const float* factor,
+                         int8_t* zeroPoint, size_t number) {
+    const int pack = 4;
+    size_t i = 0;
+    
+    while (i < number) {
+        size_t vl = __riscv_vsetvl_e32m8(number - i);
+        vfloat32m8_t vf = __riscv_vle32_v_f32m8(factor + i, vl);
+        
+        for (int c = 0; c < pack; c++) {
+            vuint32m8_t voff = __riscv_vsll_vx_u32m8(
+                __riscv_vreinterpret_v_i32m8_u32m8(
+                    __riscv_vlse32_v_i32m8(position + 2*i, 8, vl)), 4, vl);
+            voff = __riscv_vadd_vx_u32m8(voff, c * 4, vl);
+            vfloat32m8_t vr = __riscv_vluxei32_v_f32m8(src, voff, vl);
+            vfloat32m8_t vsf = __riscv_vfrsub_vf_f32m8(vf, 1.0f, vl);
+            vr = __riscv_vfmul_vv_f32m8(vr, vsf, vl);
+            
+            voff = __riscv_vsll_vx_u32m8(
+                __riscv_vreinterpret_v_i32m8_u32m8(
+                    __riscv_vlse32_v_i32m8(position + 2*i + 1, 8, vl)), 4, vl);
+            voff = __riscv_vadd_vx_u32m8(voff, c * 4, vl);
+            vsf = __riscv_vluxei32_v_f32m8(src, voff, vl);
+            vr = __riscv_vfmacc_vv_f32m8(vr, vf, vsf, vl);
+            __riscv_vsse32_v_f32m8(dst + i * pack + c, 16, vr, vl);
+        }
+        
+        i += vl;
+    }
+}

--- a/source/backend/cpu/riscv/rvv/MNNBilinearLineC8.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNBilinearLineC8.cpp
@@ -1,0 +1,40 @@
+#include <riscv_vector.h>
+
+void MNNBilinearLineC8(int8_t* dst, const int16_t* A, const int16_t* B, 
+                           const float* t, int8_t* zeroPoint, size_t number) {
+    int offset = *zeroPoint;
+    int8_t* dstPtr = dst;
+    
+    const int pack = 8;
+    const int16_t df = (int16_t)((*t) * 128.0f);
+    const int16_t sf = (int16_t)((1.0f - *t) * 128.0f);
+    const size_t total = number * pack;
+    const int32_t ROUND_HALF = 1 << 13;
+    
+    size_t vl;
+    for (size_t i = 0; i < total; i += vl) {
+        vl = __riscv_vsetvl_e16m4(total - i);
+        vint16m4_t v16 = __riscv_vle16_v_i16m4(A + i, vl);
+        vint32m8_t v32 = __riscv_vwmul_vx_i32m8(v16, sf, vl);
+        v16 = __riscv_vle16_v_i16m4(B + i, vl);
+        v32 = __riscv_vwmacc_vx_i32m8(v32, df, v16, vl);
+        
+        vbool4_t mask = __riscv_vmslt_vx_i32m8_b4(v32, 0, vl);
+        vint32m8_t tmp = __riscv_vadd_vx_i32m8(v32, ROUND_HALF, vl);
+        v32 = __riscv_vsub_vx_i32m8(v32, ROUND_HALF, vl);
+        v32 = __riscv_vmerge_vvm_i32m8(tmp, v32, mask, vl);
+        
+        tmp = __riscv_vsra_vx_i32m8(v32, 14, vl);
+                mask = __riscv_vmslt_vx_i32m8_b4(v32, 0, vl);
+        v32 = __riscv_vand_vx_i32m8(v32, 0x3FFF, vl);
+        vbool4_t hasRem = __riscv_vmsne_vx_i32m8_b4(v32, 0, vl);
+        mask = __riscv_vmand_mm_b4(mask, hasRem, vl);
+        
+        v32 = __riscv_vadd_vx_i32m8_mu(mask, tmp, tmp, 1, vl);
+                v32 = __riscv_vadd_vx_i32m8(v32, offset, vl);
+                v16 = __riscv_vnsra_wx_i16m4(v32, 0, vl);
+        vint8m2_t v8 = __riscv_vnsra_wx_i8m2(v16, 0, vl);
+        
+        __riscv_vse8_v_i8m2(dstPtr + i, v8, vl);
+    }
+}

--- a/source/backend/cpu/riscv/rvv/MNNBilinearSampleC8.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNBilinearSampleC8.cpp
@@ -1,0 +1,49 @@
+#include <riscv_vector.h>
+
+void MNNBilinearSampleC8(const int8_t* src, int16_t* dst, 
+                             const int32_t* position, const float* factor,
+                             int8_t* zeroPoint, size_t number) {
+    int16_t offset = (int16_t)(*zeroPoint);
+    const int pack = 8;
+    size_t i = 0;
+    
+    while (i < number) {
+        size_t vl = __riscv_vsetvl_e32m8(number - i);
+        vfloat32m8_t vf = __riscv_vle32_v_f32m8(factor + i, vl);
+        vint16m4_t vdf = __riscv_vnsra_wx_i16m4(
+            __riscv_vfcvt_rtz_x_f_v_i32m8(
+                __riscv_vfmul_vf_f32m8(vf, 128.0f, vl), vl), 0, vl);
+        vint16m4_t vsf = __riscv_vnsra_wx_i16m4(
+            __riscv_vfcvt_rtz_x_f_v_i32m8(
+                __riscv_vfmul_vf_f32m8(
+                    __riscv_vfrsub_vf_f32m8(vf, 1.0f, vl), 128.0f, vl), vl), 0, vl);
+        
+        for (int c = 0; c < pack; c++) {
+            vuint32m8_t voff = __riscv_vadd_vx_u32m8(
+                __riscv_vsll_vx_u32m8(
+                    __riscv_vreinterpret_v_i32m8_u32m8(
+                        __riscv_vlse32_v_i32m8(position + 2*i, 8, vl)), 3, vl), 
+                c, vl);
+            
+            vint16m4_t va = __riscv_vsub_vx_i16m4(
+                __riscv_vsext_vf2_i16m4(
+                    __riscv_vluxei32_v_i8m2(src, voff, vl), vl), offset, vl);
+            
+            vint32m8_t vr = __riscv_vwmul_vv_i32m8(va, vsf, vl);
+                        voff = __riscv_vadd_vx_u32m8(
+                __riscv_vsll_vx_u32m8(
+                    __riscv_vreinterpret_v_i32m8_u32m8(
+                        __riscv_vlse32_v_i32m8(position + 2*i + 1, 8, vl)), 3, vl), 
+                c, vl);
+            
+            vint16m4_t vb = __riscv_vsub_vx_i16m4(
+                __riscv_vsext_vf2_i16m4(
+                    __riscv_vluxei32_v_i8m2(src, voff, vl), vl), offset, vl);
+            vr = __riscv_vwmacc_vv_i32m8(vr, vb, vdf, vl);
+            __riscv_vsse16_v_i16m4(dst + i * pack + c, 16, 
+                __riscv_vnsra_wx_i16m4(vr, 0, vl), vl);
+        }
+        
+        i += vl;
+    }
+}

--- a/source/backend/cpu/riscv/rvv/MNNCubicLineC16.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNCubicLineC16.cpp
@@ -1,0 +1,53 @@
+#include <riscv_vector.h>
+
+void MNNCubicLineC16(int8_t* dst, const float* A, const float* B, 
+                     const float* C, const float* D, float* t, 
+                     int8_t* zeroPoint, size_t number, 
+                     ssize_t minValue, ssize_t maxValue) {
+    const float f = *t;
+    const float t2 = f * f, t3 = t2 * f;
+    const float b0 = 1.0f - 2.25f * t2 + 1.25f * t3;
+    const float t1 = 1.0f - f, t1_2 = t1 * t1;
+    const float c0 = 1.0f - 2.25f * t1_2 + 1.25f * t1_2 * t1;
+    const float ta = 1.0f + f, ta2 = ta * ta;
+    const float a0 = 3.0f - 6.0f * ta + 3.75f * ta2 - 0.75f * ta2 * ta;
+    const float td = 2.0f - f, td2 = td * td;
+    const float d0 = 3.0f - 6.0f * td + 3.75f * td2 - 0.75f * td2 * td;    
+    const int offset = *zeroPoint;
+    const int minVal = (int)minValue;
+    const int maxVal = (int)maxValue;
+    const size_t total = number << 4;
+    size_t i = 0;
+    
+    while (i < total) {
+        size_t vl = __riscv_vsetvl_e32m8(total - i);
+        vfloat32m8_t v, acc;
+        
+        v   = __riscv_vle32_v_f32m8(A + i, vl);
+        acc = __riscv_vfmul_vf_f32m8(v, a0, vl);
+        
+        v   = __riscv_vle32_v_f32m8(B + i, vl);
+        acc = __riscv_vfmacc_vf_f32m8(acc, b0, v, vl);
+        
+        v   = __riscv_vle32_v_f32m8(C + i, vl);
+        acc = __riscv_vfmacc_vf_f32m8(acc, c0, v, vl);
+        
+        v   = __riscv_vle32_v_f32m8(D + i, vl);
+        acc = __riscv_vfmacc_vf_f32m8(acc, d0, v, vl);
+        
+        vfloat32m8_t half = __riscv_vfmv_v_f_f32m8(0.5f, vl);
+        vfloat32m8_t signHalf = __riscv_vfsgnj_vv_f32m8(half, acc, vl);
+        acc = __riscv_vfadd_vv_f32m8(acc, signHalf, vl);
+        
+        vint32m8_t vint = __riscv_vfcvt_rtz_x_f_v_i32m8(acc, vl);
+        vint = __riscv_vadd_vx_i32m8(vint, offset, vl);
+        vint = __riscv_vmax_vx_i32m8(vint, minVal, vl);
+        vint = __riscv_vmin_vx_i32m8(vint, maxVal, vl);
+        
+        vint16m4_t vi16 = __riscv_vncvt_x_x_w_i16m4(vint, vl);
+        vint8m2_t  vi8  = __riscv_vncvt_x_x_w_i8m2(vi16, vl);
+        __riscv_vse8_v_i8m2(dst + i, vi8, vl);
+        
+        i += vl;
+    }
+}

--- a/source/backend/cpu/riscv/rvv/MNNCubicLineC4.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNCubicLineC4.cpp
@@ -1,0 +1,38 @@
+#include <riscv_vector.h>
+
+void MNNCubicLineC4(float* dst, const float* A, const float* B, 
+                        const float* C, const float* D, float* t,
+                        int8_t* zeroPoint, size_t number, 
+                        ssize_t minValue, ssize_t maxValue) {
+    const float f = *t;
+    const float t2 = f * f, t3 = t2 * f;
+    const float b0 = 1.0f - 2.25f * t2 + 1.25f * t3;
+    const float t1 = 1.0f - f, t1_2 = t1 * t1;
+    const float c0 = 1.0f - 2.25f * t1_2 + 1.25f * t1_2 * t1;
+    const float ta = 1.0f + f, ta2 = ta * ta;
+    const float a0 = 3.0f - 6.0f * ta + 3.75f * ta2 - 0.75f * ta2 * ta;
+    const float td = 2.0f - f, td2 = td * td;
+    const float d0 = 3.0f - 6.0f * td + 3.75f * td2 - 0.75f * td2 * td;
+    const size_t total = number << 2;
+    size_t i = 0;
+    
+    while (i < total) {
+        size_t vl = __riscv_vsetvl_e32m8(total - i);
+        vfloat32m8_t v, acc;
+        
+        v   = __riscv_vle32_v_f32m8(A + i, vl);
+        acc = __riscv_vfmul_vf_f32m8(v, a0, vl);
+        
+        v   = __riscv_vle32_v_f32m8(B + i, vl);
+        acc = __riscv_vfmacc_vf_f32m8(acc, b0, v, vl);
+        
+        v   = __riscv_vle32_v_f32m8(C + i, vl);
+        acc = __riscv_vfmacc_vf_f32m8(acc, c0, v, vl);
+        
+        v   = __riscv_vle32_v_f32m8(D + i, vl);
+        acc = __riscv_vfmacc_vf_f32m8(acc, d0, v, vl);
+        
+        __riscv_vse32_v_f32m8(dst + i, acc, vl);
+        i += vl;
+    }
+}

--- a/source/backend/cpu/riscv/rvv/MNNCubicSampleC16.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNCubicSampleC16.cpp
@@ -1,0 +1,79 @@
+#include <riscv_vector.h>
+
+void MNNCubicSampleC16(const int8_t* src, float* dst, 
+                        int32_t* position, const float* factor,
+                        int8_t* zeroPoint, size_t number) {
+    const int pack = 16;
+    int8_t zp = *zeroPoint;
+    size_t i = 0;
+    
+    while (i < number) {
+        size_t vl = __riscv_vsetvl_e32m8(number - i);
+        vfloat32m8_t vt = __riscv_vle32_v_f32m8(factor + i, vl);
+        
+        for (int c = 0; c < pack; c++) {
+            vuint32m8_t voff = __riscv_vsll_vx_u32m8(
+                __riscv_vreinterpret_v_i32m8_u32m8(
+                    __riscv_vlse32_v_i32m8(position + 4*i + 0, 16, vl)), 4, vl);
+            voff = __riscv_vadd_vx_u32m8(voff, c, vl);
+            
+            vint8m2_t vtmp_i8 = __riscv_vluxei32_v_i8m2(src, voff, vl);
+            vint16m4_t vtmp_i16 = __riscv_vwsub_vx_i16m4(vtmp_i8, zp, vl);
+            vfloat32m8_t vtmp = __riscv_vfcvt_f_x_v_f32m8(
+                __riscv_vwcvt_x_x_v_i32m8(vtmp_i16, vl), vl);
+            
+            vfloat32m8_t va = __riscv_vfmul_vf_f32m8(vtmp, -0.75f, vl);
+            vfloat32m8_t vb = __riscv_vfmul_vf_f32m8(vtmp, 1.5f, vl);
+            vfloat32m8_t vc = vtmp;
+            
+            voff = __riscv_vsll_vx_u32m8(
+                __riscv_vreinterpret_v_i32m8_u32m8(
+                    __riscv_vlse32_v_i32m8(position + 4*i + 1, 16, vl)), 4, vl);
+            voff = __riscv_vadd_vx_u32m8(voff, c, vl);
+            
+            vtmp_i8 = __riscv_vluxei32_v_i8m2(src, voff, vl);
+            vtmp_i16 = __riscv_vwsub_vx_i16m4(vtmp_i8, zp, vl);
+            vfloat32m8_t vB = __riscv_vfcvt_f_x_v_f32m8(
+                __riscv_vwcvt_x_x_v_i32m8(vtmp_i16, vl), vl);
+            
+            va = __riscv_vfmacc_vf_f32m8(va, 1.25f, vB, vl);
+            vb = __riscv_vfmacc_vf_f32m8(vb, -2.25f, vB, vl);
+            
+            voff = __riscv_vsll_vx_u32m8(
+                __riscv_vreinterpret_v_i32m8_u32m8(
+                    __riscv_vlse32_v_i32m8(position + 4*i + 2, 16, vl)), 4, vl);
+            voff = __riscv_vadd_vx_u32m8(voff, c, vl);
+            
+            vtmp_i8 = __riscv_vluxei32_v_i8m2(src, voff, vl);
+            vtmp_i16 = __riscv_vwsub_vx_i16m4(vtmp_i8, zp, vl);
+            vtmp = __riscv_vfcvt_f_x_v_f32m8(
+                __riscv_vwcvt_x_x_v_i32m8(vtmp_i16, vl), vl);
+            
+            va = __riscv_vfmacc_vf_f32m8(va, -1.25f, vtmp, vl);
+            vb = __riscv_vfmacc_vf_f32m8(vb, 1.5f, vtmp, vl);
+            vc = __riscv_vfsub_vv_f32m8(vtmp, vc, vl);
+            vc = __riscv_vfmul_vf_f32m8(vc, 0.75f, vl);
+            
+            voff = __riscv_vsll_vx_u32m8(
+                __riscv_vreinterpret_v_i32m8_u32m8(
+                    __riscv_vlse32_v_i32m8(position + 4*i + 3, 16, vl)), 4, vl);
+            voff = __riscv_vadd_vx_u32m8(voff, c, vl);
+            
+            vtmp_i8 = __riscv_vluxei32_v_i8m2(src, voff, vl);
+            vtmp_i16 = __riscv_vwsub_vx_i16m4(vtmp_i8, zp, vl);
+            vtmp = __riscv_vfcvt_f_x_v_f32m8(
+                __riscv_vwcvt_x_x_v_i32m8(vtmp_i16, vl), vl);
+            
+            va = __riscv_vfmacc_vf_f32m8(va, 0.75f, vtmp, vl);
+            vb = __riscv_vfmacc_vf_f32m8(vb, -0.75f, vtmp, vl);
+            
+            va = __riscv_vfmadd_vv_f32m8(va, vt, vb, vl);
+            va = __riscv_vfmadd_vv_f32m8(va, vt, vc, vl);
+            va = __riscv_vfmadd_vv_f32m8(va, vt, vB, vl);
+            
+            __riscv_vsse32_v_f32m8(dst + i * pack + c, pack * sizeof(float), va, vl);
+        }
+        
+        i += vl;
+    }
+}

--- a/source/backend/cpu/riscv/rvv/MNNCubicSampleC4.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNCubicSampleC4.cpp
@@ -1,0 +1,62 @@
+#include <riscv_vector.h>
+
+void MNNCubicSampleC4(const float* src, float* dst, 
+                              int32_t* position, const float* factor,
+                              int8_t* zeroPoint, size_t number) {
+    const int pack = 4;
+    size_t i = 0;
+    
+    while (i < number) {
+        size_t vl = __riscv_vsetvl_e32m8(number - i);
+        vfloat32m8_t vt = __riscv_vle32_v_f32m8(factor + i, vl);
+        
+        for (int c = 0; c < pack; c++) {
+            vuint32m8_t voff = __riscv_vsll_vx_u32m8(
+                __riscv_vreinterpret_v_i32m8_u32m8(
+                    __riscv_vlse32_v_i32m8(position + 4*i + 0, 16, vl)), 4, vl);
+            voff = __riscv_vadd_vx_u32m8(voff, c * 4, vl);
+            vfloat32m8_t vtmp = __riscv_vluxei32_v_f32m8(src, voff, vl);
+            
+            vfloat32m8_t va = __riscv_vfmul_vf_f32m8(vtmp, -0.75f, vl);
+            vfloat32m8_t vb = __riscv_vfmul_vf_f32m8(vtmp, 1.5f, vl);
+            vfloat32m8_t vc = vtmp;
+            
+            voff = __riscv_vsll_vx_u32m8(
+                __riscv_vreinterpret_v_i32m8_u32m8(
+                    __riscv_vlse32_v_i32m8(position + 4*i + 1, 16, vl)), 4, vl);
+            voff = __riscv_vadd_vx_u32m8(voff, c * 4, vl);
+            vfloat32m8_t vB = __riscv_vluxei32_v_f32m8(src, voff, vl);
+            
+            va = __riscv_vfmacc_vf_f32m8(va, 1.25f, vB, vl);
+            vb = __riscv_vfmacc_vf_f32m8(vb, -2.25f, vB, vl);
+            
+            voff = __riscv_vsll_vx_u32m8(
+                __riscv_vreinterpret_v_i32m8_u32m8(
+                    __riscv_vlse32_v_i32m8(position + 4*i + 2, 16, vl)), 4, vl);
+            voff = __riscv_vadd_vx_u32m8(voff, c * 4, vl);
+            vtmp = __riscv_vluxei32_v_f32m8(src, voff, vl);
+            
+            va = __riscv_vfmacc_vf_f32m8(va, -1.25f, vtmp, vl);
+            vb = __riscv_vfmacc_vf_f32m8(vb, 1.5f, vtmp, vl);
+            vc = __riscv_vfsub_vv_f32m8(vtmp, vc, vl);
+            vc = __riscv_vfmul_vf_f32m8(vc, 0.75f, vl);
+            
+            voff = __riscv_vsll_vx_u32m8(
+                __riscv_vreinterpret_v_i32m8_u32m8(
+                    __riscv_vlse32_v_i32m8(position + 4*i + 3, 16, vl)), 4, vl);
+            voff = __riscv_vadd_vx_u32m8(voff, c * 4, vl);
+            vtmp = __riscv_vluxei32_v_f32m8(src, voff, vl);
+            
+            va = __riscv_vfmacc_vf_f32m8(va, 0.75f, vtmp, vl);
+            vb = __riscv_vfmacc_vf_f32m8(vb, -0.75f, vtmp, vl);
+            
+            va = __riscv_vfmadd_vv_f32m8(va, vt, vb, vl);
+            va = __riscv_vfmadd_vv_f32m8(va, vt, vc, vl);
+            va = __riscv_vfmadd_vv_f32m8(va, vt, vB, vl);
+            
+            __riscv_vsse32_v_f32m8(dst + i * pack + c, 16, va, vl);
+        }
+        
+        i += vl;
+    }
+}


### PR DESCRIPTION
## Summary

Optimize CPUBilinearLineC4, CPUBilinearSampleC4, MNNBilinearLineC8, MNNBilinearSampleC8, MNNCubicLineC4, MNNCubicLineC16, MNNCubicSampleC4 and MNNCubicSampleC16 using RVV intrinsics.

## Environment

* **Platform**: Banana PI BPI-F3
* **OS**: EulixOS 3.0

## Benchmark

<details>
<summary>Click to expand full test logs</summary>

```text
[root@EulixOS ~]# ./test_cpu_bilinear_sample_c4
number=1
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.09x
Test number=1: PASSED
number=3
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.33x
Test number=3: PASSED
number=4
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.24x
Test number=4: PASSED
number=100
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 2.35x
Test number=100: PASSED
number=1024
Scalar time: 0.0002 sec
RVV time   : 0.0001 sec
Speedup    : 2.50x
Test number=1024: PASSED
number=65536
Scalar time: 0.0375 sec
RVV time   : 0.0282 sec
Speedup    : 1.33x
Test number=65536: PASSED
number=1000000
Scalar time: 0.6814 sec
RVV time   : 0.5264 sec
Speedup    : 1.29x
Test number=1000000: PASSED
number=10000000
Scalar time: 8.5642 sec
RVV time   : 6.2049 sec
Speedup    : 1.38x
Test number=10000000: PASSED

All tests PASSED 
[root@EulixOS ~]# ./test_cpu_bilinear_line_c4
number=1 (elements=4)
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.24x
Test number=1: PASSED
number=3 (elements=12)
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.00x
Test number=3: PASSED
number=16 (elements=64)
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 3.00x
Test number=16: PASSED
number=256 (elements=1024)
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 4.88x
Test number=256: PASSED
number=65536 (elements=262144)
Scalar time: 0.0070 sec
RVV time   : 0.0011 sec
Speedup    : 6.13x
Test number=65536: PASSED
number=1000000 (elements=4000000)
Scalar time: 0.0971 sec
RVV time   : 0.0165 sec
Speedup    : 5.88x
Test number=1000000: PASSED
number=10000000 (elements=40000000)
Scalar time: 0.9737 sec
RVV time   : 0.1657 sec
Speedup    : 5.88x
Test number=10000000: PASSED

All tests PASSED 
[root@EulixOS ~]# ./test_cubic_sample_c4
number=1
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.15x
Test number=1: PASSED
number=3
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.19x
Test number=3: PASSED
number=4
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.57x
Test number=4: PASSED
number=100
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 2.20x
Test number=100: PASSED
number=1024
Scalar time: 0.0005 sec
RVV time   : 0.0003 sec
Speedup    : 1.48x
Test number=1024: PASSED
number=65536
Scalar time: 0.0840 sec
RVV time   : 0.0638 sec
Speedup    : 1.32x
Test number=65536: PASSED
number=1000000
Scalar time: 1.4451 sec
RVV time   : 1.1162 sec
Speedup    : 1.29x
Test number=1000000: PASSED
number=10000000
Scalar time: 17.2672 sec
RVV time   : 13.3197 sec
Speedup    : 1.30x
Test number=10000000: PASSED

All tests PASSED 
[root@EulixOS ~]# ./test_cubic_line_c4
number=1 (elements=4)
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.19x
Test number=1: PASSED
number=3 (elements=12)
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 2.25x
Test number=3: PASSED
number=16 (elements=64)
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 9.50x
Test number=16: PASSED
number=256 (elements=1024)
Scalar time: 0.0001 sec
RVV time   : 0.0000 sec
Speedup    : 12.22x
Test number=256: PASSED
number=65536 (elements=262144)
Scalar time: 0.0338 sec
RVV time   : 0.0018 sec
Speedup    : 18.72x
Test number=65536: PASSED
number=1000000 (elements=4000000)
Scalar time: 0.5043 sec
RVV time   : 0.0267 sec
Speedup    : 18.86x
Test number=1000000: PASSED
number=10000000 (elements=40000000)
Scalar time: 5.0435 sec
RVV time   : 0.2670 sec
Speedup    : 18.89x
Test number=10000000: PASSED

All tests PASSED 
[root@EulixOS ~]# ./test_cubic_sample_c16
number=1
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.04x
Test number=1: PASSED
number=3
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.13x
Test number=3: PASSED
number=16
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.43x
Test number=16: PASSED
number=100
Scalar time: 0.0001 sec
RVV time   : 0.0001 sec
Speedup    : 1.22x
Test number=100: PASSED
number=1024
Scalar time: 0.0011 sec
RVV time   : 0.0008 sec
Speedup    : 1.31x
Test number=1024: PASSED
number=65536
Scalar time: 0.1328 sec
RVV time   : 0.1153 sec
Speedup    : 1.15x
Test number=65536: PASSED
number=1000000
Scalar time: 2.3127 sec
RVV time   : 2.1074 sec
Speedup    : 1.10x
Test number=1000000: PASSED
number=10000000
Scalar time: 28.7091 sec
RVV time   : 24.0172 sec
Speedup    : 1.20x
Test number=10000000: PASSED

All tests PASSED 
[root@EulixOS ~]# ./test_cubic_line_c16
number=1 (elements=16)
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.16x
Test number=1: PASSED
number=3 (elements=48)
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 1.33x
Test number=3: PASSED
number=16 (elements=256)
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 2.32x
Test number=16: PASSED
number=256 (elements=4096)
Scalar time: 0.0002 sec
RVV time   : 0.0001 sec
Speedup    : 3.35x
Test number=256: PASSED
number=65536 (elements=1048576)
Scalar time: 0.0546 sec
RVV time   : 0.0131 sec
Speedup    : 4.17x
Test number=65536: PASSED
number=1000000 (elements=16000000)
Scalar time: 0.8487 sec
RVV time   : 0.3470 sec
Speedup    : 2.45x
Test number=1000000: PASSED
number=10000000 (elements=160000000)
Scalar time: 8.3221 sec
RVV time   : 1.9775 sec
Speedup    : 4.21x
Test number=10000000: PASSED

All tests PASSED 
[root@EulixOS ~]# ./test_bilinear_sample_c8
number=1
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.07x
Test number=1: PASSED
number=3
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.31x
Test number=3: PASSED
number=8
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.59x
Test number=8: PASSED
number=9
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.81x
Test number=9: PASSED
number=100
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 2.69x
Test number=100: PASSED
number=1024
Scalar time: 0.0004 sec
RVV time   : 0.0001 sec
Speedup    : 4.15x
Test number=1024: PASSED
number=65536
Scalar time: 0.0484 sec
RVV time   : 0.0287 sec
Speedup    : 1.69x
Test number=65536: PASSED
number=1000000
Scalar time: 0.9063 sec
RVV time   : 0.5891 sec
Speedup    : 1.54x
Test number=1000000: PASSED
number=10000000
Scalar time: 11.0285 sec
RVV time   : 6.5783 sec
Speedup    : 1.68x
Test number=10000000: PASSED

All tests PASSED 
[root@EulixOS ~]# ./test_bilinear_line_c8
number=1
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.10x
Test number=1: PASSED
number=3
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 0.50x
Test number=3: PASSED
number=8
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 3.20x
Test number=8: PASSED
number=9
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 2.12x
Test number=9: PASSED
number=100
Scalar time: 0.0000 sec
RVV time   : 0.0000 sec
Speedup    : 4.20x
Test number=100: PASSED
number=1024
Scalar time: 0.0004 sec
RVV time   : 0.0001 sec
Speedup    : 4.83x
Test number=1024: PASSED
number=65536
Scalar time: 0.0272 sec
RVV time   : 0.0055 sec
Speedup    : 4.93x
Test number=65536: PASSED
number=1000000
Scalar time: 0.4100 sec
RVV time   : 0.0840 sec
Speedup    : 4.88x
Test number=1000000: PASSED
number=10000000
Scalar time: 4.0944 sec
RVV time   : 0.8405 sec
Speedup    : 4.87x
Test number=10000000: PASSED

All tests PASSED 
````

\</details\>