### PR TITLE
[LLM:Feature] Support Qwen3.5 smooth and omni export

### DIFF
--- a/transformers/llm/export/utils/config.py
+++ b/transformers/llm/export/utils/config.py
@@ -91,11 +91,13 @@ class LlmConfig(PretrainedConfig):
             else:
                 llm_config.head_dim = llm_config.hidden_size // llm_config.num_attention_heads
 
-        # Determine attention type
+        # Determine attention type.
+        # Qwen3.5 mixed-attention models mark non-full layers as
+        # `linear_attention`; reuse the existing mix path for them.
         sliding_attn_layers = []
         if hasattr(llm_config, 'layer_types') and llm_config.layer_types:
             for i in range(len(llm_config.layer_types)):
-                if llm_config.layer_types[i] == 'sliding_attention':
+                if llm_config.layer_types[i] in ('sliding_attention', 'linear_attention'):
                     sliding_attn_layers.append(i)
 
         if llm_config.num_hidden_layers and len(sliding_attn_layers) >= llm_config.num_hidden_layers:

--- a/transformers/llm/export/utils/model_mapper.py
+++ b/transformers/llm/export/utils/model_mapper.py
@@ -979,6 +979,8 @@ class ModelMapper:
             'num_key_value_heads': 'text_config.num_key_value_heads',
             'rope_parameters': 'text_config.rope_parameters',
             'max_position_embeddings': 'text_config.max_position_embeddings',
+            'layer_types': 'text_config.layer_types',
+            'sliding_window': 'text_config.full_attention_interval',
             'rms_norm_eps': 'text_config.rms_norm_eps',
             'linear_conv_kernel_dim': 'text_config.linear_conv_kernel_dim',
             'linear_key_head_dim': 'text_config.linear_key_head_dim',

--- a/transformers/llm/export/utils/omni_quantizer.py
+++ b/transformers/llm/export/utils/omni_quantizer.py
@@ -51,6 +51,21 @@ class OmniQuantizer:
         self.act_dict = [defaultdict(dict) for _ in range(len(self.modules))]
 
     @staticmethod
+    def _is_offset_rmsnorm(op):
+        type_name = str(type(op))
+        if any(
+            t in type_name
+            for t in [
+                "GemmaRMSNorm",
+                "Qwen3_5RMSNorm",
+                "Qwen3_5MoeRMSNorm",
+                "Qwen3NextRMSNorm",
+            ]
+        ):
+            return True
+        return False
+
+    @staticmethod
     def get_best_device():
         if torch.backends.mps.is_available():
             return "mps"
@@ -172,10 +187,31 @@ class OmniQuantizer:
                 sanitized_kwargs[k] = v
         return sanitized_kwargs
 
+    def _select_layer_kwargs(self, module, inputs_kwargs):
+        """Select per-layer kwargs for mixed attention models."""
+        selected_kwargs = dict(inputs_kwargs)
+        attention_mask = selected_kwargs.get("attention_mask", None)
+        if attention_mask is None:
+            return selected_kwargs
+
+        if getattr(self.model.config, "attention_type", None) != "mix":
+            return selected_kwargs
+
+        if isinstance(attention_mask, torch.Tensor) and attention_mask.dim() >= 1 and attention_mask.shape[0] == 2:
+            layer_type = getattr(module, "layer_type", None)
+            is_sliding = layer_type in ("linear_attention", "sliding_attention")
+            selected_kwargs["attention_mask"] = attention_mask[int(is_sliding)]
+        return selected_kwargs
+
     def _clear_block_kv_cache(self, block):
         """Clear KV cache on the block's attention so each calibration sample is independent."""
-        if hasattr(block, "self_attn") and hasattr(block.self_attn, "past_key_value"):
-            block.self_attn.past_key_value = None
+        if hasattr(block, "self_attn") and block.self_attn is not None:
+            if hasattr(block.self_attn, "past_key_value"):
+                block.self_attn.past_key_value = None
+            if hasattr(block.self_attn, "conv_state"):
+                block.self_attn.conv_state = None
+            if hasattr(block.self_attn, "rnn_state"):
+                block.self_attn.rnn_state = None
 
     def _safe_forward(self, x, module, module_kwargs):
         try:
@@ -336,7 +372,7 @@ class OmniQuantizer:
         with torch.no_grad():
             final_scale = torch.exp(log_scale).detach().view(-1)
 
-            if 'GemmaRMSNorm' in str(type(ln)):
+            if self._is_offset_rmsnorm(ln):
                 ln.weight += 1
                 ln.weight.div_(final_scale)
                 ln.weight -= 1
@@ -425,7 +461,8 @@ class OmniQuantizer:
         for name in named_linears:
             handles.append(named_linears[name].register_forward_hook(functools.partial(stat_io_hook, name=name)))
 
-        sanitized_kwargs = self._sanitize_kwargs(module_kwargs, layer)
+        layer_kwargs = self._select_layer_kwargs(layer, module_kwargs)
+        sanitized_kwargs = self._sanitize_kwargs(layer_kwargs, layer)
 
         with torch.no_grad():
             self._safe_forward(x_in, layer, sanitized_kwargs)
@@ -491,7 +528,6 @@ class OmniQuantizer:
             self.act_dict = [defaultdict(dict) for _ in range(len(self.modules))]
 
         print(f"OmniQuant: Starting weight optimization (Epochs={self.epochs})...")
-
         for idx in tqdm(range(len(self.modules)), desc="OmniQuant: Optimize Weights"):
             block = self.modules[idx]
             self.to_device(block, self.best_device)
@@ -514,7 +550,23 @@ class OmniQuantizer:
                     inp = i
                 mlp_inputs_list.append(inp.detach().view(-1, inp.shape[-1]))
 
-            h1 = block.self_attn.q_proj.register_forward_hook(hook_attn_input)
+            attn_module = block.self_attn
+            attn_linears = []
+            attn_hook_target = None
+            if all(hasattr(attn_module, name) for name in ("q_proj", "k_proj", "v_proj")):
+                attn_linears = [attn_module.q_proj, attn_module.k_proj, attn_module.v_proj]
+                attn_hook_target = attn_module.q_proj
+            elif hasattr(attn_module, "in_proj_qkv"):
+                attn_linears = [attn_module.in_proj_qkv]
+                for optional_name in ("in_proj_a", "in_proj_b", "in_proj_z"):
+                    optional_proj = getattr(attn_module, optional_name, None)
+                    if optional_proj is not None:
+                        attn_linears.append(optional_proj)
+                attn_hook_target = attn_module.in_proj_qkv
+
+            h1 = None
+            if attn_hook_target is not None:
+                h1 = attn_hook_target.register_forward_hook(hook_attn_input)
             h2 = block.mlp.gate_proj.register_forward_hook(hook_mlp_input)
 
             # Pre-compute sanitized kwargs once for this block
@@ -524,6 +576,7 @@ class OmniQuantizer:
                     sample_kw_gpu[k] = v.to(self.best_device)
                 else:
                     sample_kw_gpu[k] = v
+            sample_kw_gpu = self._select_layer_kwargs(block, sample_kw_gpu)
             sanitized_kw_template = self._sanitize_kwargs(sample_kw_gpu, block)
 
             # Single forward pass: collect hooks AND compute outputs
@@ -532,6 +585,7 @@ class OmniQuantizer:
                     # Clear KV cache so each sample is processed independently (no past_key_value from previous iteration)
                     self._clear_block_kv_cache(block)
                     inp_gpu = inp.to(self.best_device)
+                    kw = self._select_layer_kwargs(block, kw)
 
                     # Reuse sanitized keys, only update tensor values
                     kw_gpu = {}
@@ -548,23 +602,31 @@ class OmniQuantizer:
 
                     del inp_gpu, kw_gpu, out
 
-            h1.remove()
+            if h1 is not None:
+                h1.remove()
             h2.remove()
 
             # Process collected attention inputs
-            if len(attn_inputs_list) > 0:
+            optimize_attn = len(attn_inputs_list) > 0
+            if optimize_attn:
                 # Concatenate on GPU, then move to CPU once
                 total_attn_in = torch.cat(attn_inputs_list, dim=0).to("cpu")
                 del attn_inputs_list
 
-                qkv = [block.self_attn.q_proj, block.self_attn.k_proj, block.self_attn.v_proj]
+                # Mixed-attention models such as Qwen3.5 are highly sensitive to
+                # attention-side rescaling. Keep the generic optimization path for
+                # other architectures only.
                 ln_attn = block.input_layernorm
                 robust_max_attn = self._get_robust_act_max(total_attn_in)
-                self._run_optimization(total_attn_in, qkv, ln_attn, robust_max_attn)
-                del total_attn_in, robust_max_attn
+                self._run_optimization(total_attn_in, attn_linears, ln_attn, robust_max_attn)
+                del robust_max_attn
+                del total_attn_in
+            else:
+                del attn_inputs_list
 
             # Process collected MLP inputs
-            if len(mlp_inputs_list) > 0:
+            optimize_mlp = len(mlp_inputs_list) > 0
+            if optimize_mlp:
                 # Concatenate on GPU, then move to CPU once
                 total_mlp_in = torch.cat(mlp_inputs_list, dim=0).to("cpu")
                 del mlp_inputs_list
@@ -574,6 +636,8 @@ class OmniQuantizer:
                 robust_max_mlp = self._get_robust_act_max(total_mlp_in)
                 self._run_optimization(total_mlp_in, fcs_mlp, ln_mlp, robust_max_mlp)
                 del total_mlp_in, robust_max_mlp
+            else:
+                del mlp_inputs_list
 
             self.clear_memory()
 
@@ -671,6 +735,7 @@ class OmniQuantizer:
                     # Process each calibration sample independently to avoid KV cache from the previous sample causing dimension mismatch between attn_weights and attention_mask
                     self._clear_block_kv_cache(block)
                     inp_gpu = inp.to(self.best_device)
+                    kw = self._select_layer_kwargs(block, kw)
                     kw_gpu = {k: (v.to(self.best_device) if isinstance(v, torch.Tensor) else v) for k, v in kw.items()}
 
                     # First forward: collect activation scales

--- a/transformers/llm/export/utils/smooth_quantizer.py
+++ b/transformers/llm/export/utils/smooth_quantizer.py
@@ -166,6 +166,21 @@ class SmoothQuantizer:
         gc.collect()
         torch.cuda.empty_cache()
 
+    @staticmethod
+    def clear_block_cache(block):
+        if hasattr(block, 'self_attn') and block.self_attn is not None:
+            attn = block.self_attn
+            if hasattr(attn, 'past_key_value'):
+                attn.past_key_value = None
+            if hasattr(attn, 'conv_state'):
+                attn.conv_state = None
+            if hasattr(attn, 'rnn_state'):
+                attn.rnn_state = None
+
+    def clear_all_block_caches(self):
+        for block in self.modules:
+            self.clear_block_cache(block)
+
 
     def init_quant(self, n_samples=128, max_seq_len=512):
         samples = SmoothQuantizer.get_calib_dataset(
@@ -193,9 +208,26 @@ class SmoothQuantizer:
 
     def _get_max_input(self, idx, layer, named_linears):
 
-        def stat_tensor(name, tensor):
+        def infer_feature_dim(module):
+            if hasattr(module, "in_features"):
+                return module.in_features
+            if hasattr(module, "in_channels"):
+                return module.in_channels
+            if hasattr(module, "weight") and getattr(module, "weight", None) is not None:
+                weight = module.weight
+                if weight.dim() == 1:
+                    return weight.numel()
+            return None
+
+        def stat_tensor(name, tensor, module):
+            feature_dim = infer_feature_dim(module)
+            if tensor.dim() == 3 and feature_dim is not None:
+                if tensor.shape[-1] == feature_dim:
+                    pass
+                elif tensor.shape[1] == feature_dim:
+                    tensor = tensor.transpose(1, 2).contiguous()
             hidden_dim = tensor.shape[-1]
-            tensor = tensor.view(-1, hidden_dim).abs().detach()
+            tensor = tensor.reshape(-1, hidden_dim).abs().detach()
             comming_max = torch.max(tensor, dim=0)[0].float().cpu()
             if name in self.act_scales[idx]:
                 self.act_scales[idx][name] = torch.max(self.act_scales[idx][name], comming_max)
@@ -205,7 +237,7 @@ class SmoothQuantizer:
         def stat_input_hook(m, x, y, name):
             if isinstance(x, tuple):
                 x = x[0]
-            stat_tensor(name, x)
+            stat_tensor(name, x, m)
         handles = []
         for name in named_linears:
             handles.append(
@@ -213,7 +245,8 @@ class SmoothQuantizer:
                     functools.partial(stat_input_hook, name=name)
                 )
             )
-        module_kwargs = self._sanitize_kwargs(self.module_kwargs, layer)
+        layer_kwargs = self._select_layer_kwargs(layer, self.module_kwargs)
+        module_kwargs = self._sanitize_kwargs(layer_kwargs, layer)
 
         self.inps = self._module_forward(self.inps, layer, module_kwargs)
         for h in handles:
@@ -237,6 +270,21 @@ class SmoothQuantizer:
             if k in module_signature:
                 sanitized_kwargs[k] = v
         return sanitized_kwargs
+
+    def _select_layer_kwargs(self, module, inputs_kwargs):
+        selected_kwargs = dict(inputs_kwargs)
+        attention_mask = selected_kwargs.get("attention_mask", None)
+        if attention_mask is None:
+            return selected_kwargs
+
+        if getattr(self.model.config, "attention_type", None) != "mix":
+            return selected_kwargs
+
+        if isinstance(attention_mask, torch.Tensor) and attention_mask.dim() >= 1 and attention_mask.shape[0] == 2:
+            layer_type = getattr(module, "layer_type", None)
+            is_sliding = layer_type in ("linear_attention", "sliding_attention")
+            selected_kwargs["attention_mask"] = attention_mask[int(is_sliding)]
+        return selected_kwargs
 
     @torch.no_grad()
     def _module_forward(
@@ -300,6 +348,21 @@ class SmoothQuantizer:
         return targets
 
     @staticmethod
+    def is_offset_rmsnorm(op):
+        type_name = str(type(op))
+        if any(
+            t in type_name
+            for t in [
+                'GemmaRMSNorm',
+                'Qwen3_5RMSNorm',
+                'Qwen3_5MoeRMSNorm',
+                'Qwen3NextRMSNorm',
+            ]
+        ):
+            return True
+        return False
+
+    @staticmethod
     @torch.no_grad()
     def smooth_ln_fcs(ln, fcs, act_scales, alpha=0.5):
         if not isinstance(fcs, list):
@@ -324,7 +387,7 @@ class SmoothQuantizer:
             .to(dtype)
         )
 
-        if 'GemmaRMSNorm' in str(type(ln)):
+        if SmoothQuantizer.is_offset_rmsnorm(ln):
             ln.weight += 1
             ln.weight.div_(scales)
             ln.weight -= 1
@@ -348,15 +411,45 @@ class SmoothQuantizer:
         return False
 
     def _apply_scale(self, idx, module):
-        attn_ln = module.input_layernorm
-        qkv = [
-                module.self_attn.q_proj,
-                module.self_attn.k_proj,
-                module.self_attn.v_proj,
-            ]
+        model_type = getattr(self.model.config, "model_type", "")
+        layer_type = getattr(module, "layer_type", None)
 
-        qkv_input_scales = self.act_scales[idx]["self_attn.q_proj"]
-        SmoothQuantizer.smooth_ln_fcs(attn_ln, qkv, qkv_input_scales, self.alpha)
+        if model_type in ("qwen3_5", "qwen3_5_moe"):
+            if layer_type == "linear_attention" and hasattr(module, "linear_attn"):
+                attn_ln = module.input_layernorm
+                linear_attn = module.linear_attn
+                fcs = []
+                for name in ("in_proj_qkv", "in_proj_a", "in_proj_b", "in_proj_z"):
+                    fc = getattr(linear_attn, name, None)
+                    if fc is not None:
+                        fcs.append(fc)
+                if fcs and "linear_attn.in_proj_qkv" in self.act_scales[idx]:
+                    input_scales = self.act_scales[idx]["linear_attn.in_proj_qkv"]
+                    SmoothQuantizer.smooth_ln_fcs(attn_ln, fcs, input_scales, self.alpha)
+                return
+
+            if hasattr(module.self_attn, 'q_proj') and hasattr(module.self_attn, 'k_proj') and hasattr(module.self_attn, 'v_proj'):
+                attn_ln = module.input_layernorm
+                qkv = [
+                        module.self_attn.q_proj,
+                        module.self_attn.k_proj,
+                        module.self_attn.v_proj,
+                    ]
+                if "self_attn.q_proj" in self.act_scales[idx]:
+                    qkv_input_scales = self.act_scales[idx]["self_attn.q_proj"]
+                    SmoothQuantizer.smooth_ln_fcs(attn_ln, qkv, qkv_input_scales, self.alpha)
+                return
+
+        if hasattr(module.self_attn, 'q_proj') and hasattr(module.self_attn, 'k_proj') and hasattr(module.self_attn, 'v_proj'):
+            attn_ln = module.input_layernorm
+            qkv = [
+                    module.self_attn.q_proj,
+                    module.self_attn.k_proj,
+                    module.self_attn.v_proj,
+                ]
+
+            qkv_input_scales = self.act_scales[idx]["self_attn.q_proj"]
+            SmoothQuantizer.smooth_ln_fcs(attn_ln, qkv, qkv_input_scales, self.alpha)
 
         ffn_ln = module.post_attention_layernorm  # feed forward norm
         fcs = [module.mlp.gate_proj, module.mlp.up_proj]
@@ -387,7 +480,8 @@ class SmoothQuantizer:
                     functools.partial(stat_io_hook, name=name)
                 )
             )
-        module_kwargs = self._sanitize_kwargs(self.module_kwargs, layer)
+        layer_kwargs = self._select_layer_kwargs(layer, self.module_kwargs)
+        module_kwargs = self._sanitize_kwargs(layer_kwargs, layer)
 
         self.inps = self._module_forward(self.inps, layer, module_kwargs)
         for h in handles:
@@ -440,10 +534,12 @@ class SmoothQuantizer:
             sample = self.samples[i]
             if sample.numel() == 0:
                 continue
+            self.clear_all_block_caches()
             self.module_kwargs, self.inps = self._get_first_input(sample)
 
             for idx in range(len(self.modules)):
                 SmoothQuantizer.to_device(self.modules[idx], self.best_device)
+                self.clear_block_cache(self.modules[idx])
 
                 if self.module_kwargs.get("position_ids", None) is not None:
                     self.module_kwargs["position_ids"] = self.module_kwargs["position_ids"].to(self.best_device)
@@ -464,10 +560,12 @@ class SmoothQuantizer:
             sample = self.samples[i]
             if sample.numel() == 0:
                 continue
+            self.clear_all_block_caches()
             self.module_kwargs, self.inps = self._get_first_input(sample)
 
             for idx in range(len(self.modules)):
                 SmoothQuantizer.to_device(self.modules[idx], self.best_device)
+                self.clear_block_cache(self.modules[idx])
 
                 if self.module_kwargs.get("position_ids", None) is not None:
                     self.module_kwargs["position_ids"] = self.module_kwargs["position_ids"].to(self.best_device)
@@ -735,13 +833,3 @@ class SmoothQuantizer:
             json.dump(mnn, f, ensure_ascii=False, indent=4)
 
         return base_path
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
## Description

Add Qwen3.5 export support for both SmoothQuant and OmniQuant in MNN LLM export.

This change adapts Qwen3.5 mixed attention layers during quantization/export, including:
- per-layer routing for linear attention and full/sliding attention
- Qwen3.5 RMSNorm offset handling in smooth and omni quant flows
- calibration/runtime kwargs selection and cache state cleanup for mixed attention

With these changes, Qwen3.5 can complete `--smooth` and `--omni` export flows without relying on skip logic, and the exported models run normally in `llm_demo`.

## Module

LLM

## Type

- [x] Feature
- [ ] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [x] Tested on relevant platform(s)
- [x] No unrelated format or style changes included