### PR TITLE
[MNNChat:Release] Android 0.8.2.2 release

### DIFF
--- a/apps/Android/MnnLlmChat/README.md
+++ b/apps/Android/MnnLlmChat/README.md
@@ -62,6 +62,16 @@ This is our full multimodal language model (LLM) Android app
 
 # Releases
 
+## Version 0.8.2.2
++ Click here to [download](https://meta.alicdn.com/data/mnn/apks/mnn_chat_0_8_2_2.apk)
++ Highlights:
+  + Refresh the bundled MNN runtime with the latest CPU LinearAttention and Arm82 fp16 optimization path.
+  + Improve tokenizer and template rendering compatibility for thinking-mode prompts and array concatenation cases.
+  + Add TopKV2 backend coverage for OpenCL and Metal execution paths.
++ Bugfix:
+  + Fix the crash when tapping Add Local Model on Android.
+  + Avoid deadlocks caused by partially initialized mmap weights during model loading.
+
 ## Version 0.8.2.1
 + Click here to [download](https://meta.alicdn.com/data/mnn/apks/mnn_chat_0_8_2_1.apk)
 + Bugfix:

--- a/apps/Android/MnnLlmChat/README_CN.md
+++ b/apps/Android/MnnLlmChat/README_CN.md
@@ -58,6 +58,16 @@
   ```
 # Releases
 
+## Version 0.8.2.2
++ 点击这里 [下载](https://meta.alicdn.com/data/mnn/apks/mnn_chat_0_8_2_2.apk)
++ 更新亮点：
+  + 刷新内置 MNN runtime，带入最新的 CPU LinearAttention 与 Arm82 fp16 优化路径。
+  + 提升思考模式提示词和数组拼接场景下的 tokenizer 与模板渲染兼容性。
+  + 为 OpenCL 和 Metal 执行路径补充 TopKV2 后端支持。
++ 问题修复：
+  + 修复 Android 点击 Add Local Model 时的崩溃问题。
+  + 避免模型加载时因 mmap 权重部分初始化而导致的死锁问题。
+
 ## Version 0.8.2.1
 + 点击这里 [下载](https://meta.alicdn.com/data/mnn/apks/mnn_chat_0_8_2_1.apk)
 + 问题修复：

--- a/apps/Android/MnnLlmChat/app/build.gradle
+++ b/apps/Android/MnnLlmChat/app/build.gradle
@@ -69,8 +69,8 @@ android {
         applicationId "com.alibaba.mnnllm.android"
         minSdk 26
         targetSdk 35
-        versionCode 821
-        versionName "0.8.2.1"
+        versionCode 822
+        versionName "0.8.2.2"
         buildConfigField "boolean", "ENABLE_FIREBASE", enableFirebase ? "true" : "false"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         externalNativeBuild {


### PR DESCRIPTION
Recompile engine code to fix https://github.com/alibaba/MNN/issues/4309

## Summary
- bump MnnLlmChat Android versionCode/versionName to 822 / 0.8.2.2
- add English and Chinese 0.8.2.2 release notes with the published APK link
- capture the latest runtime, tokenizer/template, TopKV2 and Add Local Model fixes in the release notes

## Verification
- ENABLE_FIREBASE=true ./scripts/release.sh