### PR TITLE
Fix ./tools/script/get_model.sh error, Enable gzip compression for cu…

### DIFF
--- a/tools/script/get_model.sh
+++ b/tools/script/get_model.sh
@@ -16,7 +16,7 @@ download() {
 
   name=`basename $2`
   echo "downloading $name ..."
-  status=`curl $1 -s -w %{http_code} -o $2`
+  status=`curl --compressed $1 -s -w %{http_code} -o $2`
   if (( status == 200 )); then
     return 0
   else


### PR DESCRIPTION
…rl download

在Mac M1上测试，发现curl下载的数据是gzip而不是原始文件，加上`--compressed` 强制解压。

复现方式,：
```
╰─$ ./tools/script/get_model.sh                                                                                                 130 ↵
download and convert build/mobilenet_v1.caffe.caffemodel build/mobilenet_v1.caffe.prototxt
downloading mobilenet_v1.caffe.caffemodel ...
(using proxy: socks5://127.0.0.1:4781)
############################################################################################################################### 100.0%
download mobilenet_v1.caffe.caffemodel successful (size: 17027058 bytes)
downloading mobilenet_v1.caffe.prototxt ...
(using proxy: socks5://127.0.0.1:4781)
############################################################################################################################### 100.0%
download mobilenet_v1.caffe.prototxt successful (size: 1577 bytes)
hw.cpufamily: 3660830781 , size = 4
The device support i8sdot:1, support fp16:1, support i8mm: 0
Start to Convert Other Model Format To MNN Model..., target version: 2.8
[libprotobuf ERROR /Volumes/SSD1T/work_ssd/my_project/mediapipe-lite-project/MNN-2.8.0/3rd_party/protobuf/src/google/protobuf/text_format.cc:335] Error parsing text-format caffe.NetParameter: 1:1: Invalid control characters encountered in text.
[libprotobuf ERROR /Volumes/SSD1T/work_ssd/my_project/mediapipe-lite-project/MNN-2.8.0/3rd_party/protobuf/src/google/protobuf/text_format.cc:335] Error parsing text-format caffe.NetParameter: 1:2: Interpreting non ascii codepoint 139.
[libprotobuf ERROR /Volumes/SSD1T/work_ssd/my_project/mediapipe-lite-project/MNN-2.8.0/3rd_party/protobuf/src/google/protobuf/text_format.cc:335] Error parsing text-format caffe.NetParameter: 1:2: Expected identifier, got: �
[22:04:45] /Volumes/SSD1T/work_ssd/my_project/mediapipe-lite-project/MNN-2.8.0/tools/converter/source/caffe/caffeConverter.cpp:27: Check failed: succ ==> read_proto_from_text failed
[22:04:45] /Volumes/SSD1T/work_ssd/my_project/mediapipe-lite-project/MNN-2.8.0/tools/converter/source/caffe/caffeConverter.cpp:30: Check failed: succ ==> read_proto_from_binary failed
[ERROR] Model file is not caffe model.
[ERROR] Convert error, please check your file format.

# 查看文件格式
file ./resource/build/mobilenet_v1.caffe.prototxt mobilenet_v1.caffe.prototxt: gzip compressed data, from Unix, original size modulo 2^32 28105 # 显示是gzip
```
