### PR TITLE
[MNN:Bugfix] Support ONNX Shape start/end and preserve OpParameter compatibility

### DIFF
--- a/schema/current/MNN_generated.h
+++ b/schema/current/MNN_generated.h
@@ -39,6 +39,9 @@ struct FmhcaParamT;
 struct StftParam;
 struct StftParamT;
 
+struct ShapeParam;
+struct ShapeParamT;
+
 struct WhileParam;
 struct WhileParamT;
 
@@ -87,6 +90,8 @@ inline const flatbuffers::TypeTable *FmhaV2ParamTypeTable();
 inline const flatbuffers::TypeTable *FmhcaParamTypeTable();
 
 inline const flatbuffers::TypeTable *StftParamTypeTable();
+
+inline const flatbuffers::TypeTable *ShapeParamTypeTable();
 
 inline const flatbuffers::TypeTable *WhileParamTypeTable();
 
@@ -1207,11 +1212,12 @@ enum OpParameter {
   OpParameter_AttentionParam = 98,
   OpParameter_StftParam = 99,
   OpParameter_LinearAttentionParam = 100,
+  OpParameter_ShapeParam = 101,
   OpParameter_MIN = OpParameter_NONE,
-  OpParameter_MAX = OpParameter_LinearAttentionParam
+  OpParameter_MAX = OpParameter_ShapeParam
 };
 
-inline const OpParameter (&EnumValuesOpParameter())[101] {
+inline const OpParameter (&EnumValuesOpParameter())[102] {
   static const OpParameter values[] = {
     OpParameter_NONE,
     OpParameter_QuantizedAdd,
@@ -1313,7 +1319,8 @@ inline const OpParameter (&EnumValuesOpParameter())[101] {
     OpParameter_FmhcaParam,
     OpParameter_AttentionParam,
     OpParameter_StftParam,
-    OpParameter_LinearAttentionParam
+    OpParameter_LinearAttentionParam,
+    OpParameter_ShapeParam
   };
   return values;
 }
@@ -1421,6 +1428,7 @@ inline const char * const *EnumNamesOpParameter() {
     "AttentionParam",
     "StftParam",
     "LinearAttentionParam",
+    "ShapeParam",
     nullptr
   };
   return names;
@@ -1658,6 +1666,10 @@ template<> struct OpParameterTraits<Reshape> {
 
 template<> struct OpParameterTraits<Resize> {
   static const OpParameter enum_value = OpParameter_Resize;
+};
+
+template<> struct OpParameterTraits<ShapeParam> {
+  static const OpParameter enum_value = OpParameter_ShapeParam;
 };
 
 template<> struct OpParameterTraits<RoiParameters> {
@@ -2314,6 +2326,14 @@ struct OpParameterUnion {
   const ResizeT *AsResize() const {
     return type == OpParameter_Resize ?
       reinterpret_cast<const ResizeT *>(value) : nullptr;
+  }
+  ShapeParamT *AsShapeParam() {
+    return type == OpParameter_ShapeParam ?
+      reinterpret_cast<ShapeParamT *>(value) : nullptr;
+  }
+  const ShapeParamT *AsShapeParam() const {
+    return type == OpParameter_ShapeParam ?
+      reinterpret_cast<const ShapeParamT *>(value) : nullptr;
   }
   RoiParametersT *AsRoiParameters() {
     return type == OpParameter_RoiParameters ?
@@ -3320,6 +3340,93 @@ inline flatbuffers::Offset<StftParam> CreateStftParam(
 
 flatbuffers::Offset<StftParam> CreateStftParam(flatbuffers::FlatBufferBuilder &_fbb, const StftParamT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
+struct ShapeParamT : public flatbuffers::NativeTable {
+  typedef ShapeParam TableType;
+  bool hasStart;
+  int32_t start;
+  bool hasEnd;
+  int32_t end;
+  ShapeParamT()
+      : hasStart(false),
+        start(0),
+        hasEnd(false),
+        end(0) {
+  }
+};
+
+struct ShapeParam FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef ShapeParamT NativeTableType;
+  static const flatbuffers::TypeTable *MiniReflectTypeTable() {
+    return ShapeParamTypeTable();
+  }
+  bool hasStart() const {
+    return GetField<uint8_t>(4, 0) != 0;
+  }
+  int32_t start() const {
+    return GetField<int32_t>(6, 0);
+  }
+  bool hasEnd() const {
+    return GetField<uint8_t>(8, 0) != 0;
+  }
+  int32_t end() const {
+    return GetField<int32_t>(10, 0);
+  }
+  bool Verify(flatbuffers::Verifier &verifier) const {
+    return VerifyTableStart(verifier) &&
+           VerifyField<uint8_t>(verifier, 4) &&
+           VerifyField<int32_t>(verifier, 6) &&
+           VerifyField<uint8_t>(verifier, 8) &&
+           VerifyField<int32_t>(verifier, 10) &&
+           verifier.EndTable();
+  }
+  ShapeParamT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(ShapeParamT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static flatbuffers::Offset<ShapeParam> Pack(flatbuffers::FlatBufferBuilder &_fbb, const ShapeParamT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+};
+
+struct ShapeParamBuilder {
+  flatbuffers::FlatBufferBuilder &fbb_;
+  flatbuffers::uoffset_t start_;
+  void add_hasStart(bool hasStart) {
+    fbb_.AddElement<uint8_t>(4, static_cast<uint8_t>(hasStart), 0);
+  }
+  void add_start(int32_t start) {
+    fbb_.AddElement<int32_t>(6, start, 0);
+  }
+  void add_hasEnd(bool hasEnd) {
+    fbb_.AddElement<uint8_t>(8, static_cast<uint8_t>(hasEnd), 0);
+  }
+  void add_end(int32_t end) {
+    fbb_.AddElement<int32_t>(10, end, 0);
+  }
+  explicit ShapeParamBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+        : fbb_(_fbb) {
+    start_ = fbb_.StartTable();
+  }
+  ShapeParamBuilder &operator=(const ShapeParamBuilder &);
+  flatbuffers::Offset<ShapeParam> Finish() {
+    const auto end = fbb_.EndTable(start_);
+    auto o = flatbuffers::Offset<ShapeParam>(end);
+    return o;
+  }
+};
+
+inline flatbuffers::Offset<ShapeParam> CreateShapeParam(
+    flatbuffers::FlatBufferBuilder &_fbb,
+    bool hasStart = false,
+    int32_t start = 0,
+    bool hasEnd = false,
+    int32_t end = 0) {
+  ShapeParamBuilder builder_(_fbb);
+  builder_.add_end(end);
+  builder_.add_start(start);
+  builder_.add_hasEnd(hasEnd);
+  builder_.add_hasStart(hasStart);
+  return builder_.Finish();
+}
+
+flatbuffers::Offset<ShapeParam> CreateShapeParam(flatbuffers::FlatBufferBuilder &_fbb, const ShapeParamT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+
 struct WhileParamT : public flatbuffers::NativeTable {
   typedef WhileParam TableType;
   std::string cond_graph;
@@ -3973,6 +4080,9 @@ struct Op FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   const Resize *main_as_Resize() const {
     return main_type() == OpParameter_Resize ? static_cast<const Resize *>(main()) : nullptr;
   }
+  const ShapeParam *main_as_ShapeParam() const {
+    return main_type() == OpParameter_ShapeParam ? static_cast<const ShapeParam *>(main()) : nullptr;
+  }
   const RoiParameters *main_as_RoiParameters() const {
     return main_type() == OpParameter_RoiParameters ? static_cast<const RoiParameters *>(main()) : nullptr;
   }
@@ -4364,6 +4474,10 @@ template<> inline const Reshape *Op::main_as<Reshape>() const {
 
 template<> inline const Resize *Op::main_as<Resize>() const {
   return main_as_Resize();
+}
+
+template<> inline const ShapeParam *Op::main_as<ShapeParam>() const {
+  return main_as_ShapeParam();
 }
 
 template<> inline const RoiParameters *Op::main_as<RoiParameters>() const {
@@ -5490,6 +5604,41 @@ inline flatbuffers::Offset<StftParam> CreateStftParam(flatbuffers::FlatBufferBui
       _abs);
 }
 
+inline ShapeParamT *ShapeParam::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
+  auto _o = new ShapeParamT();
+  UnPackTo(_o, _resolver);
+  return _o;
+}
+
+inline void ShapeParam::UnPackTo(ShapeParamT *_o, const flatbuffers::resolver_function_t *_resolver) const {
+  (void)_o;
+  (void)_resolver;
+  { auto _e = hasStart(); _o->hasStart = _e; };
+  { auto _e = start(); _o->start = _e; };
+  { auto _e = hasEnd(); _o->hasEnd = _e; };
+  { auto _e = end(); _o->end = _e; };
+}
+
+inline flatbuffers::Offset<ShapeParam> ShapeParam::Pack(flatbuffers::FlatBufferBuilder &_fbb, const ShapeParamT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
+  return CreateShapeParam(_fbb, _o, _rehasher);
+}
+
+inline flatbuffers::Offset<ShapeParam> CreateShapeParam(flatbuffers::FlatBufferBuilder &_fbb, const ShapeParamT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
+  (void)_rehasher;
+  (void)_o;
+  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const ShapeParamT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  auto _hasStart = _o->hasStart;
+  auto _start = _o->start;
+  auto _hasEnd = _o->hasEnd;
+  auto _end = _o->end;
+  return MNN::CreateShapeParam(
+      _fbb,
+      _hasStart,
+      _start,
+      _hasEnd,
+      _end);
+}
+
 inline WhileParamT *WhileParam::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
   auto _o = new WhileParamT();
   UnPackTo(_o, _resolver);
@@ -6170,6 +6319,10 @@ inline bool VerifyOpParameter(flatbuffers::Verifier &verifier, const void *obj, 
       auto ptr = reinterpret_cast<const Resize *>(obj);
       return verifier.VerifyTable(ptr);
     }
+    case OpParameter_ShapeParam: {
+      auto ptr = reinterpret_cast<const ShapeParam *>(obj);
+      return verifier.VerifyTable(ptr);
+    }
     case OpParameter_RoiParameters: {
       auto ptr = reinterpret_cast<const RoiParameters *>(obj);
       return verifier.VerifyTable(ptr);
@@ -6588,6 +6741,10 @@ inline void *OpParameterUnion::UnPack(const void *obj, OpParameter type, const f
       auto ptr = reinterpret_cast<const Resize *>(obj);
       return ptr->UnPack(resolver);
     }
+    case OpParameter_ShapeParam: {
+      auto ptr = reinterpret_cast<const ShapeParam *>(obj);
+      return ptr->UnPack(resolver);
+    }
     case OpParameter_RoiParameters: {
       auto ptr = reinterpret_cast<const RoiParameters *>(obj);
       return ptr->UnPack(resolver);
@@ -6994,6 +7151,10 @@ inline flatbuffers::Offset<void> OpParameterUnion::Pack(flatbuffers::FlatBufferB
       auto ptr = reinterpret_cast<const ResizeT *>(value);
       return CreateResize(_fbb, ptr, _rehasher).Union();
     }
+    case OpParameter_ShapeParam: {
+      auto ptr = reinterpret_cast<const ShapeParamT *>(value);
+      return CreateShapeParam(_fbb, ptr, _rehasher).Union();
+    }
     case OpParameter_RoiParameters: {
       auto ptr = reinterpret_cast<const RoiParametersT *>(value);
       return CreateRoiParameters(_fbb, ptr, _rehasher).Union();
@@ -7398,6 +7559,10 @@ inline OpParameterUnion::OpParameterUnion(const OpParameterUnion &u) FLATBUFFERS
     }
     case OpParameter_Resize: {
       value = new ResizeT(*reinterpret_cast<ResizeT *>(u.value));
+      break;
+    }
+    case OpParameter_ShapeParam: {
+      value = new ShapeParamT(*reinterpret_cast<ShapeParamT *>(u.value));
       break;
     }
     case OpParameter_RoiParameters: {
@@ -7860,6 +8025,11 @@ inline void OpParameterUnion::Reset() {
     }
     case OpParameter_Resize: {
       auto ptr = reinterpret_cast<ResizeT *>(value);
+      delete ptr;
+      break;
+    }
+    case OpParameter_ShapeParam: {
+      auto ptr = reinterpret_cast<ShapeParamT *>(value);
       delete ptr;
       break;
     }
@@ -8572,7 +8742,8 @@ inline const flatbuffers::TypeTable *OpParameterTypeTable() {
     { flatbuffers::ET_SEQUENCE, 0, 96 },
     { flatbuffers::ET_SEQUENCE, 0, 97 },
     { flatbuffers::ET_SEQUENCE, 0, 98 },
-    { flatbuffers::ET_SEQUENCE, 0, 99 }
+    { flatbuffers::ET_SEQUENCE, 0, 99 },
+    { flatbuffers::ET_SEQUENCE, 0, 100 }
   };
   static const flatbuffers::TypeFunction type_refs[] = {
     QuantizedAddTypeTable,
@@ -8674,7 +8845,8 @@ inline const flatbuffers::TypeTable *OpParameterTypeTable() {
     FmhcaParamTypeTable,
     AttentionParamTypeTable,
     StftParamTypeTable,
-    LinearAttentionParamTypeTable
+    LinearAttentionParamTypeTable,
+    ShapeParamTypeTable
   };
   static const char * const names[] = {
     "NONE",
@@ -8777,10 +8949,11 @@ inline const flatbuffers::TypeTable *OpParameterTypeTable() {
     "FmhcaParam",
     "AttentionParam",
     "StftParam",
-    "LinearAttentionParam"
+    "LinearAttentionParam",
+    "ShapeParam"
   };
   static const flatbuffers::TypeTable tt = {
-    flatbuffers::ST_UNION, 101, type_codes, type_refs, nullptr, names
+    flatbuffers::ST_UNION, 102, type_codes, type_refs, nullptr, names
   };
   return &tt;
 }
@@ -8965,6 +9138,25 @@ inline const flatbuffers::TypeTable *StftParamTypeTable() {
   };
   static const flatbuffers::TypeTable tt = {
     flatbuffers::ST_TABLE, 3, type_codes, nullptr, nullptr, names
+  };
+  return &tt;
+}
+
+inline const flatbuffers::TypeTable *ShapeParamTypeTable() {
+  static const flatbuffers::TypeCode type_codes[] = {
+    { flatbuffers::ET_BOOL, 0, -1 },
+    { flatbuffers::ET_INT, 0, -1 },
+    { flatbuffers::ET_BOOL, 0, -1 },
+    { flatbuffers::ET_INT, 0, -1 }
+  };
+  static const char * const names[] = {
+    "hasStart",
+    "start",
+    "hasEnd",
+    "end"
+  };
+  static const flatbuffers::TypeTable tt = {
+    flatbuffers::ST_TABLE, 4, type_codes, nullptr, nullptr, names
   };
   return &tt;
 }

--- a/schema/default/MNN.fbs
+++ b/schema/default/MNN.fbs
@@ -255,6 +255,13 @@ table StftParam {
     abs: bool = true;
 }
 
+table ShapeParam {
+    hasStart: bool = false;
+    start: int = 0;
+    hasEnd: bool = false;
+    end: int = 0;
+}
+
 table WhileParam {
     // The name of condition subgraph.
     cond_graph: string;
@@ -432,7 +439,8 @@ union OpParameter {
     FmhcaParam,
     AttentionParam,
     StftParam,
-    LinearAttentionParam
+    LinearAttentionParam,
+    ShapeParam
 }
 
 table Op {

--- a/source/geometry/GeometryShape.cpp
+++ b/source/geometry/GeometryShape.cpp
@@ -6,13 +6,37 @@
 //  Copyright © 2018, Alibaba Group Holding Limited
 //
 
+#include <algorithm>
 #include <math.h>
+#include <utility>
 #include "core/AutoStorage.h"
 #include "geometry/GeometryComputer.hpp"
 #include "geometry/GeometryComputerUtils.hpp"
 #include "backend/cpu/compute/CommonOptFunction.h"
 
 namespace MNN {
+static std::pair<int, int> _resolveShapeRange(const Op* op, int rank) {
+    int start = 0;
+    int end = rank;
+    if (auto param = op->main_as_ShapeParam()) {
+        if (param->hasStart()) {
+            start = param->start();
+            if (start < 0) {
+                start += rank;
+            }
+        }
+        if (param->hasEnd()) {
+            end = param->end();
+            if (end < 0) {
+                end += rank;
+            }
+        }
+    }
+    start = std::max(0, std::min(start, rank));
+    end = std::max(start, std::min(end, rank));
+    return std::make_pair(start, end);
+}
+
 class GeometryShape : public GeometryComputer {
 public:
     virtual bool onCompute(const Op* op, const std::vector<Tensor*>& inputs, const std::vector<Tensor*>& outputs,
@@ -28,15 +52,22 @@ public:
         auto& ib         = inputs[0]->buffer();
         auto outputData = outputs[0]->host<int>();
         auto inputFormat = TensorUtils::getDescribe(inputs[0])->dimensionFormat;
+        int shapeData[MNN_MAX_TENSOR_DIM];
+        int rank = ib.dimensions;
         if ((inputFormat == MNN_DATA_FORMAT_NC4HW4) && TensorUtils::getDescribe(outputs[0])->dimensionFormat == MNN_DATA_FORMAT_NHWC) {
-            outputData[0] = ib.dim[0].extent;
-            outputData[1] = ib.dim[2].extent;
-            outputData[2] = ib.dim[3].extent;
-            outputData[3] = ib.dim[1].extent;
+            rank = 4;
+            shapeData[0] = ib.dim[0].extent;
+            shapeData[1] = ib.dim[2].extent;
+            shapeData[2] = ib.dim[3].extent;
+            shapeData[3] = ib.dim[1].extent;
         } else {
             for (int i = 0; i < ib.dimensions; i++) {
-                outputData[i] = ib.dim[i].extent;
+                shapeData[i] = ib.dim[i].extent;
             }
+        }
+        auto range = _resolveShapeRange(op, rank);
+        for (int i = range.first; i < range.second; ++i) {
+            outputData[i - range.first] = shapeData[i];
         }
         return true;
     }

--- a/source/shape/ShapeReshape.cpp
+++ b/source/shape/ShapeReshape.cpp
@@ -99,22 +99,41 @@ public:
             // For the model convert from tensorflow, the format is NHWC, otherwise NCHW
             fromTf          = TensorUtils::getDescribe(inputShape)->dimensionFormat == MNN_DATA_FORMAT_NHWC;
             dimSize         = inputShape->elementSize();
-            auto dim = inputShape->host<int32_t>();
             auto dimType = MNN_DATA_FORMAT_NHWC;
             if (OpParameter_Reshape == mainType) {
                 dimType = op->main_as_Reshape()->dimType();
             }
-            if ((inputFormat == MNN_DATA_FORMAT_NC4HW4) && dimType == MNN_DATA_FORMAT_NHWC) {
-                //NCHW / NC4HW4
-                //NHWC -> NCHW
-                shapes[0] = dim[0];
-                shapes[1] = dim[3];
-                shapes[2] = dim[1];
-                shapes[3] = dim[2];
-            } else {
-                for (int i = 0; i < dimSize; ++i) {
-                    shapes[i] = dim[i];
+            if (inputShape->buffer().type == halide_type_of<int32_t>()) {
+                auto dim = inputShape->host<int32_t>();
+                if ((inputFormat == MNN_DATA_FORMAT_NC4HW4) && dimType == MNN_DATA_FORMAT_NHWC) {
+                    //NCHW / NC4HW4
+                    //NHWC -> NCHW
+                    shapes[0] = dim[0];
+                    shapes[1] = dim[3];
+                    shapes[2] = dim[1];
+                    shapes[3] = dim[2];
+                } else {
+                    for (int i = 0; i < dimSize; ++i) {
+                        shapes[i] = dim[i];
+                    }
                 }
+            } else if (inputShape->buffer().type == halide_type_of<int64_t>()) {
+                auto dim = inputShape->host<int64_t>();
+                if ((inputFormat == MNN_DATA_FORMAT_NC4HW4) && dimType == MNN_DATA_FORMAT_NHWC) {
+                    //NCHW / NC4HW4
+                    //NHWC -> NCHW
+                    shapes[0] = (int)dim[0];
+                    shapes[1] = (int)dim[3];
+                    shapes[2] = (int)dim[1];
+                    shapes[3] = (int)dim[2];
+                } else {
+                    for (int i = 0; i < dimSize; ++i) {
+                        shapes[i] = (int)dim[i];
+                    }
+                }
+            } else {
+                MNN_ERROR("Invalid reshape shape type: code=%d bits=%d\n", inputShape->buffer().type.code, inputShape->buffer().type.bits);
+                return false;
             }
         }
         output->buffer().dimensions = dimSize;

--- a/source/shape/ShapeShape.cpp
+++ b/source/shape/ShapeShape.cpp
@@ -6,11 +6,35 @@
 //  Copyright © 2018, Alibaba Group Holding Limited
 //
 
+#include <algorithm>
+#include <utility>
 #include "shape/SizeComputer.hpp"
 #include "core/Macro.h"
 #include "core/TensorUtils.hpp"
 
 namespace MNN {
+
+static std::pair<int, int> _resolveShapeRange(const Op* op, int rank) {
+    int start = 0;
+    int end = rank;
+    if (auto param = op->main_as_ShapeParam()) {
+        if (param->hasStart()) {
+            start = param->start();
+            if (start < 0) {
+                start += rank;
+            }
+        }
+        if (param->hasEnd()) {
+            end = param->end();
+            if (end < 0) {
+                end += rank;
+            }
+        }
+    }
+    start = std::max(0, std::min(start, rank));
+    end = std::max(start, std::min(end, rank));
+    return std::make_pair(start, end);
+}
 
 class ShapeSizeComputer : public SizeComputer {
     virtual bool onComputeSize(const MNN::Op* op, const std::vector<Tensor*>& inputs,
@@ -24,12 +48,13 @@ class ShapeSizeComputer : public SizeComputer {
         outputs[0]->setType(DataType_DT_INT32);
         TensorUtils::getDescribe(outputs[0])->dimensionFormat = op->defaultDimentionFormat();
         auto inputFormat = TensorUtils::getDescribe(inputs[0])->dimensionFormat;
+        int rank = ib.dimensions;
         if (inputFormat == MNN_DATA_FORMAT_NC4HW4 && op->defaultDimentionFormat() == MNN_DATA_FORMAT_NHWC) {
             // For compability
-            ob.dim[0].extent = 4;
-        } else {
-            ob.dim[0].extent = ib.dimensions;
+            rank = 4;
         }
+        auto range = _resolveShapeRange(op, rank);
+        ob.dim[0].extent = range.second - range.first;
         return true;
     }
 };

--- a/test/op/ReshapeTest.cpp
+++ b/test/op/ReshapeTest.cpp
@@ -119,6 +119,37 @@ public:
         return true;
     }
 };
+class ReshapeInt64ShapeTest : public MNNTestCase {
+public:
+    virtual ~ReshapeInt64ShapeTest() = default;
+    virtual bool run(int precision) {
+        auto input = _Input({6}, NCHW);
+        input->setName("input_tensor");
+        const float inputData[] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+        auto inputPtr           = input->writeMap<float>();
+        memcpy(inputPtr, inputData, sizeof(inputData));
+        input->unMap();
+
+        const int64_t shapeData[] = {2, 3};
+        auto shape                = _Const(shapeData, {2}, NCHW, halide_type_of<int64_t>());
+        auto output               = _Reshape(input, shape);
+
+        const std::vector<float> expectedOutput = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+        auto gotOutput                          = output->readMap<float>();
+        if (!checkVector<float>(gotOutput, expectedOutput.data(), 6, 0.01f)) {
+            MNN_ERROR("ReshapeInt64ShapeTest values failed!\n");
+            return false;
+        }
+        const std::vector<int> expectedDim = {2, 3};
+        auto gotDim                        = output->getInfo()->dim;
+        if (!checkVector<int>(gotDim.data(), expectedDim.data(), (int)expectedDim.size(), 0)) {
+            MNN_ERROR("ReshapeInt64ShapeTest dims failed!\n");
+            return false;
+        }
+        return true;
+    }
+};
 MNNTestSuiteRegister(ReshapeNCHWTest, "op/reshape/nchw");
 MNNTestSuiteRegister(ReshapeNHWCTest, "op/reshape/nhwc");
 MNNTestSuiteRegister(ReshapeNC4HW4Test, "op/reshape/nc4hw4");
+MNNTestSuiteRegister(ReshapeInt64ShapeTest, "op/reshape/int64shape");

--- a/test/op/ShapeTest.cpp
+++ b/test/op/ShapeTest.cpp
@@ -8,6 +8,7 @@
 
 #include <MNN/expr/Expr.hpp>
 #include <MNN/expr/ExprCreator.hpp>
+#include "MNN_generated.h"
 #include "MNNTestSuite.h"
 #include "TestUtils.h"
 
@@ -33,4 +34,46 @@ public:
         return true;
     }
 };
+class ShapeSliceTest : public MNNTestCase {
+public:
+    virtual ~ShapeSliceTest() = default;
+    virtual bool run(int precision) {
+        auto input = _Input({2, 3, 5, 7}, NCHW);
+        input->setName("input_tensor");
+
+        std::unique_ptr<MNN::OpT> op(new MNN::OpT);
+        op->type                      = MNN::OpType_Shape;
+        op->main.type                 = MNN::OpParameter_ShapeParam;
+        op->main.value                = new MNN::ShapeParamT;
+        op->main.AsShapeParam()->hasStart = true;
+        op->main.AsShapeParam()->start    = 1;
+        op->main.AsShapeParam()->hasEnd   = true;
+        op->main.AsShapeParam()->end      = 3;
+        auto output = Variable::create(Expr::create(std::move(op), {input}));
+
+        const std::vector<int> expectedOutput = {3, 5};
+        auto gotOutput                        = output->readMap<int>();
+        if (!checkVector<int>(gotOutput, expectedOutput.data(), (int)expectedOutput.size(), 0)) {
+            MNN_ERROR("ShapeSliceTest positive slice failed!\n");
+            return false;
+        }
+
+        std::unique_ptr<MNN::OpT> negativeOp(new MNN::OpT);
+        negativeOp->type                      = MNN::OpType_Shape;
+        negativeOp->main.type                 = MNN::OpParameter_ShapeParam;
+        negativeOp->main.value                = new MNN::ShapeParamT;
+        negativeOp->main.AsShapeParam()->hasStart = true;
+        negativeOp->main.AsShapeParam()->start    = -2;
+        auto negativeOutput = Variable::create(Expr::create(std::move(negativeOp), {input}));
+
+        const std::vector<int> negativeExpected = {5, 7};
+        auto negativeGot                        = negativeOutput->readMap<int>();
+        if (!checkVector<int>(negativeGot, negativeExpected.data(), (int)negativeExpected.size(), 0)) {
+            MNN_ERROR("ShapeSliceTest negative start failed!\n");
+            return false;
+        }
+        return true;
+    }
+};
 MNNTestSuiteRegister(ShapeTest, "op/shape");
+MNNTestSuiteRegister(ShapeSliceTest, "op/shape/slice");

--- a/tools/converter/source/common/cli.cpp
+++ b/tools/converter/source/common/cli.cpp
@@ -790,16 +790,14 @@ bool Cli::convertModel(modelConfig& modelPath) {
 }
 
 static bool compareOutput(MNN::Express::VARP output, const std::string& directName, const std::string& name, MNN::Express::Dimensionformat dataFormat, int order, float maxError) {
+    if (output == nullptr) {
+        MNN_ERROR("TESTERROR name:%s, output is null.\n", name.c_str());
+        return false;
+    }
     auto info = output->getInfo();
-    auto ptr = output->readMap<float>();
     if (info && info->size <= 0) {
         MNN_PRINT("skip checking value for zero content tensor %s\n", name.c_str());
         return true;
-    }
-
-    if (nullptr == info || nullptr == ptr) {
-        MNN_ERROR("TESTERROR name:%s, info:%p, ptr:%p.\n", name.c_str(), info, ptr);
-        return false;
     }
     std::ifstream outputOrigin;
     // First find key
@@ -818,6 +816,10 @@ static bool compareOutput(MNN::Express::VARP output, const std::string& directNa
         MNN_PRINT("Skip check %s\n", name.c_str());
         return true;
     }
+    if (nullptr == info) {
+        MNN_ERROR("TESTERROR name:%s, info is null.\n", name.c_str());
+        return false;
+    }
     if (info->order == MNN::Express::NC4HW4 && info->dim.size() > 1) {
         output = _Convert(output, dataFormat);
         info = output->getInfo();
@@ -825,6 +827,11 @@ static bool compareOutput(MNN::Express::VARP output, const std::string& directNa
     if (info->type.code != halide_type_float) {
         output = MNN::Express::_Cast<float>(output);
         info = output->getInfo();
+    }
+    auto ptr = output->readMap<float>();
+    if (nullptr == info || nullptr == ptr) {
+        MNN_ERROR("TESTERROR name:%s, info:%p, ptr:%p.\n", name.c_str(), info, ptr);
+        return false;
     }
     MNN_PRINT("%s: (", name.c_str());
     for (int i=0; i<info->dim.size(); ++i) {
@@ -1026,7 +1033,12 @@ int Cli::testconvert(const std::string& defaultCacheFile, const std::string& dir
     bool modelError = false;
     // Module Branch
     auto outputs = net->onForward(inputs);
-    for (int i=0; i<outputNames.size(); ++i) {
+    if (outputs.size() != outputNames.size()) {
+        modelError = true;
+        MNN_ERROR("TESTERROR output size mismatch: module returns %zu outputs, test expects %zu.\n", outputs.size(), outputNames.size());
+    }
+    auto compareSize = (int)std::min(outputs.size(), outputNames.size());
+    for (int i=0; i<compareSize; ++i) {
         auto name = outputNames[i];
         auto v = outputs[i];
         auto info = v->getInfo();
@@ -1043,7 +1055,7 @@ int Cli::testconvert(const std::string& defaultCacheFile, const std::string& dir
         outputs[i] = v;
     }
 
-    for (int i=0; i<outputNames.size(); ++i) {
+    for (int i=0; i<compareSize; ++i) {
         auto output = outputs[i];
         bool success = compareOutput(output, directName, outputNames[i], mInfo->defaultFormat, i, maxErrorRate);
         if (!success) {
@@ -1054,7 +1066,7 @@ int Cli::testconvert(const std::string& defaultCacheFile, const std::string& dir
 
     if (modelError) {
         MNN_ERROR("Save mnn result to  .error director\n");
-        for (int i=0; i<outputNames.size(); ++i) {
+        for (int i=0; i<compareSize; ++i) {
             auto v = outputs[i];
             auto name = outputNames[i];
             auto info = v->getInfo();

--- a/tools/converter/source/onnx/ShapeOnnx.cpp
+++ b/tools/converter/source/onnx/ShapeOnnx.cpp
@@ -15,11 +15,25 @@ MNN::OpType ShapeOnnx::opType() {
     return MNN::OpType_Shape;
 }
 MNN::OpParameter ShapeOnnx::type() {
-    return MNN::OpParameter_NONE;
+    return MNN::OpParameter_ShapeParam;
 }
 
 void ShapeOnnx::run(MNN::OpT* dstOp, const onnx::NodeProto* onnxNode,
                     OnnxScope* scope) {
+    std::unique_ptr<MNN::ShapeParamT> shapeParam(new MNN::ShapeParamT);
+    for (int i = 0; i < onnxNode->attribute_size(); ++i) {
+        const auto& attributeProto = onnxNode->attribute(i);
+        const auto& attributeName  = attributeProto.name();
+        if (attributeName == "start") {
+            shapeParam->hasStart = true;
+            shapeParam->start = attributeProto.i();
+        }
+        if (attributeName == "end") {
+            shapeParam->hasEnd = true;
+            shapeParam->end = attributeProto.i();
+        }
+    }
+    dstOp->main.value = shapeParam.release();
     dstOp->defaultDimentionFormat = MNN::MNN_DATA_FORMAT_NCHW;
 }
 


### PR DESCRIPTION
## Summary

This PR fixes ONNX `Shape` conversion for `start` / `end` attributes and preserves `OpParameter` serialization compatibility.

## Changes

- add `ShapeParam` for ONNX `Shape` `start` / `end`
- parse `start` / `end` in ONNX `Shape` converter
- update shape inference and geometry compute for sliced shape output
- support `int64` shape tensor input for `Reshape`
- append `ShapeParam` to the end of `OpParameter` to preserve old serialized enum values
- add unit tests for `Shape(start/end)` and `Reshape` with `int64` shape tensor

## Validation

Passed local tests:

- `./run_test.out op/shape/slice`
- `./run_test.out op/reshape/int64shape`
- `./run_test.out op/shape`
- `./run_test.out op/reshape/nchw`
- `./run_test.out op/reshape/nhwc`
- `./run_test.out op/reshape/nc4hw4`

Fixes #4152