### PR TITLE
feat: Split async token2wav into 3-stage pipeline: DiT ∥ Vocoder

### DIFF
--- a/transformers/llm/engine/src/omni.cpp
+++ b/transformers/llm/engine/src/omni.cpp
@@ -1420,6 +1420,14 @@ void Talker::ditWorkerLoop() {
         mMelQueueCond.notify_one();
     }
 
+    {
+        WavChunk sentinel;
+        sentinel.is_last = true;
+        std::lock_guard<std::mutex> lock(mMelQueueMutex);
+        mMelQueue.push(std::move(sentinel));
+    }
+    mMelQueueCond.notify_one();
+
     mPreDit_async.reset();
     mDit_async.reset();
     mSpk_async = nullptr;
@@ -1659,8 +1667,12 @@ void Talker::generate() {
     if (mAsyncToken2Wav) {
         trySubmitChunkAsync(true);
         std::unique_lock<std::mutex> lock(mWavQueueMutex);
+        auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(60);
         while (!mWavLastDone.load()) {
-            mWavQueueCond.wait(lock);
+            if (!mWavQueueCond.wait_until(lock, deadline, [this] { return mWavLastDone.load(); })) {
+                MNN_ERROR("Talker async worker timeout; audio may be incomplete\n");
+                break;
+            }
         }
     } else {
         token2wav(true);

--- a/transformers/llm/engine/src/omni.hpp
+++ b/transformers/llm/engine/src/omni.hpp
@@ -9,6 +9,7 @@
 #define OMNI_hpp
 
 #include "llm/llm.hpp"
+#include <vector>
 #include <thread>
 #include <mutex>
 #include <condition_variable>


### PR DESCRIPTION
继续上次PR[https://github.com/alibaba/MNN/pull/4240](https://github.com/alibaba/MNN/pull/4240) 的改造。实际上我实机打了log发现前面token生成得太快了，把音频的转换过程全部放在cpu上会发生背压问题。很自然想到考虑继续分为两步。

## 概述
将原有的单线程 `asyncWorkerLoop`（DiT → BigVGAN 串行）拆分为三级流水线，DiT 和 BigVGAN 分别运行在**独立线程、独立 Executor** 上，实现真正的并行。

## 问题

在 `asyncWorkerLoop` 中，每个 chunk 的 DiT 和 BigVGAN 串行执行：

```
asyncWorkerLoop:  [===DiT===][=BigVGAN=][===DiT===][=BigVGAN=] ...
                     chunk 0              chunk 1
```

设 N 个 chunk 的单块耗时分别为 $d_i$（DiT）和 $v_i$（BigVGAN），则总挂钟时间为：

$$
T_{old} = \sum {d_i + v_i}
$$

BigVGAN 执行期间，下一个 chunk 的 DiT 只能空等。在 Qwen2.5-Omni 的典型语音输出中，一段话会产生 4–13 个 chunk，空等时间显著累积。

## 方案

```
Talker 线程:     [codec decode ...]
                       ↓ mWavQueue（codec tokens + noise）
DiT 线程:        [===DiT_0===][===DiT_1===][===DiT_2===] ...
                       ↓ mMelQueue（mel 浮点数据）
Vocoder 线程:              [=BV_0=][=BV_1=][=BV_2=] ...
                             ↑ callback
```

两个生产者-消费者队列，三个线程。每个 worker 拥有独立的 `Executor`，通过 `Module::clone()` 克隆模型（共享权重、独立 Session）。理论挂钟时间变为：

$$
T_{new} = d_0 + v_0 + \sum_{i=1}^{N-1} max(d_i, v_{i-1}) + v_{N-1}
$$


### 跨 Executor 的 mel 数据传递

VARP 不能跨 Executor 共享。DiT 线程通过 `readMap` 将 mel 拷贝到 `WavChunk.mel`（`std::vector<float>`），Vocoder 线程通过 `_Const()` 重建：

```cpp
// ditWorkerLoop —— DiT 前向完成后：
chunk.mel.assign(generated_mel->readMap<float>(),
                 generated_mel->readMap<float>() + mel_info->size);

// processWavChunk —— vocoder 端：
auto generated_mel = _Const(chunk.mel.data(), chunk.mel_dims, NCHW, halide_type_of<float>());
```

每 chunk 的 mel 形状为 `[1, 80, 120]` = **37.5 KB**。在 ARM LPDDR 带宽（~8 GB/s）下，拷贝耗时约 **5 μs**，而 DiT 每 chunk 耗时约 2800 ms —— 拷贝开销占比 **0.0002%**，完全可忽略。

### 等待完成机制

这里是我后面测试出来的问题：旧版使用 `wait_for(lock, 10s)` 硬编码超时，在慢速设备上可能误判超时、在快速设备上浪费等待时间。新版改为事件驱动的精确等待：

```cpp
// 旧版：固定超时 —— 慢设备可能误判
bool completed = mWavQueueCond.wait_for(lock, std::chrono::seconds(10), ...);
if (!completed) MNN_ERROR("timeout");

// 新版：事件驱动 —— 无论耗时多长都正确，完成后立即唤醒
while (!mWavLastDone.load()) {
    mWavQueueCond.wait(lock);
}
```

`mWavLastDone` 由 vocoder 线程在最后一个 chunk 的 callback 完成后设置，主线程立即被唤醒，不存在误判或空等。

实测 profiling 数据（Qwen2.5-Omni，ARM big.LITTLE，OpenCL LLM + CPU mllm，12 chunks）显示典型单块耗时 `d ≈ 2800 ms`，`v ≈ 2250 ms`，其它的log大概如下

```
嗯，你是在问关于啥的呀？是工作上的问题，还是生活里的？快和我说说呗。
#################################
prompt tokens num = 50
decode tokens num = 763
  prefill time = 0.28 s
   decode time = 3.88 s
      dit time = 0.00 s
token2wav time = 28.21 s
      tts time = 28.21 s
  prefill speed = 178.64 tok/s
   decode speed = 196.74 tok/s
token2wav speed = 27.05 tok/s
      tts rtf   = 1.85 
##################################
Waveform saved to: output.wav
```

总的来说还是有用的，实际生成的体验也更稳定一些，不会有之前那种突然有某个case就出现语音拉长音或者外星语的情况。
