### PR TITLE
[LLM:Bugfix] Fix Qwen3-Embedding QNN export crash

### DIFF
--- a/tools/cpp/compilefornpu.cpp
+++ b/tools/cpp/compilefornpu.cpp
@@ -900,12 +900,20 @@ int main(int argc, const char* argv[]) {
             for (auto iter = testdir.Begin(); iter != testdir.End(); iter++) {
                 std::string dirname = iter->GetString();
                 auto subinputs = MNN::Express::Variable::load((dirname + "/input.mnn").c_str());
+                if (subinputs.empty()) {
+                    MNN_ERROR("Failed to load test inputs from %s/input.mnn\n", dirname.c_str());
+                    return 1;
+                }
                 inputs.emplace_back(subinputs);
                 inputNames.clear();
                 for (int i=0; i<subinputs.size(); ++i) {
                     inputNames.emplace_back(subinputs[i]->name());
                 }
                 auto outputs = MNN::Express::Variable::load((dirname + "/output.mnn").c_str());
+                if (outputs.empty()) {
+                    MNN_ERROR("Failed to load test outputs from %s/output.mnn\n", dirname.c_str());
+                    return 1;
+                }
                 outputNames.clear();
                 for (int i=0; i<outputs.size(); ++i) {
                     outputNames.emplace_back(outputs[i]->name());
@@ -915,6 +923,10 @@ int main(int argc, const char* argv[]) {
     }
     if (outputNames.empty()) {
         std::shared_ptr<MNN::Express::Module> m(MNN::Express::Module::load(inputNames, outputNames, srcMNN), MNN::Express::Module::destroy);
+        if (nullptr == m.get()) {
+            MNN_ERROR("Failed to load source module from %s\n", srcMNN);
+            return 1;
+        }
         auto minfo = m->getInfo();
         outputNames = minfo->outputNames;
         inputNames = minfo->inputNames;

--- a/transformers/llm/engine/tools/generateLlmIO.cpp
+++ b/transformers/llm/engine/tools/generateLlmIO.cpp
@@ -73,10 +73,55 @@ static void createInputsForLLM(int seqLen, int hiddenSize, const std::string& at
     return;
 }
 
-static void generateForLLM(const std::string& modelPath, const std::string& outputDir, const std::string& jsonPath, int blockSize) {
+static void createInputsForEmbedding(int seqLen, int hiddenSize, const std::string& attentionMaskType, std::vector<MNN::Express::VARP>& inputs) {
+    MNN::Express::VARP inputEmbeds = MNN::Express::_Input({seqLen, 1, hiddenSize}, MNN::Express::NCHW, halide_type_of<float>());
+    float* inputEmbedsData = inputEmbeds->writeMap<float>();
+    for (int i = 0; i < seqLen * hiddenSize; ++i) {
+        inputEmbedsData[i] = (float)(rand()) / RAND_MAX;
+    }
+    inputs.push_back(inputEmbeds);
+
+    MNN::Express::VARP attentionMask = MNN::Express::_Input({1, 1, seqLen, seqLen}, MNN::Express::NCHW, halide_type_of<float>());
+    float* attentionMaskData = attentionMask->writeMap<float>();
+    for (int i = 0; i < seqLen; ++i) {
+        for (int j = 0; j < seqLen; ++j) {
+            if (attentionMaskType == "float") {
+                attentionMaskData[i * seqLen + j] = (j > i) ? std::numeric_limits<float>::lowest() : 0.0f;
+            } else {
+                attentionMaskData[i * seqLen + j] = 1.0f;
+            }
+        }
+    }
+    inputs.push_back(attentionMask);
+
+    MNN::Express::VARP positionIds = MNN::Express::_Input({1, seqLen}, MNN::Express::NCHW, halide_type_of<int>());
+    int* positionIdsData = positionIds->writeMap<int>();
+    for (int i = 0; i < seqLen; ++i) {
+        positionIdsData[i] = i;
+    }
+    inputs.push_back(positionIds);
+}
+
+static bool isEmbeddingModel(const rapidjson::Document& doc) {
+    if (doc.HasMember("output_names") && doc["output_names"].IsArray()) {
+        for (auto iter = doc["output_names"].Begin(); iter != doc["output_names"].End(); ++iter) {
+            if (iter->IsString() && std::string(iter->GetString()) == "sentence_embeddings") {
+                return true;
+            }
+        }
+    }
+    auto modelType = std::string(doc.HasMember("model_type") && doc["model_type"].IsString() ? doc["model_type"].GetString() : "");
+    if (modelType == "bert" || modelType == "new" || modelType == "qwen3") {
+        return true;
+    }
+    return false;
+}
+
+static bool generateForModel(const std::string& modelPath, const std::string& outputDir, const std::string& jsonPath, int blockSize) {
     std::shared_ptr<MNN::Express::Module> net;
-    std::vector<std::string> inputNames = {"input_ids", "attention_mask", "position_ids", "logits_index"};
-    std::vector<std::string> outputNames = {"logits"};
+    std::vector<std::string> inputNames;
+    std::vector<std::string> outputNames;
+    bool isEmbedding = false;
 
     int hiddenSize;
     std::string attentionMaskType;
@@ -84,7 +129,7 @@ static void generateForLLM(const std::string& modelPath, const std::string& outp
         std::ifstream ifs(jsonPath);
         if (!ifs.is_open()) {
             MNN_ERROR("Failed to open JSON config file: %s.\n", jsonPath.c_str());
-            return;
+            return false;
         }
         rapidjson::IStreamWrapper isw(ifs);
         rapidjson::Document doc;
@@ -92,51 +137,88 @@ static void generateForLLM(const std::string& modelPath, const std::string& outp
 
         if (doc.HasParseError() || !doc.IsObject()) {
             MNN_ERROR("Failed to parse JSON config file: %s.\n", jsonPath.c_str());
-            return;
+            return false;
         }
 
         if (!doc.HasMember("hidden_size") || !doc["hidden_size"].IsInt()) {
             MNN_ERROR("'hidden_size' not found or not an integer in %s\n", jsonPath.c_str());
-            return;
+            return false;
         }
         hiddenSize = doc["hidden_size"].GetInt();
 
         if (!doc.HasMember("attention_mask") || !doc["attention_mask"].IsString()) {
             MNN_ERROR("'attention_mask' not found or not a string in %s\n", jsonPath.c_str());
-            return;
+            return false;
         }
         attentionMaskType = doc["attention_mask"].GetString();
+
+        isEmbedding = isEmbeddingModel(doc);
     }
 
-    // Load Model.
     MNN::ScheduleConfig config;
     std::shared_ptr<MNN::Express::Executor::RuntimeManager> rtmgr(MNN::Express::Executor::RuntimeManager::createRuntimeManager(config));
     rtmgr->setExternalFile((modelPath + ".weight").c_str());
+
+    if (isEmbedding) {
+        inputNames = {"input_ids", "attention_mask", "position_ids"};
+        outputNames = {"sentence_embeddings"};
+    } else {
+        inputNames = {"input_ids", "attention_mask", "position_ids", "logits_index"};
+        outputNames = {"logits"};
+    }
     net.reset(MNN::Express::Module::load(inputNames, outputNames, modelPath.c_str(), rtmgr), MNN::Express::Module::destroy);
+    if (nullptr == net.get()) {
+        MNN_ERROR("Failed to load module for QNN IO generation as %s model.\n", isEmbedding ? "embedding" : "llm");
+        return false;
+    }
 
     {
         std::vector<MNN::Express::VARP> inputs;
         std::vector<MNN::Express::VARP> outputs;
-        createInputsForLLM(blockSize, hiddenSize, attentionMaskType, false, inputs);
+        if (isEmbedding) {
+            createInputsForEmbedding(blockSize, hiddenSize, attentionMaskType, inputs);
+        } else {
+            createInputsForLLM(blockSize, hiddenSize, attentionMaskType, false, inputs);
+        }
         outputs = net->onForward(inputs);
+        if (outputs.empty()) {
+            MNN_ERROR("Failed to run forward for QNN IO generation.\n");
+            return false;
+        }
         saveInputOutputs(net->getInfo(), inputs, outputs, outputDir, blockSize);
     }
 
-    {
+    if (!isEmbedding) {
         std::vector<MNN::Express::VARP> inputs;
         std::vector<MNN::Express::VARP> outputs;
         createInputsForLLM(1, hiddenSize, attentionMaskType, true, inputs);
         outputs = net->onForward(inputs);
+        if (outputs.empty()) {
+            MNN_ERROR("Failed to run decode forward for QNN IO generation.\n");
+            return false;
+        }
         saveInputOutputs(net->getInfo(), inputs, outputs, outputDir, 1);
     }
 
-    return;
+    if (isEmbedding) {
+        std::vector<MNN::Express::VARP> inputs;
+        std::vector<MNN::Express::VARP> outputs;
+        createInputsForEmbedding(1, hiddenSize, attentionMaskType, inputs);
+        outputs = net->onForward(inputs);
+        if (outputs.empty()) {
+            MNN_ERROR("Failed to run single token embedding forward for QNN IO generation.\n");
+            return false;
+        }
+        saveInputOutputs(net->getInfo(), inputs, outputs, outputDir, 1);
+    }
+
+    return true;
 }
 
 int main(int argc, char* argv[]) {
     if (argc < 3) {
         MNN_PRINT("Usage: ./generateLlmIO model/config.json outputDir [blocksize]\n");
-        MNN_PRINT("This program generates IO test data, i.e. input.mnn and output.mnn, for a given llm model, assuming standard inputs ('inputs_ids', 'attention_mask', 'position_ids', 'logits_index') and standard outputs('logits').\n");
+        MNN_PRINT("This program generates IO test data for QNN export. It supports both generation models and embedding models exported by llmexport.\n");
         return 1;
     }
 
@@ -157,7 +239,9 @@ int main(int argc, char* argv[]) {
         MNN_PRINT("Failed to create dir %s.\n", outputDir.c_str());
     }
 
-    generateForLLM(modelPath, outputDir, llmConfigPath, blockSize);
+    if (!generateForModel(modelPath, outputDir, llmConfigPath, blockSize)) {
+        return 1;
+    }
 
     return 0;
 }

--- a/transformers/llm/export/npu/generate_llm_qnn.py
+++ b/transformers/llm/export/npu/generate_llm_qnn.py
@@ -10,7 +10,11 @@ import shutil
 def makeIO(args):
     exe = os.path.join(os.getcwd(), args.mnn_path, "generateLlmIO")
     output = os.path.join(args.cache_path, 'testdir')
-    print(os.popen(exe + " " + args.model + " " + output + ' %d' %args.chunk_size).read())
+    process = subprocess.Popen(exe + " " + args.model + " " + output + ' %d' %args.chunk_size, bufsize=1, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, shell=True)
+    for line in process.stdout:
+        print(line, end='')
+    process.wait()
+    return process.returncode
 
 def seperate(args):
     exe = os.path.join(os.getcwd(), args.mnn_path, "compilefornpu")
@@ -35,6 +39,7 @@ def seperate(args):
         print(line, end='')
 
     process.wait()
+    return process.returncode
 
 def compile_qnn(args):
     exe = os.path.join(os.getcwd(), args.mnn_path, "..", "source", "backend", "qnn", "npu_convert.py")
@@ -43,6 +48,7 @@ def compile_qnn(args):
     for line in process.stdout:
         print(line, end='')
     process.wait()
+    return process.returncode
 
 def output_qnn(args):
     if os.path.exists(os.path.join(args.model, 'qnn')):
@@ -69,19 +75,25 @@ def convert(args):
     os.makedirs(cache, exist_ok=True)
     sta = time.time()
     print("Step1: Make IO")
-    makeIO(args)
+    code = makeIO(args)
     end = time.time()
     print("Cost: ", end - sta, ' s')
+    if code != 0:
+        raise RuntimeError(f"Step1 failed with exit code {code}")
     sta = end
     print("Step2: Seperate Model")
-    seperate(args)
+    code = seperate(args)
     end = time.time()
     print("Cost: ", end - sta, ' s')
+    if code != 0:
+        raise RuntimeError(f"Step2 failed with exit code {code}")
     sta = end
     print("Step3: Compile to QNN")
-    compile_qnn(args)
+    code = compile_qnn(args)
     end = time.time()
     print("Cost: ", end - sta, ' s')
+    if code != 0:
+        raise RuntimeError(f"Step3 failed with exit code {code}")
     print("Step4: Move result file to ", args.model)
     output_qnn(args)
 


### PR DESCRIPTION
### Motivation
`generate_llm_qnn.py` assumes all exported models use generative LLM IO.
This breaks embedding models such as `Qwen3-Embedding-0.6B`, which use
`sentence_embeddings` as output and do not have `logits_index`.

As a result:
- Step1 crashes in `generateLlmIO`
- Step2 runs with missing test IO
- Step3 reports a misleading `npu_postreat.json` not found error

### Changes
Detect embedding models from `llm_config.json`
Generate embedding test IO in `generateLlmIO`
Keep the existing generative LLM path unchanged
Add missing test IO checks in `compilefornpu`
Stop the QNN export script immediately when a step fails

### Testing
Reproduced the failure on `Qwen3-Embedding-0.6B`
Confirmed Step1 generates `testdir/1` and `testdir/128` successfully
Confirmed Step2 generates `npu_postreat.json` successfully
Confirmed Step3 proceeds into QNN graph compilation instead of failing at the original crash point

Fixes: [Qwen3-Embedding-0.6B generate_llm_qnn.py 报错 #4212](https://github.com/alibaba/MNN/issues/4212)
