### PR TITLE
Add header for uint8_t and fix build with gcc 15.2.

### DIFF
--- a/transformers/diffusion/engine/src/tokenizer.hpp
+++ b/transformers/diffusion/engine/src/tokenizer.hpp
@@ -1,5 +1,6 @@
 #include <vector>
 #include <string>
+#include <cstdint>
 #include <unordered_map>
 
 #ifndef MNN_DIFFUSION_TOKENIZER_HPP

--- a/transformers/llm/engine/src/tokenizer.hpp
+++ b/transformers/llm/engine/src/tokenizer.hpp
@@ -15,6 +15,7 @@
 #include <iostream>
 // #include <string_view>
 #include <cstring>
+#include <cstdint>
 class string_view_ {
 public:
     string_view_() : data_(nullptr), size_(0) {}


### PR DESCRIPTION
Fix MNN cli build with the gcc 15.2 without this patch compiler gives error, because uint8_t is undefined.