### PR TITLE
Add input tensor dimension type detection to support both CAFFE and TENSORFLOW formats

### DIFF
--- a/demo/exec/multiPose.cpp
+++ b/demo/exec/multiPose.cpp
@@ -332,11 +332,21 @@ int main(int argc, char* argv[]) {
     auto session        = mnnNet->createSession(netConfig);
 
     auto input = mnnNet->getSessionInput(session, nullptr);
+    Tensor::DimensionType inputFormat = input->getDimensionType();
+    std::vector<int> desiredShape;
 
-    if (input->elementSize() <= 4) {
-        mnnNet->resizeTensor(input, {1, 3, targetHeight, targetWidth});
-        mnnNet->resizeSession(session);
+    if (inputFormat == MNN::Tensor::CAFFE) {
+        desiredShape = { 1, 3, targetHeight, targetWidth };
     }
+    else if (inputFormat == MNN::Tensor::TENSORFLOW) {
+        desiredShape = { 1, targetHeight, targetWidth, 3 };
+    }
+    else {
+        desiredShape = { 1, targetHeight, targetWidth, 3 };
+    }
+
+    mnnNet->resizeTensor(input, desiredShape);
+    mnnNet->resizeSession(session);
 
     // preprocess input image
     {
@@ -382,16 +392,23 @@ int main(int argc, char* argv[]) {
         mnnNet->runSession(session);
     }
 
+    auto output = mnnNet->getSessionInput(session, nullptr);
+    Tensor::DimensionType outputFormat = output->getDimensionType();
+
     // get output
     auto offsets         = mnnNet->getSessionOutput(session, OFFSET_NODE_NAME);
     auto displacementFwd = mnnNet->getSessionOutput(session, DISPLACE_FWD_NODE_NAME);
     auto displacementBwd = mnnNet->getSessionOutput(session, DISPLACE_BWD_NODE_NAME);
     auto heatmaps        = mnnNet->getSessionOutput(session, HEATMAPS);
 
-    Tensor offsetsHost(offsets, Tensor::CAFFE);
-    Tensor displacementFwdHost(displacementFwd, Tensor::CAFFE);
-    Tensor displacementBwdHost(displacementBwd, Tensor::CAFFE);
-    Tensor heatmapsHost(heatmaps, Tensor::CAFFE);
+    Tensor::DimensionType offsetsFormat = offsets->getDimensionType();
+    Tensor::DimensionType heatmapsFormat = heatmaps->getDimensionType();
+
+    Tensor offsetsHost(offsets, offsetsFormat); 
+    Tensor displacementFwdHost(displacementFwd, offsetsFormat);
+    Tensor displacementBwdHost(displacementBwd, offsetsFormat);
+    Tensor heatmapsHost(heatmaps, heatmapsFormat);
+
 
     offsets->copyToHostTensor(&offsetsHost);
     displacementFwd->copyToHostTensor(&displacementFwdHost);


### PR DESCRIPTION
Automatically set correct input shape based on dimension type:
  - CAFFE format uses NCHW order [1, 3, height, width]
  - TENSORFLOW format uses NHWC order [1, height, width, 3]