### PR TITLE
[Vulkan:Bugfix] Removed static lookup to dynamic symbol

### DIFF
--- a/source/backend/vulkan/component/VulkanDevice.cpp
+++ b/source/backend/vulkan/component/VulkanDevice.cpp
@@ -209,15 +209,6 @@ VulkanDevice::VulkanDevice(std::shared_ptr<VulkanInstance> instance)
     vkEnumerateDeviceExtensionProperties(mPhysicalDevice, nullptr, &extensionCount, nullptr);
     std::vector<VkExtensionProperties> extensions(extensionCount);
     vkEnumerateDeviceExtensionProperties(mPhysicalDevice, nullptr, &extensionCount, extensions.data());
-
-    VkPhysicalDeviceShaderFloat16Int8FeaturesKHR float16Features = {};
-    float16Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES_KHR;
-
-    VkPhysicalDeviceFeatures2 features2 = {};
-    features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-    features2.pNext = &float16Features;
-
-    vkGetPhysicalDeviceFeatures2(mPhysicalDevice, &features2);
 }
 
 }
@@ -643,10 +634,13 @@ void VulkanDevice::checkFP16(const std::vector<VkExtensionProperties>& available
     mFP16Info.enabledVulkan12Features = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES};
     mFP16Info.enabledShaderFloat16Int8Features = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES};
     mFP16Info.enabled16BitStorageFeatures = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES};
-    
-    PFN_vkGetPhysicalDeviceFeatures2 getFeatures2 = vkGetPhysicalDeviceFeatures2;
+
+    VkInstance instance = mInstance->get();
+    auto getFeatures2 =
+        (PFN_vkGetPhysicalDeviceFeatures2)vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceFeatures2");
     if (!getFeatures2) {
-        getFeatures2 = vkGetPhysicalDeviceFeatures2KHR;
+        getFeatures2 =
+            (PFN_vkGetPhysicalDeviceFeatures2)vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceFeatures2KHR");
     }
     if (!getFeatures2) {
         return;
@@ -704,9 +698,12 @@ void VulkanDevice::checkCoopMat(const std::vector<VkExtensionProperties>& availa
     mCoopMatInfo.selectedFP32CoopMatShape.clear();
     mCoopMatInfo.selectedFP16CoopMatShape.clear();
 
-    PFN_vkGetPhysicalDeviceFeatures2 getFeatures2 = vkGetPhysicalDeviceFeatures2;
+    VkInstance instance = mInstance->get();
+    auto getFeatures2 =
+        (PFN_vkGetPhysicalDeviceFeatures2)vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceFeatures2");
     if (!getFeatures2) {
-        getFeatures2 = vkGetPhysicalDeviceFeatures2KHR;
+        getFeatures2 =
+            (PFN_vkGetPhysicalDeviceFeatures2)vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceFeatures2KHR");
     }
     if (!getFeatures2) {
         return;
@@ -725,7 +722,6 @@ void VulkanDevice::checkCoopMat(const std::vector<VkExtensionProperties>& availa
     if (mCoopMatInfo.enabledCoopMatFeatures.cooperativeMatrix != VK_TRUE) return;
 
     // 3. Query Properties (Shapes)
-    VkInstance instance = mInstance->get();
     auto fpGetCoopMat = reinterpret_cast<PFN_vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR>(
             vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR"));
 


### PR DESCRIPTION
## Description

Removed static lookup of dynamic symbol to prevent linker errors on debug, static builds.

`vkGetPhysicalDeviceFeatures2KHR` is a legacy symbol that is only recognized by 1.0 loaders. The current code tries to dynamically set it by verifying if it is null, which doesn't work in static linked contexts because functions are always defined. This leads to a problem that only occurs in debug builds, because it tries to statically link to a non-existent symbol. This doesn't happen on release mode because once the compiler sees that `if (!getFeatures2)` will never be false, it shaves the second lookup of the code and the linker doesn't even attempt to look for it. What should have been done is to look for it dynamically instead of statically.

## Module

Vulkan

## Type

- [ ] Feature
- [X] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [X] Commit message follows `[Module:Type] Description` format
- [X] Code compiles without errors
- [X] Tested on relevant platform(s)
- [X] No unrelated format or style changes included
