### PR TITLE
[CPU Backend:Bugfix] Avoid deadlock when cached mmap weights are partially initialized

### DIFF
--- a/source/backend/cpu/CPUBackend.cpp
+++ b/source/backend/cpu/CPUBackend.cpp
@@ -289,15 +289,17 @@ Backend* CPURuntime::onCreate(const BackendConfig* config, Backend* origin) cons
         prefix[6] += mPower;
         // prefix += hint().modelUUID + "_";
         bool autoRemove = true;
+        bool syncValid = false;
         if (hint().useCachedMmap) {
             autoRemove = false;
             std::string fileName = MNNFilePathConcat(hint().weightMemoryPath, prefix + "sync.static");
-            const_cast<RuntimeHint&>(hint()).useCachedMmap += MNNFileExist(fileName.c_str());
+            syncValid = MNNFileExist(fileName.c_str());
+            const_cast<RuntimeHint&>(hint()).useCachedMmap += syncValid;
         }
         if (nullptr == mStaticAllocatorMMap.get()) {
             // Only support set weightmap dir once
             mStaticAllocatorRaw = mStaticAllocator;
-            auto mmapMem = BufferAllocator::Allocator::createMmap(hint().weightMemoryPath.c_str(), prefix.c_str(), "static", autoRemove);
+            auto mmapMem = BufferAllocator::Allocator::createMmap(hint().weightMemoryPath.c_str(), prefix.c_str(), "static", autoRemove, syncValid);
             size_t mmapSize = static_cast<size_t>(hint().mmapFileSize) * 1024 * 1024;
             mStaticAllocator.reset(new EagerBufferAllocator(mmapMem, 32, mmapSize));
             mStaticAllocatorMMap = mStaticAllocator;

--- a/source/core/BufferAllocator.cpp
+++ b/source/core/BufferAllocator.cpp
@@ -73,9 +73,10 @@ private:
     bool mRemove;
     bool mNewMmap = false;
     bool mSynced = false;
+    bool mSyncValid = false;
 
 public:
-    MmapAllocator(const char* dirName, const char* prefix, const char* posfix, bool autoRemove) {
+    MmapAllocator(const char* dirName, const char* prefix, const char* posfix, bool autoRemove, bool syncValid) {
         if (nullptr != dirName) {
             mFileName = dirName;
             if (!MNNCreateDir(dirName)) {
@@ -89,6 +90,7 @@ public:
             mPosfix = posfix;
         }
         mRemove = autoRemove;
+        mSyncValid = syncValid;
     }
     virtual ~ MmapAllocator() {
         for (auto& iter : mCache) {
@@ -141,14 +143,18 @@ public:
         if (mSynced) {
             return;
         }
-        if (!mRemove && mNewMmap) {
-            for (auto& iter : mCache) {
-                MNNMmapSync(iter.first, std::get<1>(iter.second));
+        if (!mRemove) {
+            if (mNewMmap) {
+                for (auto& iter : mCache) {
+                    MNNMmapSync(iter.first, std::get<1>(iter.second));
+                }
             }
-            std::string cacheName = mPrefix + "sync." + mPosfix;
-            std::string fileName = MNNFilePathConcat(mFileName, cacheName);
-            MNNCreateFile(fileName.c_str());
-            mSynced = true;
+            if (mNewMmap || !mSyncValid) {
+                std::string cacheName = mPrefix + "sync." + mPosfix;
+                std::string fileName = MNNFilePathConcat(mFileName, cacheName);
+                MNNCreateFile(fileName.c_str());
+                mSynced = true;
+            }
         }
     }
 };
@@ -175,9 +181,9 @@ std::shared_ptr<BufferAllocator::Allocator> BufferAllocator::Allocator::createDe
     _res.reset(new DefaultAllocator);
     return _res;
 }
-std::shared_ptr<BufferAllocator::Allocator> BufferAllocator::Allocator::createMmap(const char* dirName, const char* prefix, const char* posfix, bool autoRemove) {
+std::shared_ptr<BufferAllocator::Allocator> BufferAllocator::Allocator::createMmap(const char* dirName, const char* prefix, const char* posfix, bool autoRemove, bool syncValid) {
     std::shared_ptr<BufferAllocator::Allocator> _res;
-    _res.reset(new MmapAllocator(dirName, prefix, posfix, autoRemove));
+    _res.reset(new MmapAllocator(dirName, prefix, posfix, autoRemove, syncValid));
     return _res;
 }
 

--- a/source/core/BufferAllocator.hpp
+++ b/source/core/BufferAllocator.hpp
@@ -86,7 +86,7 @@ public:
         virtual void onRelease(MemChunk chunk) = 0;
         virtual void sync() {};
         static std::shared_ptr<Allocator> createDefault();
-        static std::shared_ptr<Allocator> createMmap(const char* dirName, const char* prefix, const char* posfix, bool autoRemove = true);
+        static std::shared_ptr<Allocator> createMmap(const char* dirName, const char* prefix, const char* posfix, bool autoRemove = true, bool syncValid = false);
         static std::shared_ptr<Allocator> createRecurse(BufferAllocator* parent);
     };
     BufferAllocator() = default;


### PR DESCRIPTION
## Cause
If cached mmap files already exist but `sync.static` is missing, the previous logic may skip recreating the sync marker when `mNewMmap` is false.
If the existing mmap cache is not manually cleared, `sync.static` may never be created and cause a deadlock.



## Changes
- Pass `sync.static` validity into Allocator
- Recreate the sync marker when cached mmap exists but the sync state is incomplete



## Validation
- Reproduced the deadlock before the fix
- Verified the sync marker is created correctly after the fix
- Confirmed normal cached mmap behavior is unchanged