### PR TITLE
cache `MNN_DEPS` to `MNN_LIBS`, `MNN_INCLUDES` to `MNN_INCLUDE_DIRS` for external projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -940,6 +940,11 @@ if (NOT MNN_BUILD_SHARED_LIBS)
 endif()
 list(APPEND MNN_TARGETS MNN)
 list(REMOVE_ITEM MNN_TARGETS MNN)
+
+# Cache MNN_DEPS and MNN_INCLUDES for external projects
+set(MNN_LIBS ${MNN_DEPS} CACHE INTERNAL "MNN targets")
+set(MNN_INCLUDE_DIRS ${MNN_INCLUDES} CACHE INTERNAL "MNN include directories")
+
 IF(MNN_BUILD_DEMO)
 include(${CMAKE_CURRENT_LIST_DIR}/demo/exec/CMakeLists.txt)
 ENDIF()


### PR DESCRIPTION
fixes: #4105 

## Motivation

`MNN_DEPS` and `MNN_INCLUDES` are not cached, so unseeable to external projects that introduce `MNN` via `FetchContent`.

## Current solution
It's also possible to get the desired variables but hacky and `FetchContent_Populate` is deprecated.
```cmake
include(FetchContent)
FetchContent_Declare(
        mnn
        URL https://github.com/alibaba/MNN/archive/refs/tags/${MNN_VERSION}.tar.gz
)
# FetchContent_MakeAvailable(mnn)
FetchContent_GetProperties(mnn)
if(NOT mnn_POPULATED)
    FetchContent_Populate(mnn)
    add_subdirectory(${mnn_SOURCE_DIR} ${mnn_BINARY_DIR})
    
    get_directory_property(SUB_MNN_DEPS 
        DIRECTORY ${mnn_SOURCE_DIR} 
        DEFINITION MNN_DEPS
    )
    set(MNN_DEPS ${SUB_MNN_DEPS} CACHE INTERNAL "Captured from MNN subdirectory")
endif()
```

## New solution proposed in this PR
Cache MNN_DEPS and MNN_INCLUDES by creating 2 new variables `MNN_LIBS` and `MNN_INCLUDE_DIRS`
```cmake
# Cache MNN_DEPS and MNN_INCLUDES for external projects
set(MNN_LIBS ${MNN_DEPS} CACHE INTERNAL "MNN targets")
set(MNN_INCLUDE_DIRS ${MNN_INCLUDES} CACHE INTERNAL "MNN include directories")
```

The cached variables will be available in parent projects and theoretically it's a minor change, the added variables are new and not used in the entire original MNN project.