### PR TITLE
feat(llm): async token2wav pipeline across runtimes

### DIFF
--- a/transformers/llm/engine/src/omni.cpp
+++ b/transformers/llm/engine/src/omni.cpp
@@ -1169,6 +1169,7 @@ void Talker::generate_init(std::ostream* os, const char* end_with) {
     dit_start_index = 0;
     dit_left_padding = 0;
     vocoder_left_pad = 0;
+    mWavLastDone.store(false);
     {
         std::lock_guard<std::mutex> lock(mWavQueueMutex);
         std::queue<WavChunk>().swap(mWavQueue);
@@ -1317,16 +1318,13 @@ VARP Talker::token2wav(const std::vector<int>& codec_tokens) {
 }
 
 void Talker::startAsyncWorker() {
-    mWavWorkerRunning = true;
+    if (mWavWorkerRunning.exchange(true)) return; // already running
     mWavWorkerThread = std::thread(&Talker::asyncWorkerLoop, this);
 }
 
 void Talker::stopAsyncWorker() {
-    {
-        std::lock_guard<std::mutex> lock(mWavQueueMutex);
-        mWavWorkerRunning = false;
-    }
-    mWavQueueCond.notify_one();
+    mWavWorkerRunning.store(false);
+    mWavQueueCond.notify_all();
     if (mWavWorkerThread.joinable()) {
         mWavWorkerThread.join();
     }
@@ -1367,10 +1365,8 @@ void Talker::asyncWorkerLoop() {
         processWavChunk(chunk);
         
         if (chunk.is_last) {
-            std::lock_guard<std::mutex> lock(mWavQueueMutex);
-            if (mWavQueue.empty()) {
-                mWavQueueCond.notify_all();
-            }
+            mWavLastDone.store(true);
+            mWavQueueCond.notify_all();
         }
     }
 
@@ -1563,7 +1559,7 @@ void Talker::generate() {
             input_embeds = input_embeds + mTextPad;
         }
         auto logits = forward(input_embeds);
-        int token = Llm::sample(logits);
+        int token = sample(logits);
         mContext->current_token = token;
         mContext->history_tokens.push_back(token);
         mContext->output_tokens.push_back(token);
@@ -1583,10 +1579,11 @@ void Talker::generate() {
         
         std::unique_lock<std::mutex> lock(mWavQueueMutex);
         auto timeout = std::chrono::seconds(10);
-        bool drained = mWavQueueCond.wait_for(lock, timeout, [this] {
-            return mWavQueue.empty();
+        bool completed = mWavQueueCond.wait_for(lock, timeout, [this] {
+            return mWavLastDone.load();
         });
-        if (!drained) {
+        if (!completed) {
+            MNN_ERROR("Talker async worker timeout after 10s; audio may be incomplete\n");
         }
     } else {
         token2wav(true);

--- a/transformers/llm/engine/src/omni.hpp
+++ b/transformers/llm/engine/src/omni.hpp
@@ -13,6 +13,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <queue>
+#include <atomic>
 
 namespace MNN {
 using namespace Express;
@@ -119,7 +120,8 @@ private:
     std::mutex mWavQueueMutex;
     std::condition_variable mWavQueueCond;
     std::queue<WavChunk> mWavQueue;
-    bool mWavWorkerRunning = false;
+    std::atomic<bool> mWavWorkerRunning{false};
+    std::atomic<bool> mWavLastDone{false};
     bool mAsyncToken2Wav = false;
     // cloned modules for worker thread — independent Session/Runtime, shared weights
     std::shared_ptr<Module> mPreDit_async, mDit_async, mBigvgan_async;


### PR DESCRIPTION
下面是AI写的diff，大概这么个意思。
优化主要是基于前面分离RuntimeManager之后想到的并行优化。
源码写的串行生成在分离后就有点不适用了，主要在sample和generate部分进行了修改

## 背景

当配置 `mllm_config_` 时，`Omni::load()` 会创建 `mProcessorRuntimeManager`，用于视觉/音频/processor 侧模块的独立 backend/thread 配置：

```cpp
mProcessorRuntimeManager.reset(Executor::RuntimeManager::createRuntimeManager(config));
setRuntimeHint(mProcessorRuntimeManager);
```

在 `Talker::load()` 中，DIT / BigVGAN 等 token2wav 模块会优先加载到 `module_runtime = mProcessorRuntimeManager`；而 codec token 的自回归 decode（`mModule` forward + `Llm::sample`）仍在 Talker/LLM runtime 上执行。

在源代码的实现里，token2wav 会在 decode 线程内同步执行（要么每 token，要么 decode 完一次性），导致：

- decode 与 token2wav **串行互相阻塞**（即使它们在不同 runtime/backend 上）
- 流式音频 chunk 输出更不稳定

这个PR和之前的目标是一直的：**当 LLM runtime != processor runtime 时，优化并行性**


## 对比图

### Before：

```mermaid
flowchart LR
  A[Decode线程] --> B[生成token]
  B --> C[token2wav: DIT+BigVGAN\n同线程同步执行]
  C --> B
  C --> D[waveform callback]
```

### After：队列 + 可复用 worker 的异步流水线（本 PR）
```mermaid
flowchart LR
  subgraph T1["Decode线程（LLM runtime）"]
    A["生成 token"] --> S["trySubmitChunkAsync<br/>打包 WavChunk 并入队"]
    S --> Q[("WavChunk 队列")]
    S --> A
  end
  subgraph T2["Worker线程（processor runtime）"]
    Q --> W["processWavChunk<br/>DIT + BigVGAN（克隆模块）"]
    W --> CB["waveform callback"]
  end
```
核心点：

1) Decode 线程只负责生成 token，并在满足 chunk 条件时把任务（`WavChunk`）入队；不再被 DIT/vocoder 阻塞。
2) `generate()` 返回前等待队列 drain（带超时），保持“函数返回前音频已处理完成”的语义一致性。


## 相关修改

### 1) 仅在 runtime 不同时启用异步

上个PR里我将主LLM和用于生成音频的runtime分离了：
```cpp
auto module_runtime = mProcessorRuntimeManager ? mProcessorRuntimeManager : mRuntimeManager;
// ... load mPreDit/mDit/mBigvgan on module_runtime
return true;
```

这里我又增加了新的部分，让队列提前启动（因为测试的时候要用，而且提前启动不会delay到增加用时再启动的耗时）：
```cpp
auto module_runtime = mProcessorRuntimeManager ? mProcessorRuntimeManager : mRuntimeManager;
// ... load mPreDit/mDit/mBigvgan on module_runtime

mAsyncToken2Wav = (module_runtime.get() != mRuntimeManager.get());
if (mAsyncToken2Wav && doGenerate()) {
    startAsyncWorker();
}
return true;
```

### 2) 引入 `WavChunk` 作为任务边界 + 队列同步原语

源代码：
```cpp
// 无：token2wav 直接读取 mContext->output_tokens / mInitialNoise 等共享状态
```

修改后（`omni.hpp`）：
```cpp
struct WavChunk {
    std::vector<int> codec_tokens;
    std::vector<float> noise;
    int mel_slice_start = 0;
    int mel_slice_size = -1;
    bool is_last = false;
};
```

修改后（`Talker` 成员，`omni.hpp`）：
```cpp
std::thread mWavWorkerThread;
std::mutex mWavQueueMutex;
std::condition_variable mWavQueueCond;
std::queue<WavChunk> mWavQueue;
bool mWavWorkerRunning = false;
bool mAsyncToken2Wav = false;
```

### 3) Worker 线程：独立 ExecutorScope + clone 模块以隔离执行状态

源代码：
```cpp
// 无 worker 线程：DIT/BigVGAN 在 decode 线程内同步执行
```

修改后（`Talker::asyncWorkerLoop()` 核心片段）：
```cpp
auto executor = Express::Executor::newExecutor(forwardType, backendConfig, numThread);
Express::ExecutorScope scope(executor);

mPreDit_async.reset(Module::clone(mPreDit.get()));
mDit_async.reset(Module::clone(mDit.get()));
mBigvgan_async.reset(Module::clone(mBigvgan.get()));
mSpk_async = _Clone(mSpk, true);
mCond_async = _Clone(mCond, true);
```

### 4) `sample()`：从同步 token2wav 变为非阻塞提交 chunk

源代码：
```cpp
int Talker::sample(Express::VARP logits, int offset, int size) {
    MNN::Express::ExecutorScope s(mExecutor);
    int token = Llm::sample(logits, offset, size);
    if (mStreamWithDecode) {
        token2wav();
    }
    return token;
}
```

修改后：
```cpp
int Talker::sample(Express::VARP logits, int offset, int size) {
    MNN::Express::ExecutorScope s(mExecutor);
    int token = Llm::sample(logits, offset, size);
    if (mAsyncToken2Wav) {
        if (!mWavWorkerRunning) {
            startAsyncWorker();
        }
        trySubmitChunkAsync(false);
    } else if (mStreamWithDecode) {
        token2wav();
    }
    return token;
}
```

### 5) `generate()`：异步提交 + drain 等待，保持返回语义一致

源代码：
```cpp
void Talker::generate() {
    MNN::Express::ExecutorScope s(mExecutor);
    if (!doGenerate()) { return; }
    // ... decode loop
    mContext->decode_us += _t.durationInUs();
    token2wav(true);
}
```

修改后（核心片段）：
```cpp
void Talker::generate() {
    MNN::Express::ExecutorScope s(mExecutor);
    if (!doGenerate()) { return; }

    // ... decode loop
    if (mAsyncToken2Wav) {
        trySubmitChunkAsync(false);
    }

    mContext->decode_us += _t.durationInUs();
    if (mAsyncToken2Wav) {
        trySubmitChunkAsync(true);

        std::unique_lock<std::mutex> lock(mWavQueueMutex);
        auto timeout = std::chrono::seconds(10);
        mWavQueueCond.wait_for(lock, timeout, [this] {
            return mWavQueue.empty();
        });
    } else {
        token2wav(true);
    }
}
```

---

## 行为变化 / 注意点

1) **回调线程变化**：异步模式下 `mWavformCallback(...)` 在 **worker 线程**触发；同步模式则在 decode 线程触发。调用方需保证回调线程安全（或自行切回目标线程）。

2) **语义保持**：`generate()` 在异步模式下会等待队列 drain（带超时），使“返回前音频已处理完成”的语义与上游同步 `token2wav(true)` 保持一致。


---

## 为什么选“可复用 worker + 队列”

- **复用 worker + 一次性 clone**：避免每次生成反复创建线程/clone 模块带来的启动尖峰与抖动。
- **WavChunk 任务边界清晰**：worker 不直接读写 decode 线程的动态上下文（如 `mContext->output_tokens`），降低数据竞争风险，review 更容易。
- **真正跨后端重叠**：在 LLM runtime 与 processor runtime 不同的情况下，使 decode 与 token2wav 能并行推进，提高吞吐并改善流式稳定性。

下面是测试程序
```cpp
#include "llm/llm.hpp"
#include <MNN/AutoTime.hpp>
#include <MNN/expr/ExecutorScope.hpp>
#include <MNN/expr/Expr.hpp>
#include <MNN/expr/ExprCreator.hpp>


#include "audio/audio.hpp"

#include <cstdint>
#include <fstream>
#include <iostream>
#include <memory>
#include <sstream>
#include <string>
#include <vector>

using namespace MNN;
using namespace MNN::Express;
using namespace MNN::Transformer;

static void saveWaveToFile(const std::vector<float> &waveform,
                           const std::string &outPath, int sampleRate = 24000) {
  if (waveform.empty()) {
    MNN_PRINT("No waveform data, skip save.\n");
    return;
  }
  auto var = _Const(waveform.data(), {(int)waveform.size()}, NCHW,
                    halide_type_of<float>());
  bool ok = AUDIO::save(outPath.c_str(), var, sampleRate);
  if (!ok) {
    MNN_ERROR("Save wav to %s failed.\n", outPath.c_str());
  } else {
    MNN_PRINT("Waveform saved to: %s\n", outPath.c_str());
  }
}

/**
 * 构造一个带音频输入标签的 prompt：
 *   <audio>audio_path</audio> + 用户自定义问题
 */
static std::string buildAudioPrompt(const std::string &audioPath,
                                    const std::string &userQuestion) {
  std::ostringstream os;
  os << "<audio>" << audioPath << "</audio>";
  if (!userQuestion.empty()) {
    os << userQuestion;
  } else {
    os << "";
  }
  return os.str();
}

int main(int argc, const char *argv[]) {
  if (argc < 3) {
    std::cout << "Usage:\n";
    std::cout << "  " << argv[0]
              << " <config.json> <audio.wav> [output.wav] [question]\n\n";
    std::cout << "示例：\n";
    std::cout
        << "  " << argv[0]
        << " D:/Project/models/qwen2.5/config.json "
           "C:/Users/wu_mi/Documents/录音/audio.wav output.wav \"请把内容翻译成中文并简要概括\"\n";
    return 0;
  }

  std::string configPath = argv[1];
  std::string audioPath = argv[2];
  std::string outWave = "output.wav";
  if (argc >= 4) {
    outWave = argv[3];
  }

  std::string question;
  if (argc >= 5) {
    // 剩余参数合并成一句话
    std::ostringstream q;
    for (int i = 4; i < argc; ++i) {
      if (i > 4)
        q << " ";
      q << argv[i];
    }
    question = q.str();
  }

  std::cout << "Config : " << configPath << std::endl;
  std::cout << "Audio  : " << audioPath << std::endl;
  std::cout << "OutWav : " << outWave << std::endl;

  BackendConfig backendConfig;
  auto executor =
      Express::Executor::newExecutor(MNN_FORWARD_CPU, backendConfig, 1);
  Express::ExecutorScope scope(executor);

  std::unique_ptr<Llm> llm(Llm::createLLM(configPath));
  if (!llm) {
    MNN_ERROR("Create LLM failed, check config.json path.\n");
    return 1;
  }

  llm->set_config(R"({"tmp_path":"tmp"})");
  llm->set_config(R"({"async":false})");

  int64_t load_us = 0;
  {
    MNN::Timer _t;
    bool ok = llm->load();
    load_us = _t.durationInUs();
    if (!ok) {
      MNN_ERROR("LLM load failed, please check your Omni model files.\n");
      return 1;
    }
  }

  // 收集语音输出（仅在回调中累积数据，不做 Express 操作）
  std::vector<float> waveform;
  llm->setWavformCallback([&](const float *ptr, size_t size, bool last_chunk) {
    if (ptr && size > 0) {
      waveform.insert(waveform.end(), ptr, ptr + size);
    }
    return true;
  });

  // 构造带音频标签的 prompt
  auto prompt = buildAudioPrompt(audioPath, question);
  std::cout << "\n==== Prompt ====\n" << prompt << "\n================\n";

  auto context = llm->getContext();

  MNN::Timer _genTimer;
  llm->response(prompt, &std::cout);

  llm->generateWavform();
  uint64_t gen_us = _genTimer.durationInUs();
  saveWaveToFile(waveform, outWave);

  std::cout << "\n\n===== Stats =====\n";
  std::cout << "Prompt tokens : " << context->prompt_len << "\n";
  std::cout << "Decode tokens : " << context->gen_seq_len << "\n";
  std::cout << "Audio input s : " << context->audio_input_s << "\n";
  std::cout << "Audio proc  s : " << (context->audio_us / 1e6) << "\n";
  std::cout << "Load time    : " << (load_us / 1e6) << "\n";
  std::cout << "Gen time     : " << (gen_us / 1e6) << "\n";
  if (context->audio_input_s > 0.0f) {
    std::cout << "Audio RTF     : "
              << (context->audio_us / 1e6 / context->audio_input_s) << "\n";
  }
  std::cout << "=================\n";

  return 0;
}
```

prompt为空，只有一个音频文件的输入，音频文件内容为：”Hello,please introduce yourself.“

加了队列 opencl+cpu
<img width="1279" height="431" alt="屏幕截图 2026-03-11 113303" src="https://github.com/user-attachments/assets/c069cd5c-8333-4612-b5d8-6fa72d752ced" />
加了队列 cpu+cpu
<img width="1690" height="444" alt="屏幕截图 2026-03-11 113258" src="https://github.com/user-attachments/assets/623bb56f-4d6e-480a-9344-63d8380d47c6" />

没加队列 opencl+cpu
<img width="1312" height="456" alt="屏幕截图 2026-03-11 113701" src="https://github.com/user-attachments/assets/b8fc0e55-8f75-4147-a55d-cca9579f0ebf" />

没加队列 cpu+cpu
<img width="1718" height="461" alt="屏幕截图 2026-03-11 113941" src="https://github.com/user-attachments/assets/d2b7553f-eea1-4108-85f3-7c94673b7b28" />

纯cpu模式下影响不大，主要是runtime不同的情况差距比较明显一点


