### PR TITLE
fix: interleaved mrope in qwen3-vl

### DIFF
--- a/transformers/llm/export/utils/transformers.py
+++ b/transformers/llm/export/utils/transformers.py
@@ -322,7 +322,8 @@ class Rotary(torch.nn.Module):
                         freqs_t[..., idx] = freqs[dim, ..., idx]
                     return freqs_t
                 if self.use_interleaved_mrope:
-                    freq_idx = torch.arange(0, 3 * self.rotary_dim).reshape(3, 1, self.rotary_dim)
+                    half_rotary = self.rotary_dim // 2
+                    freq_idx = torch.arange(0, 3 * half_rotary).reshape(3, 1, half_rotary)
                     self.mrope_reindex = apply_interleaved_mrope(freq_idx, self.mrope_section).flatten()
 
     def forward(self, position_ids):
@@ -345,7 +346,7 @@ class Rotary(torch.nn.Module):
         position_ids = position_ids.float().unsqueeze(-1)
         if self.use_interleaved_mrope:
             idx_theta = position_ids * self.theta.to(position_ids.device)
-            idx_theta = idx_theta.transpose(1, 0).reshape(-1, 3 * self.rotary_dim)
+            idx_theta = idx_theta.transpose(1, 0).reshape(-1, 3 * self.rotary_dim // 2)
             idx_theta = idx_theta[:, self.mrope_reindex]
         else:
             idx_theta = torch.concat([

--- a/transformers/llm/export/utils/transformers.py
+++ b/transformers/llm/export/utils/transformers.py
@@ -312,7 +312,7 @@ class Rotary(torch.nn.Module):
             if 'mrope_section' in scaling_config:
                 self.mrope_section = scaling_config['mrope_section']
                 self.theta_sections = get_theta().unsqueeze(0).split(self.mrope_section, dim=-1)
-                self.use_interleaved_mrope = self.model_type == 'qwen3_vl'
+                self.use_interleaved_mrope = self.model_type in ['qwen3_vl', 'qwen3_vl_moe']
                 def apply_interleaved_mrope(freqs, mrope_section):
                     # mrope apply func from qwen3-vl
                     freqs_t = freqs[0]  # just overwrite the first dimension T

--- a/transformers/llm/export/utils/transformers.py
+++ b/transformers/llm/export/utils/transformers.py
@@ -312,7 +312,7 @@ class Rotary(torch.nn.Module):
             if 'mrope_section' in scaling_config:
                 self.mrope_section = scaling_config['mrope_section']
                 self.theta_sections = get_theta().unsqueeze(0).split(self.mrope_section, dim=-1)
-                self.use_interleaved_mrope = self.model_type in ['qwen3_vl', 'qwen3_vl_moe']
+                self.use_interleaved_mrope = self.model_type in ['qwen3_vl', 'qwen3_vl_moe'] or scaling_config.get('mrope_interleaved', False)
                 def apply_interleaved_mrope(freqs, mrope_section):
                     # mrope apply func from qwen3-vl
                     freqs_t = freqs[0]  # just overwrite the first dimension T

--- a/transformers/llm/export/utils/transformers.py
+++ b/transformers/llm/export/utils/transformers.py
@@ -307,9 +307,23 @@ class Rotary(torch.nn.Module):
                 self.theta = get_theta() / torch.tensor(short_factor, dtype=torch.float32)
 
             # mrope for multimode
+            self.use_interleaved_mrope = False
+            self.mrope_reindex = None
             if 'mrope_section' in scaling_config:
                 self.mrope_section = scaling_config['mrope_section']
                 self.theta_sections = get_theta().unsqueeze(0).split(self.mrope_section, dim=-1)
+                self.use_interleaved_mrope = self.model_type == 'qwen3_vl'
+                def apply_interleaved_mrope(freqs, mrope_section):
+                    # mrope apply func from qwen3-vl
+                    freqs_t = freqs[0]  # just overwrite the first dimension T
+                    for dim, offset in enumerate((1, 2), start=1):  # H, W
+                        length = mrope_section[dim] * 3
+                        idx = slice(offset, length, 3)
+                        freqs_t[..., idx] = freqs[dim, ..., idx]
+                    return freqs_t
+                if self.use_interleaved_mrope:
+                    freq_idx = torch.arange(0, 3 * self.rotary_dim).reshape(3, 1, self.rotary_dim)
+                    self.mrope_reindex = apply_interleaved_mrope(freq_idx, self.mrope_section).flatten()
 
     def forward(self, position_ids):
         if self.theta_sections is not None:
@@ -329,11 +343,16 @@ class Rotary(torch.nn.Module):
 
     def mrope_forward(self, position_ids):
         position_ids = position_ids.float().unsqueeze(-1)
-        idx_theta = torch.concat([
-            position_ids[0] * self.theta_sections[0],
-            position_ids[1] * self.theta_sections[1],
-            position_ids[2] * self.theta_sections[2]
-        ], dim=-1)
+        if self.use_interleaved_mrope:
+            idx_theta = position_ids * self.theta.to(position_ids.device)
+            idx_theta = idx_theta.transpose(1, 0).reshape(-1, 3 * self.rotary_dim)
+            idx_theta = idx_theta[:, self.mrope_reindex]
+        else:
+            idx_theta = torch.concat([
+                position_ids[0] * self.theta_sections[0],
+                position_ids[1] * self.theta_sections[1],
+                position_ids[2] * self.theta_sections[2]
+            ], dim=-1)
         rotary_pos_emb = torch.stack([torch.cos(idx_theta), torch.sin(idx_theta)])
         rotary_pos_emb = torch.cat((rotary_pos_emb, rotary_pos_emb), dim=-1)
         rotary_pos_emb = rotary_pos_emb.unsqueeze(2).unsqueeze(1)


### PR DESCRIPTION
This PR aims to address #4120 #4104 . Qwen3-VL uses [interleaved mrope](https://github.com/huggingface/transformers/blob/v4.57.6/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py#L299-L314) instead of [blocked mrope](https://github.com/huggingface/transformers/blob/v4.57.6/src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py#L577-L583) in Qwen2.5VL. The old impl behaves the same when processing text, but causes infinite loop in vision mode. 