### PR TITLE
[MNNChat:Bugfix] fix crash when tapping Add Local Model

### DIFF
--- a/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mnnllm/android/main/MainActivity.kt
+++ b/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mnnllm/android/main/MainActivity.kt
@@ -528,6 +528,23 @@ class MainActivity : AppCompatActivity(), MainFragmentManager.FragmentLifecycleL
         }
     }
 
+    fun addLocalModels(view: View?) {
+        val adbCommand = "adb shell mkdir -p /data/local/tmp/mnn_models && adb push \${model_path} /data/local/tmp/mnn_models/"
+        val message = getResources().getString(R.string.add_local_models_message, adbCommand)
+        val dialog = androidx.appcompat.app.AlertDialog.Builder(this)
+            .setTitle(R.string.add_local_models_title)
+            .setMessage(message)
+            .setPositiveButton(android.R.string.ok) { dialog, _ -> dialog.dismiss() }
+            .setNeutralButton(R.string.copy_command) { _, _ ->
+                val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                val clip = ClipData.newPlainText("ADB Command", adbCommand)
+                clipboard.setPrimaryClip(clip)
+                Toast.makeText(this, R.string.copied_to_clipboard, Toast.LENGTH_SHORT).show()
+            }
+            .create()
+        dialog.show()
+    }
+
     fun runModel(destModelDir: String?, modelIdParam: String?, sessionId: String?) {
         ChatRouter.startRun(this, modelIdParam!!, destModelDir, sessionId)
         drawerLayout.closeDrawer(GravityCompat.START)

--- a/apps/Android/MnnLlmChat/app/src/test/java/com/alibaba/mnnllm/android/main/MainActivityClickBindingTest.kt
+++ b/apps/Android/MnnLlmChat/app/src/test/java/com/alibaba/mnnllm/android/main/MainActivityClickBindingTest.kt
@@ -1,0 +1,39 @@
+package com.alibaba.mnnllm.android.main
+
+import android.view.View
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MainActivityClickBindingTest {
+
+    @Test
+    fun activityMainOnClickHandlersResolveOnMainActivity() {
+        val layoutFile = File("src/main/res/layout/activity_main.xml")
+        val missingHandlers = mutableListOf<String>()
+
+        val document = DocumentBuilderFactory.newInstance()
+            .newDocumentBuilder()
+            .parse(layoutFile)
+        val nodes = document.getElementsByTagName("*")
+
+        for (i in 0 until nodes.length) {
+            val node = nodes.item(i)
+            val attributes = node.attributes ?: continue
+            val onClick = attributes.getNamedItem("android:onClick")?.nodeValue ?: continue
+            val methodExists = MainActivity::class.java.methods.any { method ->
+                method.name == onClick &&
+                    method.parameterTypes.contentEquals(arrayOf(View::class.java))
+            }
+            if (!methodExists) {
+                missingHandlers += onClick
+            }
+        }
+
+        assertTrue(
+            "activity_main.xml declares missing MainActivity onClick handlers: $missingHandlers",
+            missingHandlers.isEmpty()
+        )
+    }
+}


### PR DESCRIPTION
## 背景

这个 PR 修复了 `MnnLlmChat` 中点击 **Add Local Model** 时发生崩溃的问题。

问题原因是由于：`activity_main.xml` 中仍然声明了 `android:onClick="addLocalModels"`，但是 `MainActivity` 里已经没有这个点击处理方法了。  
因此用户点击该 FAB 选项时，Android 在解析点击回调时失败，应用会直接崩溃。报错日志如下
```
FATAL EXCEPTION: main
                                                         Process: com.alibaba.mnnllm.android, PID: 7680
                                                         android.content.res.Resources$NotFoundException: Unable to find resource ID #0x9
                                                         	at android.content.res.ResourcesImpl.getResourceEntryName(ResourcesImpl.java:362)
                                                         	at android.content.res.Resources.getResourceEntryName(Resources.java:2399)
                                                         	at android.view.View$DeclaredOnClickListener.resolveMethod(View.java:6860)
                                                         	at android.view.View$DeclaredOnClickListener.onClick(View.java:6820)
                                                         	at com.nambimobile.widgets.efab.FabOption.setOnClickListener$lambda-4(FabOption.kt:343)
                                                         	at com.nambimobile.widgets.efab.FabOption.$r8$lambda$fKne-mcgJ9uU7TA2mjfUfvq-Ar4(Unknown Source:0)
                                                         	at com.nambimobile.widgets.efab.FabOption$$ExternalSyntheticLambda0.onClick(D8$$SyntheticClass:0)
                                                         	at android.view.View.performClick(View.java:8083)
                                                         	at android.view.View.performClickInternal(View.java:8060)
                                                         	at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)
                                                         	at android.view.View$PerformClick.run(View.java:31549)
                                                         	at android.os.Handler.handleCallback(Handler.java:995)
                                                         	at android.os.Handler.dispatchMessage(Handler.java:103)
                                                         	at android.os.Looper.loopOnce(Looper.java:248)
                                                         	at android.os.Looper.loop(Looper.java:338)
                                                         	at android.app.ActivityThread.main(ActivityThread.java:9067)
                                                         	at java.lang.reflect.Method.invoke(Native Method)
                                                         	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:593)
                                                         	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:932)
```

## 修改内容

本次修改包含两部分：

- 在 `MainActivity` 中恢复 `addLocalModels(View?)`
- 补充一个回归测试，校验 `activity_main.xml` 中声明的 `android:onClick` 方法都能在 `MainActivity` 中正确解析

## 修复效果

这次修复保持了原有逻辑，不修改现有页面结构和导航逻辑。

修复后，点击 **Add Local Model** 时：
- 不再崩溃
- 会正常弹出本地模型导入说明对话框
- 对话框中仍然包含 ADB 导入命令
- 仍然支持一键复制命令到剪贴板

## 为什么采用这个方案

这是一个最小范围、行为保持一致的修复。

当前 `activity_main.xml` 中这个 FAB 入口本身就是绑定到 `addLocalModels`，因此恢复对应处理方法，可以在不改变现有 UI 和功能路径的前提下，直接修复崩溃并恢复预期行为。

## 验证方式

### 自动化验证
已执行：

- `./gradlew :app:testStandardDebugUnitTest --tests com.alibaba.mnnllm.android.main.MainActivityClickBindingTest`
- `./gradlew :app:assembleStandardDebug`

### 手动验证
已验证以下流程：

1. 安装最新 debug APK
2. 打开 `MnnLlmChat`
3. 展开右下角 FAB
4. 点击 **Add Local Model**

预期结果：
- 应用不崩溃
- 正常弹出 **Add Local Models** 对话框
- 对话框中包含 ADB 命令和 **Copy Command** 按钮
