### PR TITLE
fix(android): restore chat auto-scroll after resume

### DIFF
--- a/apps/Android/MnnLlmChat/app/src/androidTest/java/com/alibaba/mnnllm/android/chat/ChatAutoScrollUiAutomatorTest.kt
+++ b/apps/Android/MnnLlmChat/app/src/androidTest/java/com/alibaba/mnnllm/android/chat/ChatAutoScrollUiAutomatorTest.kt
@@ -1,0 +1,146 @@
+package com.alibaba.mnnllm.android.chat
+
+import android.content.Intent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiObject2
+import androidx.test.uiautomator.Until
+import com.alibaba.mnnllm.android.R
+import org.junit.After
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ChatAutoScrollUiAutomatorTest {
+
+    private data class ChatProbe(
+        val atBottom: Boolean,
+        val bottomGapPx: Int,
+        val userScrolling: Boolean,
+        val assistantChars: Int
+    )
+
+    private lateinit var device: UiDevice
+    private val timeoutMs = 10_000L
+    private val settleMs = 2_000L
+    private val streamObserveMs = 300L
+    private val streamAdvanceTimeoutMs = 2_000L
+
+    @Before
+    fun setup() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        device = UiDevice.getInstance(instrumentation)
+        device.setOrientationNatural()
+        val context = instrumentation.targetContext
+        val intent = Intent().apply {
+            setClassName(context.packageName, "com.alibaba.mnnllm.android.chat.ChatActivity")
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            putExtra("modelName", "Qwen")
+            putExtra("modelId", "mock")
+            putExtra(ChatActivity.EXTRA_MOCK_STREAM_ENABLE, true)
+            putExtra(ChatActivity.EXTRA_MOCK_STREAM_TEXT_LENGTH, 8000)
+            putExtra(ChatActivity.EXTRA_MOCK_STREAM_INTERVAL_MS, 10L)
+            putExtra(ChatActivity.EXTRA_MOCK_STREAM_LINE_WIDTH, 6)
+            putExtra(ChatActivity.EXTRA_MOCK_STREAM_DETACH_AT_CHARS, 400)
+            putExtra(ChatActivity.EXTRA_MOCK_STREAM_PAUSE_ON_DETACH, true)
+        }
+        context.startActivity(intent)
+        device.wait(Until.hasObject(By.pkg(context.packageName).depth(0)), timeoutMs)
+        assertNotNull(
+            "Chat recyclerView not found after launching mock ChatActivity",
+            device.wait(Until.findObject(By.res(context.packageName, "recyclerView")), timeoutMs)
+        )
+    }
+
+    @After
+    fun tearDown() {
+        device.unfreezeRotation()
+    }
+
+    @Test
+    fun scrollToBottomRestoresAutoScrollDuringStreaming() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val packageName = context.packageName
+
+        val recycler = device.wait(Until.findObject(By.res(packageName, "recyclerView")), timeoutMs)
+        assertNotNull("Chat recyclerView not found", recycler)
+
+        Thread.sleep(1_500L)
+
+        val scrollButton = device.wait(
+            Until.findObject(By.desc(context.getString(R.string.scroll_to_bottom))),
+            timeoutMs
+        )
+        assertNotNull("Scroll-to-bottom button did not appear after user scroll", scrollButton)
+        val beforeClick = readProbe(packageName)
+        assertTrue("Expected chat list to leave bottom after manual swipe: $beforeClick", !beforeClick.atBottom)
+        assertTrue("Expected user scrolling state to be true after manual swipe: $beforeClick", beforeClick.userScrolling)
+        scrollButton!!.click()
+
+        Thread.sleep(300L)
+
+        var previous = readProbe(packageName)
+        assertTrue("Scroll-to-bottom tap should clear user scrolling state: $previous", !previous.userScrolling)
+        assertTrue("Scroll-to-bottom tap should bring chat back to bottom: $previous", previous.atBottom)
+
+        repeat(3) { sampleIndex ->
+            val current = waitForAssistantCharsToIncrease(packageName, previous.assistantChars)
+            assertTrue(
+                "Mock stream did not continue after tapping scroll-to-bottom at sample $sampleIndex",
+                current.assistantChars > previous.assistantChars
+            )
+            assertTrue(
+                "Chat stopped following new content after tapping scroll-to-bottom at sample $sampleIndex: $current",
+                current.atBottom
+            )
+            assertTrue(
+                "User scrolling state unexpectedly stayed true after tapping scroll-to-bottom at sample $sampleIndex: $current",
+                !current.userScrolling
+            )
+            previous = current
+        }
+    }
+
+    private fun waitForAssistantCharsToIncrease(packageName: String, previousChars: Int): ChatProbe {
+        val deadline = System.currentTimeMillis() + streamAdvanceTimeoutMs
+        var latest = readProbe(packageName)
+        while (System.currentTimeMillis() < deadline) {
+            if (latest.assistantChars > previousChars) {
+                return latest
+            }
+            Thread.sleep(streamObserveMs)
+            latest = readProbe(packageName)
+        }
+        return latest
+    }
+
+    private fun readProbe(packageName: String): ChatProbe {
+        val recycler = device.findObject(By.res(packageName, "recyclerView"))
+        assertNotNull("Chat recyclerView not found while reading probe", recycler)
+        return parseProbe(recycler!!)
+    }
+
+    private fun parseProbe(recycler: UiObject2): ChatProbe {
+        val description = recycler.contentDescription?.toString()
+        assertNotNull("RecyclerView debug probe missing", description)
+        val values = description!!
+            .split(';')
+            .mapNotNull { entry ->
+                val parts = entry.split('=', limit = 2)
+                if (parts.size == 2) parts[0] to parts[1] else null
+            }
+            .toMap()
+
+        return ChatProbe(
+            atBottom = values["atBottom"].toBoolean(),
+            bottomGapPx = values["bottomGapPx"]?.toIntOrNull() ?: Int.MAX_VALUE,
+            userScrolling = values["userScrolling"].toBoolean(),
+            assistantChars = values["assistantChars"]?.toIntOrNull() ?: -1
+        )
+    }
+}

--- a/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mnnllm/android/chat/ChatActivity.kt
+++ b/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mnnllm/android/chat/ChatActivity.kt
@@ -5,6 +5,8 @@ package com.alibaba.mnnllm.android.chat
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
@@ -19,6 +21,7 @@ import kotlinx.coroutines.flow.first
 import com.alibaba.mls.api.ApplicationProvider
 import com.alibaba.mnnllm.android.llm.ChatSession
 import com.alibaba.mnnllm.android.R
+import com.alibaba.mnnllm.android.BuildConfig
 import com.alibaba.mnnllm.android.audio.AudioChunksPlayer
 import com.alibaba.mnnllm.android.benchmark.BenchmarkModule
 import com.alibaba.mnnllm.android.modelist.ModelListManager
@@ -100,6 +103,9 @@ class ChatActivity : AppCompatActivity() {
 
     private var benchmarkModule: BenchmarkModule = BenchmarkModule(activity = this)
     private lateinit var voiceModelsChecker: VoiceModelsChecker
+    private var isMockStreamSession: Boolean = false
+    private val mockStreamHandler = Handler(Looper.getMainLooper())
+    private var mockStreamRunnable: Runnable? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -124,6 +130,12 @@ class ChatActivity : AppCompatActivity() {
             }
         }
         setupView(this.modelId!!, this.modelName)
+        if (shouldStartMockStream()) {
+            isMockStreamSession = true
+            chatListComponent.setup(modelName, emptyList())
+            startMockStream()
+            return
+        }
         this.setupSession()
         initializeVoiceModelsChecker()
     }
@@ -201,6 +213,110 @@ class ChatActivity : AppCompatActivity() {
         onSessionCreated()
         Log.d(TAG, "current SessionId: $sessionId")
         chatPresenter.load()
+    }
+
+    private fun shouldStartMockStream(): Boolean {
+        if (!BuildConfig.DEBUG) {
+            return false
+        }
+        return intent.getBooleanExtra(EXTRA_MOCK_STREAM_ENABLE, false)
+    }
+
+    private fun startMockStream() {
+        val textLength = intent.getIntExtra(
+            EXTRA_MOCK_STREAM_TEXT_LENGTH,
+            DEFAULT_MOCK_STREAM_TEXT_LENGTH
+        ).coerceAtLeast(1)
+        val intervalMs = intent.getLongExtra(
+            EXTRA_MOCK_STREAM_INTERVAL_MS,
+            DEFAULT_MOCK_STREAM_INTERVAL_MS
+        ).coerceAtLeast(1L)
+        val lineWidth = intent.getIntExtra(
+            EXTRA_MOCK_STREAM_LINE_WIDTH,
+            DEFAULT_MOCK_STREAM_LINE_WIDTH
+        ).coerceAtLeast(1)
+        val detachAtChars = intent.getIntExtra(
+            EXTRA_MOCK_STREAM_DETACH_AT_CHARS,
+            DEFAULT_MOCK_STREAM_DETACH_AT_CHARS
+        )
+        val pauseOnDetach = intent.getBooleanExtra(
+            EXTRA_MOCK_STREAM_PAUSE_ON_DETACH,
+            false
+        )
+        val mockText = buildMockStreamText(textLength, lineWidth)
+        val userData = createUserMessage("mock long stream")
+        onGenerateStart(userData)
+        val processor = GenerateResultProcessor()
+        processor.generateBegin()
+        mockStreamRunnable?.let(mockStreamHandler::removeCallbacks)
+
+        var nextIndex = 0
+        var didDetachFromBottom = false
+        var mockStreamPaused = false
+        chatListComponent.setOnResumeAutoScrollListener {
+            mockStreamPaused = false
+        }
+        val streamRunnable = object : Runnable {
+            override fun run() {
+                if (isDestroyed) {
+                    return
+                }
+                if (mockStreamPaused) {
+                    mockStreamHandler.postDelayed(this, intervalMs)
+                    return
+                }
+                if (nextIndex >= mockText.length) {
+                    val bench = HashMap<String, Any>().apply {
+                        put("response", processor.getRawResult())
+                        put("prompt_len", 1L)
+                        put("decode_len", mockText.length.toLong())
+                        put("prefill_time", 1L)
+                        put("decode_time", mockText.length.toLong() * intervalMs * 1000L)
+                    }
+                    onGenerateFinished(bench)
+                    mockStreamRunnable = null
+                    return
+                }
+                val chunk = mockText[nextIndex].toString()
+                nextIndex += 1
+                processor.process(chunk)
+                onLlmGenerateProgress(chunk, processor)
+                if (!didDetachFromBottom && detachAtChars > 0 && nextIndex >= detachAtChars) {
+                    didDetachFromBottom = true
+                    if (pauseOnDetach) {
+                        mockStreamPaused = true
+                    }
+                    chatListComponent.detachFromBottomForTest()
+                }
+                mockStreamHandler.postDelayed(this, intervalMs)
+            }
+        }
+        mockStreamRunnable = streamRunnable
+        mockStreamHandler.post(streamRunnable)
+    }
+
+    private fun buildMockStreamText(length: Int, lineWidth: Int): String {
+        val base = "mockstreamoutput"
+        val builder = StringBuilder(length + 64)
+        var sourceIndex = 0
+        var currentLineWidth = 0
+        while (builder.length < length) {
+            if (currentLineWidth >= lineWidth) {
+                builder.append("\n\n")
+                currentLineWidth = 0
+                if (builder.length >= length) {
+                    break
+                }
+            }
+            val nextChar = base[sourceIndex]
+            builder.append(nextChar)
+            sourceIndex = (sourceIndex + 1) % base.length
+            currentLineWidth = if (nextChar == '\n') 0 else currentLineWidth + 1
+        }
+        if (builder.length > length) {
+            builder.setLength(length)
+        }
+        return builder.toString()
     }
 
     private fun setupOmni() {
@@ -508,6 +624,8 @@ class ChatActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
+        mockStreamRunnable?.let(mockStreamHandler::removeCallbacks)
+        mockStreamRunnable = null
         audioPlayer?.destroy()
         audioPlayer = null
         
@@ -648,6 +766,10 @@ class ChatActivity : AppCompatActivity() {
         
         recentItem.benchmarkInfo = ModelUtils.generateBenchMarkString(benchMarkResult)
         chatListComponent.updateAssistantResponse(recentItem)
+
+        if (isMockStreamSession) {
+            return
+        }
         
         // Always save to database, even for errors, to maintain conversation history
         try {
@@ -889,6 +1011,16 @@ class ChatActivity : AppCompatActivity() {
 
     companion object {
         const val TAG: String = "ChatActivity"
+        const val EXTRA_MOCK_STREAM_ENABLE = "mock_stream_enable"
+        const val EXTRA_MOCK_STREAM_TEXT_LENGTH = "mock_stream_text_length"
+        const val EXTRA_MOCK_STREAM_INTERVAL_MS = "mock_stream_interval_ms"
+        const val EXTRA_MOCK_STREAM_LINE_WIDTH = "mock_stream_line_width"
+        const val EXTRA_MOCK_STREAM_DETACH_AT_CHARS = "mock_stream_detach_at_chars"
+        const val EXTRA_MOCK_STREAM_PAUSE_ON_DETACH = "mock_stream_pause_on_detach"
+        private const val DEFAULT_MOCK_STREAM_TEXT_LENGTH = 2000
+        private const val DEFAULT_MOCK_STREAM_INTERVAL_MS = 30L
+        private const val DEFAULT_MOCK_STREAM_LINE_WIDTH = 24
+        private const val DEFAULT_MOCK_STREAM_DETACH_AT_CHARS = -1
         private var _chatPresenter: ChatPresenter? = null
         fun getChatPresenter(): ChatPresenter? {
             return this._chatPresenter

--- a/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mnnllm/android/chat/chatlist/ChatListComponent.kt
+++ b/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mnnllm/android/chat/chatlist/ChatListComponent.kt
@@ -11,6 +11,8 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.annotation.VisibleForTesting
+import com.alibaba.mnnllm.android.BuildConfig
 import com.alibaba.mnnllm.android.R
 import com.alibaba.mnnllm.android.chat.ChatActivity.Companion.TAG
 import com.alibaba.mnnllm.android.chat.model.ChatDataItem
@@ -49,8 +51,10 @@ class ChatListComponent(private val context: Context,
     private lateinit var emptyMessageTextView: TextView
     private lateinit var btnScrollToBottom: View
     private var isUserScrolling: Boolean = false
+    private var forceBottomDuringStreaming: Boolean = false
     private var modelName:String? = null
     private var historyData: List<ChatDataItem>? = null
+    private var onResumeAutoScrollListener: (() -> Unit)? = null
 
     init {
         setupRecyclerView()
@@ -107,13 +111,18 @@ class ChatListComponent(private val context: Context,
         recyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
             override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
                 super.onScrollStateChanged(recyclerView, newState)
+                if (newState == RecyclerView.SCROLL_STATE_DRAGGING) {
+                    forceBottomDuringStreaming = false
+                }
                 isUserScrolling = resolveUserScrollingState(isUserScrolling, newState, isAtBottom())
                 updateScrollToBottomButtonVisibility()
+                updateDebugProbe()
             }
 
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
                 super.onScrolled(recyclerView, dx, dy)
                 updateScrollToBottomButtonVisibility()
+                updateDebugProbe()
             }
 
         })
@@ -128,7 +137,7 @@ class ChatListComponent(private val context: Context,
     private fun setupScrollToBottomButton() {
         btnScrollToBottom = binding.btnScrollToBottom
         btnScrollToBottom.setOnClickListener {
-            scrollToBottom()
+            resumeAutoScroll()
         }
     }
 
@@ -179,19 +188,44 @@ class ChatListComponent(private val context: Context,
         Log.d(TAG, "scrollToBottom")
         val position = adapter.itemCount - 1
         if (position >= 0) {
-            // Use two steps to ensure scrolling to the very bottom
             recyclerView.post {
-                // Step 1: First scroll to the last item
                 recyclerView.scrollToPosition(position)
-                // Step 2: Ensure scrolling to the very bottom
                 recyclerView.post {
                     linearLayoutManager.scrollToPositionWithOffset(position, -99999)
-                    // Add a short delay to ensure the scroll is complete before checking button state
-                    recyclerView.postDelayed({
-                        updateScrollToBottomButtonVisibility()
-                    }, 50)
+                    recyclerView.post(object : Runnable {
+                        private var attempts = 0
+
+                        override fun run() {
+                            val remainingDistance = distanceFromBottomPx()
+                            if (remainingDistance <= scrollToBottomThresholdPx() || attempts >= 4) {
+                                updateScrollToBottomButtonVisibility()
+                                return
+                            }
+                            attempts += 1
+                            recyclerView.scrollBy(0, remainingDistance)
+                            recyclerView.post(this)
+                        }
+                    })
                 }
             }
+        }
+    }
+
+    private fun resumeAutoScroll() {
+        isUserScrolling = false
+        forceBottomDuringStreaming = true
+        scrollToBottom()
+        updateScrollToBottomButtonVisibility()
+        onResumeAutoScrollListener?.invoke()
+    }
+
+    private fun maintainBottomDuringStreaming() {
+        recyclerView.post {
+            val remainingDistance = distanceFromBottomPx()
+            if (remainingDistance > 0) {
+                recyclerView.scrollBy(0, remainingDistance)
+            }
+            updateScrollToBottomButtonVisibility()
         }
     }
 
@@ -202,23 +236,29 @@ class ChatListComponent(private val context: Context,
         } else {
             btnScrollToBottom.visibility = View.GONE
         }
+        updateDebugProbe()
     }
 
     private fun isAtBottom(): Boolean {
+        return distanceFromBottomPx() < scrollToBottomThresholdPx()
+    }
+
+    private fun scrollToBottomThresholdPx(): Int {
+        return (SCROLL_TO_BOTTOM_THRESHOLD_DP * context.resources.displayMetrics.density).toInt()
+    }
+
+    private fun distanceFromBottomPx(): Int {
         val totalItemCount = adapter.itemCount
-        if (totalItemCount == 0) return true
+        if (totalItemCount == 0) return 0
 
         if (!recyclerView.canScrollVertically(1)) {
-            return true
+            return 0
         }
 
-        val thresholdPx = (SCROLL_TO_BOTTOM_THRESHOLD_DP * context.resources.displayMetrics.density).toInt()
         val range = recyclerView.computeVerticalScrollRange()
         val extent = recyclerView.computeVerticalScrollExtent()
         val offset = recyclerView.computeVerticalScrollOffset()
-        val distanceFromBottom = range - extent - offset
-
-        return distanceFromBottom < thresholdPx
+        return (range - extent - offset).coerceAtLeast(0)
     }
 
     private fun addResponsePlaceholder() {
@@ -231,7 +271,11 @@ class ChatListComponent(private val context: Context,
     fun updateAssistantResponse(chatDataItem: ChatDataItem) {
         adapter.updateRecentItem(chatDataItem)
         if (!isUserScrolling) {
-            scrollToEnd()
+            if (forceBottomDuringStreaming) {
+                maintainBottomDuringStreaming()
+            } else {
+                scrollToEnd()
+            }
         }
         updateEmptyViewVisibility()
         updateScrollToBottomButtonVisibility()
@@ -239,6 +283,7 @@ class ChatListComponent(private val context: Context,
 
     fun onStartSendMessage(userData: ChatDataItem) {
         isUserScrolling = false
+        forceBottomDuringStreaming = false
         adapter.addItem(userData)
         addResponsePlaceholder()
         updateEmptyViewVisibility()
@@ -264,7 +309,51 @@ class ChatListComponent(private val context: Context,
         return wasReset
     }
 
+    @VisibleForTesting
+    internal fun setUserScrollingForTest(value: Boolean) {
+        isUserScrolling = value
+    }
+
+    @VisibleForTesting
+    internal fun detachFromBottomForTest() {
+        isUserScrolling = true
+        recyclerView.post {
+            val detachStep = recyclerView.height.coerceAtLeast(1)
+            var leftBottom = false
+            for (attempt in 0 until 4) {
+                recyclerView.scrollBy(0, -detachStep)
+                if (!isAtBottom()) {
+                    leftBottom = true
+                    break
+                }
+            }
+            if (!leftBottom) {
+                recyclerView.scrollBy(0, -detachStep)
+            }
+            updateScrollToBottomButtonVisibility()
+        }
+    }
+
+    @VisibleForTesting
+    internal fun isUserScrollingForTest(): Boolean = isUserScrolling
+
     fun getCurrentChatHistory(): List<ChatDataItem> {
         return adapter.getCurrentChatHistory()
+    }
+
+    fun setOnResumeAutoScrollListener(listener: (() -> Unit)?) {
+        onResumeAutoScrollListener = listener
+    }
+
+    private fun updateDebugProbe() {
+        if (!BuildConfig.DEBUG) {
+            return
+        }
+        recyclerView.contentDescription = buildString {
+            append("atBottom=").append(isAtBottom())
+            append(";bottomGapPx=").append(distanceFromBottomPx())
+            append(";userScrolling=").append(isUserScrolling)
+            append(";assistantChars=").append(recentItem?.displayText?.length ?: 0)
+        }
     }
 }

--- a/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mnnllm/android/chat/voice/VoiceChatPresenter.kt
+++ b/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mnnllm/android/chat/voice/VoiceChatPresenter.kt
@@ -68,6 +68,8 @@ class VoiceChatPresenter(
     private var isStopped = false
     private var isStoppingGeneration = false
     private var isGenerationFinished = false
+    private var isMuted = false
+    private var isAutoMuteForEchoCancelMode = false
     
     // For handling LLM generation progress with thinking support
     private var generateResultProcessor: GenerateResultProcessor? = null
@@ -222,6 +224,9 @@ class VoiceChatPresenter(
         
         // Register this presenter as an additional listener to ChatPresenter
         chatPresenter.addGenerateListener(this)
+
+        view.updateMuteButtonState(isMuted)
+        view.updateEchoCancelMode(isAutoMuteForEchoCancelMode)
         
         initTts()
         startAsr()
@@ -513,6 +518,19 @@ class VoiceChatPresenter(
         Log.d(TAG, "Speaker toggled: $isSpeakerOn")
     }
 
+    fun toggleMute() {
+        isMuted = !isMuted
+        asrService?.setMuted(isMuted)
+        view.updateMuteButtonState(isMuted)
+        Log.d(TAG, "Microphone mute toggled: $isMuted")
+    }
+
+    fun toggleEchoCancelMode() {
+        isAutoMuteForEchoCancelMode = !isAutoMuteForEchoCancelMode
+        view.updateEchoCancelMode(isAutoMuteForEchoCancelMode)
+        Log.d(TAG, "Echo cancel mode toggled, auto mute: $isAutoMuteForEchoCancelMode")
+    }
+
     fun stopGeneration() {
         Log.d(TAG, "Stopping generation...")
         if (isProcessingLlm || isSpeaking) {
@@ -644,6 +662,8 @@ interface VoiceChatView {
     fun showError(message: String)
     fun stopGeneration()
     fun showGreetingMessage()
+    fun updateMuteButtonState(isMuted: Boolean)
+    fun updateEchoCancelMode(isAutoMuteForEchoCancelMode: Boolean)
 }
 
 interface TtsClient {

--- a/apps/Android/MnnLlmChat/app/src/main/res/values-zh/strings.xml
+++ b/apps/Android/MnnLlmChat/app/src/main/res/values-zh/strings.xml
@@ -406,6 +406,9 @@
     <string name="voice_chat_stop">停止</string>
     <string name="voice_chat_stopping">正在停止...</string>
     <string name="voice_chat_ready_greeting">有什么可以帮助您的？</string>
+    <string name="echo_cancellation_mode">回声消除</string>
+    <string name="mic_mode_hardware">硬件</string>
+    <string name="mic_mode_auto_mute">自动静音</string>
     <string name="voice_chat_usage_notice">使用语音聊天需要下载TTS和ASR模型，请注意多语言支持。</string>
     <string name="nav_name_chats">我的模型</string>
     <string name="benchmark">性能评测</string>

--- a/apps/Android/MnnLlmChat/app/src/main/res/values/strings.xml
+++ b/apps/Android/MnnLlmChat/app/src/main/res/values/strings.xml
@@ -420,6 +420,9 @@
     <string name="voice_chat_stop">Stop</string>
     <string name="voice_chat_stopping">Stopping...</string>
     <string name="voice_chat_ready_greeting">What can I help you with?</string>
+    <string name="echo_cancellation_mode">Echo Cancellation</string>
+    <string name="mic_mode_hardware">Hardware</string>
+    <string name="mic_mode_auto_mute">Auto Mute</string>
     <string name="voice_chat_usage_notice">To use voice chat, TTS and ASR models need to be downloaded. Please note multi-language support.</string>
     <string name="nav_name_chats">My Models</string>
     <string name="benchmark">Benchmark</string>

--- a/apps/Android/MnnLlmChat/app/src/test/java/com/alibaba/mnnllm/android/chat/ChatActivityMockStreamAutoScrollTest.kt
+++ b/apps/Android/MnnLlmChat/app/src/test/java/com/alibaba/mnnllm/android/chat/ChatActivityMockStreamAutoScrollTest.kt
@@ -1,0 +1,54 @@
+package com.alibaba.mnnllm.android.chat
+
+import android.content.Intent
+import android.os.Looper
+import android.view.View
+import androidx.test.core.app.ApplicationProvider
+import com.alibaba.mnnllm.android.R
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+import org.robolectric.Shadows.shadowOf
+import java.util.concurrent.TimeUnit
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+@LooperMode(LooperMode.Mode.PAUSED)
+class ChatActivityMockStreamAutoScrollTest {
+
+    @Test
+    fun `scroll to bottom should resume auto scroll during mock stream`() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val intent = Intent(context, ChatActivity::class.java).apply {
+            putExtra("modelName", "Qwen")
+            putExtra("modelId", "mock")
+            putExtra(ChatActivity.EXTRA_MOCK_STREAM_ENABLE, true)
+            putExtra(ChatActivity.EXTRA_MOCK_STREAM_TEXT_LENGTH, 200)
+            putExtra(ChatActivity.EXTRA_MOCK_STREAM_INTERVAL_MS, 100L)
+        }
+
+        val activity = Robolectric.buildActivity(ChatActivity::class.java, intent)
+            .setup()
+            .get()
+
+        activity.chatListComponent.setUserScrollingForTest(true)
+        val scrollButton = activity.findViewById<View>(R.id.btn_scroll_to_bottom)
+        scrollButton.performClick()
+
+        assertFalse(activity.chatListComponent.isUserScrollingForTest())
+
+        val initialLength = activity.chatListComponent.recentItem?.displayText?.length ?: 0
+        shadowOf(Looper.getMainLooper()).idleFor(350, TimeUnit.MILLISECONDS)
+        val nextLength = activity.chatListComponent.recentItem?.displayText?.length ?: 0
+
+        assertTrue(
+            "Expected mock stream to append more text, initialLength=$initialLength nextLength=$nextLength",
+            nextLength > initialLength
+        )
+    }
+}


### PR DESCRIPTION
Fix https://github.com/alibaba/MNN/issues/4143
## Summary
- fix chat auto-scroll so tapping the scroll-to-bottom button resumes continued follow while streaming keeps growing
- keep the default auto-follow path on the existing HEAD behavior, and isolate the recovery logic to the resume path
- add a deterministic debug mock stream plus focused Robolectric/UiAutomator coverage for the resume-follow state transition

## Verification
- `./gradlew :app:testStandardDebugUnitTest --tests com.alibaba.mnnllm.android.chat.ChatActivityMockStreamAutoScrollTest`
- `./gradlew :app:connectedStandardDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.alibaba.mnnllm.android.chat.ChatAutoScrollUiAutomatorTest`