### PR TITLE
Fix build failure caused by 0244b8516bc5b97b02b4cfb2086a4357d608fd49

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -388,3 +388,5 @@ apps/Android/.qoder/settings.json
 apps/Android/MnnLlmChatOld
 
 transformers/llm/export/tmp/
+.vs
+.cxx

--- a/apps/Android/MnnLlmChat/app/src/main/cpp/diffusion_session.cpp
+++ b/apps/Android/MnnLlmChat/app/src/main/cpp/diffusion_session.cpp
@@ -7,18 +7,22 @@
 #include "mls_log.h"
 #include <memory>
 #include <utility>
-mls::DiffusionSession::DiffusionSession(std::string resource_path, int memory_mode):
-                                        resource_path_(std::move(resource_path)),
-                                        memory_mode_(memory_mode){
-    this->diffusion_= std::make_unique<Diffusion>(
-            resource_path_,
-                          DiffusionModelType::STABLE_DIFFUSION_1_5,
-                          MNNForwardType::MNN_FORWARD_OPENCL,
-            memory_mode
-            );
+mls::DiffusionSession::DiffusionSession(std::string resource_path, int memory_mode) :
+    resource_path_(std::move(resource_path)),
+    memory_mode_(memory_mode) {
+    this->diffusion_ = Diffusion::createDiffusion(
+        resource_path_,
+        DiffusionModelType::STABLE_DIFFUSION_1_5,
+        MNNForwardType::MNN_FORWARD_OPENCL,
+        memory_mode_
+    );
     MNN_DEBUG("diffusion session init resource_path_: %s memory_mode: %d ", resource_path_.c_str(), memory_mode);
     this->diffusion_->load();
     loaded_ = true;
+}
+
+mls::DiffusionSession::~DiffusionSession() {
+    delete diffusion_;
 }
 
 void mls::DiffusionSession::Run(const std::string &prompt,

--- a/apps/Android/MnnLlmChat/app/src/main/cpp/diffusion_session.h
+++ b/apps/Android/MnnLlmChat/app/src/main/cpp/diffusion_session.h
@@ -15,10 +15,11 @@ public:
     void Run(const std::string& prompt, const std::string& image_path,
              int iter_num,
              int random_seed, const std::function<void(int)>& progressCallback);
+    ~DiffusionSession();
 private:
-    bool loaded_{false};
+    bool loaded_{ false };
     std::string resource_path_;
     int memory_mode_;
-    std::unique_ptr<Diffusion> diffusion_{nullptr};
+    Diffusion* diffusion_{ nullptr };
 };
 }


### PR DESCRIPTION
Someone who actually knows C++ should verify that this is the _correct_ fix. 😄

I just used Claude to fix it enough to **compile** because `./gradlew assembleStandardDebug` was failing for `apps/Android/MnnLlmChat` when I forked the repository.