### PR TITLE
fix: sumParams4QKxV is being used without being initialized

### DIFF
--- a/source/backend/cpu/CPUAttention.cpp
+++ b/source/backend/cpu/CPUAttention.cpp
@@ -426,11 +426,11 @@ ErrorCode CPUAttention::onExecute(const std::vector<Tensor*>& inputs, const std:
         auto runningSum = mRunningSum ? (float*)(mRunningSum->host<int8_t>() + tId * mRunningSum->stride(0)) : nullptr;
         auto diffScale = mExpfDiffMax ? (float*)(mExpfDiffMax->host<int8_t>() + tId * mExpfDiffMax->stride(0)) : nullptr;
         auto outputPacked = mTempOut ? mTempOut->host<int8_t>() + tId * mTempOut->stride(0) : qkvPacked;
-
+        
         int  kvBlocks = UP_DIV(kvSeqLen, mBlockKV);
 
         QuanPostTreatParameters gemmParam4QxK, gemmParam4QKxV; // used by int8 gemm, allocated per thread.
-        SumByAxisParams sumParams4QxK, sumParams4QKxV;
+        SumByAxisParams sumParams4QxK, sumParams4QKxV = {};
         float* qSumAddr = nullptr;
         float* qScale = nullptr;
         float* qBias = nullptr;


### PR DESCRIPTION
我写了下面的这一段简短的代码
```cpp
#include "llm/llm.hpp"
#include "audio/audio.hpp"
#include <MNN/expr/ExecutorScope.hpp>
#include <vector>

int main()
{
    MNN::BackendConfig backendConfig;
    auto executor = MNN::Express::Executor::newExecutor(MNN_FORWARD_CPU, backendConfig, 1);
    MNN::Express::ExecutorScope s(executor);

    std::unique_ptr<MNN::Transformer::Llm> llm(
        MNN::Transformer::Llm::createLLM("D:/Project/github/Qwen2.5/config.json"));
    llm->load();

    llm->response("Hello,please introduce yourself in English");

    return 0;
}
```

但是会出现如下图所示的问题

<img width="458" height="290" alt="屏幕截图 2026-01-25 222428" src="https://github.com/user-attachments/assets/e14d8537-d0be-4abd-a603-300232ad89b3" />

问题出在CPUAttention.cpp中：
```cpp
infoInt8V[2] = static_cast<int32_t>(sumParams4QKxV.unitColBufferSize);
```

这行代码无条件执行，但 `sumParams4QKxV` 的初始化是有条件的：

```cpp
if (mQuantValue) {
    // ... 其他初始化 ...
    sumParams4QKxV.oneScale = 0;
    sumParams4QKxV.SRC_UNIT = lP8;
    sumParams4QKxV.blockNum = mBlockNum;
    sumParams4QKxV.DST_XUNIT = eP8;
    sumParams4QKxV.inputBlock = 0;
    sumParams4QKxV.kernelxy = 1;
    sumParams4QKxV.unitColBufferSize = ROUND_UP(MNN_FLASH_ATTENTION_BLOCK_SIZE, lP8) * eP8;
    sumParams4QKxV.kernelCountUnitDouble = UP_DIV(MNN_FLASH_ATTENTION_BLOCK_SIZE, lP8);
}
```

一整个执行流程是：
1. 声明 `sumParams4QKxV`（未初始化时成员为未定义值）
2.  仅在 `mQuantKey == true && mQuantValue == true` 时初始化
3.  无条件访问 `sumParams4QKxV.unitColBufferSize`

即当 `mQuantValue == false` 或 `mQuantKey == false` 时，`sumParams4QKxV` 未被初始化

```cpp
infoInt8V[2] = static_cast<int32_t>(sumParams4QKxV.unitColBufferSize);
```

读取未初始化成员，触发运行时检查失败。

我对原来的值进行初始化，确保所有成员为 0，即使后续未显式初始化，读取时也不会触发未初始化变量错误。