### PR TITLE
fix(rvv): add macro protection and system headers for cross-platform compatibility

### DIFF
--- a/source/backend/cpu/compute/ImageProcessFunction.cpp
+++ b/source/backend/cpu/compute/ImageProcessFunction.cpp
@@ -43,6 +43,7 @@ void MNNRGBAToBGRAFast(const unsigned char* source, unsigned char* dest, size_t 
 void MNNRGBAToBGRFast(const unsigned char* source, unsigned char* dest, size_t count);
 }
 
+#ifndef MNN_USE_RVV
 void MNNGRAYToC4(const unsigned char* source, unsigned char* dest, size_t count) {
     int sta = 0;
 #ifdef MNN_USE_NEON
@@ -549,6 +550,7 @@ void MNNNV21ToBGR(const unsigned char* source, unsigned char* dest, size_t count
         dst[3 * i + 2] = (uint8_t)R;
     }
 }
+#endif
 
 void MNNC1ToFloatC1(const unsigned char* source, float* dest, const float* mean, const float* normal, size_t count) {
 #ifdef MNN_USE_NEON

--- a/source/backend/cpu/riscv/rvv/MNNCubicLineC16.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNCubicLineC16.cpp
@@ -1,4 +1,7 @@
 #include <riscv_vector.h>
+#if defined(__linux__) || defined(__QNXNTO__)
+ #include <sys/types.h>
+#endif
 
 void MNNCubicLineC16(int8_t* dst, const float* A, const float* B, 
                      const float* C, const float* D, float* t, 

--- a/source/backend/cpu/riscv/rvv/MNNCubicLineC4.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNCubicLineC4.cpp
@@ -1,4 +1,7 @@
 #include <riscv_vector.h>
+#if defined(__linux__) || defined(__QNXNTO__)
+ #include <sys/types.h>
+#endif
 
 void MNNCubicLineC4(float* dst, const float* A, const float* B, 
                         const float* C, const float* D, float* t,


### PR DESCRIPTION
### Changes

- Added #ifndef MNN_USE_RVV protection in ImageProcessFunction.cpp.
- Included <sys/types.h> in RVV function files for Linux and QNX platforms.

### Verification

* Successfully verified the build on SG2044.