### PR TITLE
[BugFix] Fix quantized.out default batch size for fixed-shape models

### DIFF
--- a/tools/quantization/calibration.cpp
+++ b/tools/quantization/calibration.cpp
@@ -475,6 +475,7 @@ Calibration::Calibration(MNN::NetT* model, const uint8_t* modelBuffer, const int
     }
     if (picObj.HasMember("batch_size")) {
         _batch = picObj["batch_size"].GetInt();
+        _batchSetByUser = true;
     }
     if (picObj.HasMember("quant_bits")) {
         _quant_bits = picObj["quant_bits"].GetInt();
@@ -1279,6 +1280,12 @@ void Calibration::_quantizeModelEMA() {
         originFormat = originInfo->order;
         originDims = originInfo->dim;
         originType = originInfo->type;
+    }
+    if (!_batchSetByUser && !originDims.empty() && originDims[0] > 0) {
+        if (_batch != originDims[0]) {
+            DLOG(INFO) << "batch_size not set, use model batch: " << originDims[0];
+            _batch = originDims[0];
+        }
     }
     _module.reset(NN::extract(varInputs, varOutputs, true), Module::destroy);
     NN::turnQuantize(_module.get(), _quant_bits, NN::PerTensor, NN::MovingAverage, _winogradOpt);

--- a/tools/quantization/calibration.hpp
+++ b/tools/quantization/calibration.hpp
@@ -59,6 +59,7 @@ private:
     int _height = 1;
     int _channels;
     int _batch = 32;
+    bool _batchSetByUser = false;
     int _quant_bits = 8;
     bool _winogradOpt = false;
     Helper::PreprocessConfig _preprocessConfig;


### PR DESCRIPTION
### Motivation
The `quantized.out` tool defaults to batch size 32 when `batch_size` is not set.
Some models (e.g., YOLO26n) use fixed-shape Reshape constants with batch=1, which
causes a Reshape mismatch and can lead to a crash during quantization.

### Changes
Track whether `batch_size` is explicitly set in the config
If not set and the model input batch is fixed, use the model batch instead of 32

### Testing
Reproduced the failure on YOLO26n with default batch
Confirmed quantization completes after using model batch by default

Fixes: [MNN 3.3.0 量化 YOLO26 模型时发生段错误 (Segmentation Fault)  https://github.com/alibaba/MNN/issues/4116](https://github.com/alibaba/MNN/issues/4116)
