### PR TITLE
修正使用 Metal 后端时，module 在 output 被占用情况下第二次推理后，首次推理的 output offset 被异常覆盖，导致后续结果错误的问题

### DIFF
--- a/source/backend/cpu/CPUBackend.cpp
+++ b/source/backend/cpu/CPUBackend.cpp
@@ -621,8 +621,8 @@ Backend::MemObj* CPUBackend::allocBuffer(size_t size, Tensor* dest, StorageType 
     }
     if (chunk.ptr()) {
         buffer.host = chunk.ptr();
-    }
-    des->extra.offset = 0;
+     }
+    TensorUtils::getDescribeOrigin(dest)->offset = 0;
     return res;
 }
 
@@ -844,6 +844,7 @@ public:
         auto otype = op->type();
         for (auto t : inputs) {
             auto des = TensorUtils::getDescribe(t);
+            auto desO = TensorUtils::getDescribeOrigin(t);
             if (des->quantAttr == nullptr) {
                 return false;
             }

--- a/source/backend/cuda/core/CUDABackend.cpp
+++ b/source/backend/cuda/core/CUDABackend.cpp
@@ -217,7 +217,7 @@ Backend::MemObj* CUDABackend::onAcquire(const Tensor* nativeTensor, StorageType 
     auto host = buffer.ptr();
     ((Tensor*)nativeTensor)->buffer().device = (uint64_t)host;
     auto des = TensorUtils::getDescribe(nativeTensor);
-    des->extra.offset = buffer.second;
+    des->offset = buffer.second;
     return new CUDAMemObj(allocator, buffer);
 }
 

--- a/source/backend/metal/MetalBackend.mm
+++ b/source/backend/metal/MetalBackend.mm
@@ -31,10 +31,10 @@ int MNNMetalGetTensorContent(MNNMetalTensorContent* content, void* tensor) {
         return 0;
     }
     auto t = (MNN::Tensor*)tensor;
-    auto des = MNN::TensorUtils::getDescribe(t);
+    auto des = MNN::TensorUtils::getDescribeOrigin(t);
     content->buffer = ((MNN::MetalRuntimeAllocator::MetalBufferAlloc*)t->deviceId())->getBuffer();
     content->texture = nil;
-    content->offset = des->extra.offset;
+    content->offset = des->offset;
     return 0;
 }
 
@@ -43,8 +43,8 @@ namespace MNN {
 static void _MetalApplyTensor(uint8_t* host, size_t offset, Tensor* t) {
     // ptr of MetalBufferAlloc
     t->buffer().device = (uint64_t)host;
-    auto des = TensorUtils::getDescribe(t);
-    des->extra.offset = offset;
+    auto des = TensorUtils::getDescribeOrigin(t);
+    des->offset = offset;
 }
 BufferAllocator* MetalRuntime::createDynamicAllocator(int index, bool secondResize) const {
     if (hint().memoryAllocatorType == Runtime::Allocator_Defer && secondResize) {
@@ -800,7 +800,7 @@ void MetalBackend::onCopyBuffer(const Tensor *src, const Tensor *dst, id<MTLComp
 
     if (!src->buffer().host && dst->buffer().host) {
         auto device = (id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)src->deviceId())->getBuffer();
-        auto devicePtr = (uint8_t*)device.contents + TensorUtils::getDescribe(src)->extra.offset;
+        auto devicePtr = (uint8_t*)device.contents + TensorUtils::getDescribeOrigin(src)->offset;
         if (needConvert) {
             auto tDst = const_cast<Tensor*>(dst);
             auto tmpBuffer = getHostBuffer(dst->usize());
@@ -838,7 +838,7 @@ void MetalBackend::onCopyBuffer(const Tensor *src, const Tensor *dst, id<MTLComp
             commit();
         } else {
             auto device = (id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)dst->deviceId())->getBuffer();
-            auto devicePtr = (uint8_t*)device.contents + TensorUtils::getDescribe(dst)->extra.offset;
+            auto devicePtr = (uint8_t*)device.contents + TensorUtils::getDescribeOrigin(dst)->offset;
             ::memcpy(devicePtr, src->host<void>(), srcSize);
         }
         return;
@@ -869,7 +869,7 @@ id<MTLCommandBuffer> MetalBackend::getCommandBufferForNet() const {
 }
 
 void MetalBackend::setTensor(const MNN::Tensor* tensor, id<MTLComputeCommandEncoder> encoder, int index) {
-    [encoder setBuffer:((MetalRuntimeAllocator::MetalBufferAlloc *)tensor->deviceId())->getBuffer() offset:TensorUtils::getDescribe(tensor)->extra.offset atIndex:index];
+    [encoder setBuffer:((MetalRuntimeAllocator::MetalBufferAlloc *)tensor->deviceId())->getBuffer() offset:TensorUtils::getDescribeOrigin(tensor)->offset atIndex:index];
 }
 void MetalBackend::setMem(const MemChunk& chunk, id<MTLComputeCommandEncoder> encoder, int index) {
     [encoder setBuffer:((MetalRuntimeAllocator::MetalBufferAlloc *)chunk.first)->getBuffer() offset:chunk.second atIndex:index];
@@ -881,7 +881,7 @@ void MetalBackend::setBuffer(id<MTLBuffer> buffer, int offset, id<MTLComputeComm
     [encoder setBuffer:buffer offset:offset atIndex:index];
 }
 std::pair<id<MTLBuffer>, int> MetalBackend::getBuffer(const MNN::Tensor* tensor) {
-    return std::make_pair(((MetalRuntimeAllocator::MetalBufferAlloc *)tensor->deviceId())->getBuffer(), TensorUtils::getDescribe(tensor)->extra.offset);
+    return std::make_pair(((MetalRuntimeAllocator::MetalBufferAlloc *)tensor->deviceId())->getBuffer(), TensorUtils::getDescribeOrigin(tensor)->offset);
 }
 
 

--- a/source/backend/metal/MetalCast.mm
+++ b/source/backend/metal/MetalCast.mm
@@ -58,8 +58,8 @@ void MetalCast::onEncode(const std::vector<Tensor *> &inputs, const std::vector<
     auto context = (__bridge MNNMetalContext *)backend->context();
     auto input = inputs[0], output = outputs[0];
     [encoder setComputePipelineState:mPipeline];
-    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)input->deviceId())->getBuffer() offset:TensorUtils::getDescribe(input)->extra.offset atIndex:0];
-    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)output->deviceId())->getBuffer() offset:TensorUtils::getDescribe(output)->extra.offset atIndex:1];
+    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)input->deviceId())->getBuffer() offset:TensorUtils::getDescribeOrigin(input)->offset atIndex:0];
+    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)output->deviceId())->getBuffer() offset:TensorUtils::getDescribeOrigin(output)->offset atIndex:1];
     [encoder setBuffer:mConstBuffer offset:0 atIndex:2];
     [encoder dispatchThreadgroups:mThreads.first threadsPerThreadgroup:mThreads.second];
 }

--- a/source/backend/metal/MetalConvolution.mm
+++ b/source/backend/metal/MetalConvolution.mm
@@ -109,7 +109,7 @@ ErrorCode MetalConvolution::onResize(const std::vector<Tensor *> &inputs, const 
                         mConstBuffer, ((MetalRuntimeAllocator::MetalBufferAlloc *)mWeight->deviceId())->getBuffer(), ((MetalRuntimeAllocator::MetalBufferAlloc *)mBias->deviceId())->getBuffer(), nil];
         const Tensor* weight = mWeight.get();
         const Tensor* bias = mBias.get();
-        int buffer_offset[] = {TensorUtils::getDescribe(input)->extra.offset, TensorUtils::getDescribe(output)->extra.offset, 0, TensorUtils::getDescribe(weight)->extra.offset, TensorUtils::getDescribe(bias)->extra.offset};
+        int buffer_offset[] = {TensorUtils::getDescribeOrigin(input)->offset, TensorUtils::getDescribeOrigin(output)->offset, 0, TensorUtils::getDescribeOrigin(weight)->offset, TensorUtils::getDescribeOrigin(bias)->offset};
         std::string name = [kernelName UTF8String] + mParam;
         auto ret = [context getGridAndThreadgroup:mPipeline gid:MTLSizeMake(gid_x, gid_y, gid_z) loop:10 buffer:arr runtime:rt shaderName:name offsets:buffer_offset queue:backend->queue()];
         mThreads = std::make_pair(std::get<0>(ret), std::get<1>(ret));
@@ -144,11 +144,11 @@ ErrorCode MetalConvolution::onResize(const std::vector<Tensor *> &inputs, const 
         const Tensor* weight = mWeight.get();
         const Tensor* bias = mBias.get();
         int buffer_offset[] = {
-            TensorUtils::getDescribe(input)->extra.offset,
-            TensorUtils::getDescribe(output)->extra.offset,
+            TensorUtils::getDescribeOrigin(input)->offset,
+            TensorUtils::getDescribeOrigin(output)->offset,
             0,
-            TensorUtils::getDescribe(weight)->extra.offset,
-            TensorUtils::getDescribe(bias)->extra.offset
+            TensorUtils::getDescribeOrigin(weight)->offset,
+            TensorUtils::getDescribeOrigin(bias)->offset
         };
 
         for(int knl_idx = 0; knl_idx < actual_kernel; knl_idx++) {

--- a/source/backend/metal/MetalConvolution1x1.mm
+++ b/source/backend/metal/MetalConvolution1x1.mm
@@ -321,12 +321,12 @@ ErrorCode MetalConvolution1x1::onResize(const std::vector<Tensor *> &inputs, con
         const Tensor* weight = mWeight.get();
         const Tensor* bias = mBias.get();
         int buffer_offset[] = {
-            TensorUtils::getDescribe(input)->extra.offset,
-            TensorUtils::getDescribe(output)->extra.offset,
+            TensorUtils::getDescribeOrigin(input)->offset,
+            TensorUtils::getDescribeOrigin(output)->offset,
             0,
-            TensorUtils::getDescribe(weight)->extra.offset,
-            TensorUtils::getDescribe(bias)->extra.offset,
-            TensorUtils::getDescribe(mDequantScaleBias.get())->extra.offset,
+            TensorUtils::getDescribeOrigin(weight)->offset,
+            TensorUtils::getDescribeOrigin(bias)->offset,
+            TensorUtils::getDescribeOrigin(mDequantScaleBias.get())->offset,
             0};
 
         MetalRuntime *rt = (MetalRuntime *)backend->runtime();
@@ -478,7 +478,7 @@ ErrorCode MetalConvolution1x1::onResize(const std::vector<Tensor *> &inputs, con
 
             const Tensor* weight = mWeight.get();
             const Tensor* bias = mBias.get();
-            int buffer_offset[] = {TensorUtils::getDescribe(input)->extra.offset, TensorUtils::getDescribe(output)->extra.offset, 0, TensorUtils::getDescribe(weight)->extra.offset, TensorUtils::getDescribe(bias)->extra.offset, 0};
+            int buffer_offset[] = {TensorUtils::getDescribeOrigin(input)->offset, TensorUtils::getDescribeOrigin(output)->offset, 0, TensorUtils::getDescribeOrigin(weight)->offset, TensorUtils::getDescribeOrigin(bias)->offset, 0};
             std::string name = "conv1x1_g1z8";
             MetalRuntime *rt = (MetalRuntime *)backend->runtime();
             auto ret = [context getGridAndThreadgroup:mPipeline gid:MTLSizeMake(gid_x, gid_y, gid_z) loop:10 buffer:arr runtime:rt shaderName:name offsets: buffer_offset queue:backend->queue()];
@@ -495,7 +495,7 @@ ErrorCode MetalConvolution1x1::onResize(const std::vector<Tensor *> &inputs, con
                             mConstBuffer, (((MetalRuntimeAllocator::MetalBufferAlloc *)mWeight->deviceId()))->getBuffer(), ((MetalRuntimeAllocator::MetalBufferAlloc *)mBias->deviceId())->getBuffer(), nil];
             const Tensor* weight = mWeight.get();
             const Tensor* bias = mBias.get();
-            int buffer_offset[] = {TensorUtils::getDescribe(input)->extra.offset, TensorUtils::getDescribe(output)->extra.offset, 0,  TensorUtils::getDescribe(weight)->extra.offset, TensorUtils::getDescribe(bias)->extra.offset, 0};
+            int buffer_offset[] = {TensorUtils::getDescribeOrigin(input)->offset, TensorUtils::getDescribeOrigin(output)->offset, 0,  TensorUtils::getDescribeOrigin(weight)->offset, TensorUtils::getDescribeOrigin(bias)->offset, 0};
             std::string name = "conv1x1_g1z4";
             MetalRuntime *rt = (MetalRuntime *)backend->runtime();
             auto ret = [context getGridAndThreadgroup:mPipeline gid:MTLSizeMake(gid_x, gid_y, gid_z) loop:10 buffer:arr runtime:rt shaderName:name offsets: buffer_offset queue:backend->queue()];
@@ -518,7 +518,7 @@ ErrorCode MetalConvolution1x1::onResize(const std::vector<Tensor *> &inputs, con
                         mConstBuffer, (((MetalRuntimeAllocator::MetalBufferAlloc *)mWeight->deviceId()))->getBuffer(), ((MetalRuntimeAllocator::MetalBufferAlloc *)mBias->deviceId())->getBuffer(), nil];
         const Tensor* weight = mWeight.get();
         const Tensor* bias = mBias.get();
-        int buffer_offset[] = {TensorUtils::getDescribe(input)->extra.offset, TensorUtils::getDescribe(output)->extra.offset, 0, TensorUtils::getDescribe(weight)->extra.offset, TensorUtils::getDescribe(bias)->extra.offset, 0};
+        int buffer_offset[] = {TensorUtils::getDescribeOrigin(input)->offset, TensorUtils::getDescribeOrigin(output)->offset, 0, TensorUtils::getDescribeOrigin(weight)->offset, TensorUtils::getDescribeOrigin(bias)->offset, 0};
 
         for(int knl_idx = 0; knl_idx < actual_kernel; knl_idx++) {
             id<MTLComputePipelineState> pipeline = [context pipelineWithName:shaderName[knl_idx] fp16:backend->useFp16InsteadFp32()];
@@ -559,8 +559,8 @@ void MetalConvolution1x1::onEncode(const std::vector<Tensor *> &inputs, const st
         // convolution pipeline
         {
             [encoder setComputePipelineState:mPipeline];
-            [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)input->deviceId())->getBuffer() offset:TensorUtils::getDescribe(input)->extra.offset atIndex:0];
-            [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)output->deviceId())->getBuffer() offset:TensorUtils::getDescribe(output)->extra.offset atIndex:1];
+            [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)input->deviceId())->getBuffer() offset:TensorUtils::getDescribeOrigin(input)->offset atIndex:0];
+            [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)output->deviceId())->getBuffer() offset:TensorUtils::getDescribeOrigin(output)->offset atIndex:1];
             [encoder setBuffer:mConstBuffer offset:0 atIndex:2];
             MetalBackend::setTensor(mTempWeight.get(), encoder, 3);
             MetalBackend::setTensor(mBias.get(), encoder, 4);
@@ -569,8 +569,8 @@ void MetalConvolution1x1::onEncode(const std::vector<Tensor *> &inputs, const st
         }
     } else {
         [encoder setComputePipelineState:mPipeline];
-        [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)input->deviceId())->getBuffer() offset:TensorUtils::getDescribe(input)->extra.offset atIndex:0];
-        [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)output->deviceId())->getBuffer() offset:TensorUtils::getDescribe(output)->extra.offset atIndex:1];
+        [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)input->deviceId())->getBuffer() offset:TensorUtils::getDescribeOrigin(input)->offset atIndex:0];
+        [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)output->deviceId())->getBuffer() offset:TensorUtils::getDescribeOrigin(output)->offset atIndex:1];
         [encoder setBuffer:mConstBuffer offset:0 atIndex:2];
         MetalBackend::setTensor(mWeight.get(), encoder, 3);
         MetalBackend::setTensor(mBias.get(), encoder, 4);

--- a/source/backend/metal/MetalConvolutionDepthwise.mm
+++ b/source/backend/metal/MetalConvolutionDepthwise.mm
@@ -78,11 +78,11 @@ ErrorCode MetalConvolutionDepthwise::onResize(const std::vector<Tensor *> &input
     const Tensor* weight = mWeight.get();
     const Tensor* bias = mBias.get();
     int buffer_offset[] = {
-        TensorUtils::getDescribe(input)->extra.offset,
-        TensorUtils::getDescribe(output)->extra.offset,
+        TensorUtils::getDescribeOrigin(input)->offset,
+        TensorUtils::getDescribeOrigin(output)->offset,
         0,
-        TensorUtils::getDescribe(weight)->extra.offset,
-        TensorUtils::getDescribe(bias)->extra.offset
+        TensorUtils::getDescribeOrigin(weight)->offset,
+        TensorUtils::getDescribeOrigin(bias)->offset
     };
 
     std::string name = "conv_depthwise";

--- a/source/backend/metal/MetalEltwise.mm
+++ b/source/backend/metal/MetalEltwise.mm
@@ -45,9 +45,9 @@ ErrorCode MetalEltwise::onResize(const std::vector<Tensor *> &inputs, const std:
 
 void MetalEltwise::encode(const Tensor *input0, const Tensor *input1, const Tensor *output, id<MTLComputeCommandEncoder> encoder) {
     [encoder setComputePipelineState:mPipeline];
-    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)input0->deviceId())->getBuffer() offset:TensorUtils::getDescribe(input0)->extra.offset atIndex:0];
-    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)input1->deviceId())->getBuffer() offset:TensorUtils::getDescribe(input1)->extra.offset atIndex:1];
-    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)output->deviceId())->getBuffer() offset:TensorUtils::getDescribe(output)->extra.offset atIndex:2];
+    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)input0->deviceId())->getBuffer() offset:TensorUtils::getDescribeOrigin(input0)->offset atIndex:0];
+    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)input1->deviceId())->getBuffer() offset:TensorUtils::getDescribeOrigin(input1)->offset atIndex:1];
+    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)output->deviceId())->getBuffer() offset:TensorUtils::getDescribeOrigin(output)->offset atIndex:2];
     [encoder setBuffer:mConst offset:0 atIndex:3];
     [encoder dispatchThreadgroups:mThreads.first threadsPerThreadgroup:mThreads.second];
 }

--- a/source/backend/metal/MetalFuse.mm
+++ b/source/backend/metal/MetalFuse.mm
@@ -46,9 +46,9 @@ void MetalFuse::onEncode(const std::vector<Tensor *> &inputs, const std::vector<
     [encoder setComputePipelineState:mPipeline];
     int i = 0;
     for (; i < inputs.size(); i++) {
-        [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)inputs[i]->deviceId())->getBuffer() offset:TensorUtils::getDescribe(inputs[i])->extra.offset atIndex:i];
+        [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)inputs[i]->deviceId())->getBuffer() offset:TensorUtils::getDescribeOrigin(inputs[i])->offset atIndex:i];
     }
-    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)output->deviceId())->getBuffer() offset:TensorUtils::getDescribe(output)->extra.offset atIndex:i++];
+    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)output->deviceId())->getBuffer() offset:TensorUtils::getDescribeOrigin(output)->offset atIndex:i++];
     [encoder setBuffer:mConstBuffer offset:0 atIndex:i++];
     [encoder dispatchThreadgroups:mThreads.first threadsPerThreadgroup:mThreads.second];
 #ifdef MNN_FUSE_DEBUG
@@ -212,10 +212,10 @@ public:
     void encode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs, id<MTLComputeCommandEncoder> encoder, MTLSize localSize, MTLSize groupSize) {
         [encoder setComputePipelineState:mPipeline];
         for (int i=0; i<inputs.size(); ++i) {
-            [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)inputs[i]->deviceId())->getBuffer() offset:TensorUtils::getDescribe(inputs[i])->extra.offset atIndex:mInputBinding[i]];
+            [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)inputs[i]->deviceId())->getBuffer() offset:TensorUtils::getDescribeOrigin(inputs[i])->offset atIndex:mInputBinding[i]];
         }
         for (int i=0; i<outputs.size(); ++i) {
-            [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)outputs[i]->deviceId())->getBuffer() offset:TensorUtils::getDescribe(outputs[i])->extra.offset atIndex:mOutputBinding[i]];
+            [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)outputs[i]->deviceId())->getBuffer() offset:TensorUtils::getDescribeOrigin(outputs[i])->offset atIndex:mOutputBinding[i]];
         }
         for (int i=0; i<mConstIndides.size(); ++i) {
             [encoder setBuffer:mConstIndides[i].second.first offset:0 atIndex:mConstIndides[i].first];

--- a/source/backend/metal/MetalInterp.mm
+++ b/source/backend/metal/MetalInterp.mm
@@ -61,8 +61,8 @@ void MetalInterp::onEncode(const std::vector<Tensor *> &inputs, const std::vecto
     auto input = inputs[0], output = outputs[0];
     // encode
     [encoder setComputePipelineState:mPipeline];
-    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)input->deviceId())->getBuffer() offset:TensorUtils::getDescribe(input)->extra.offset atIndex:0];
-    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)output->deviceId())->getBuffer() offset:TensorUtils::getDescribe(output)->extra.offset atIndex:1];
+    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)input->deviceId())->getBuffer() offset:TensorUtils::getDescribeOrigin(input)->offset atIndex:0];
+    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)output->deviceId())->getBuffer() offset:TensorUtils::getDescribeOrigin(output)->offset atIndex:1];
     [encoder setBuffer:mShape offset:0 atIndex:2];
     [encoder setBuffer:mCordTransform offset:0 atIndex:3];
     [encoder dispatchThreadgroups:mThreads.first threadsPerThreadgroup:mThreads.second];

--- a/source/backend/metal/MetalLinearAttention.mm
+++ b/source/backend/metal/MetalLinearAttention.mm
@@ -155,7 +155,7 @@ ErrorCode MetalLinearAttention::onResize(const std::vector<Tensor *> &inputs, co
             bool success = backend()->onAcquireBuffer(mStateCache->mConvState.get(), Backend::STATIC);
             if (!success) return OUT_OF_MEMORY;
             auto convDevice = (id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)mStateCache->mConvState->deviceId())->getBuffer();
-            auto convPtr = (uint8_t*)convDevice.contents + TensorUtils::getDescribe(mStateCache->mConvState.get())->extra.offset;
+            auto convPtr = (uint8_t*)convDevice.contents + TensorUtils::getDescribeOrigin(mStateCache->mConvState.get())->offset;
             ::memset(convPtr, 0, batch * convDim * convStateSize * bytesPerElement);
         }
 
@@ -163,17 +163,17 @@ ErrorCode MetalLinearAttention::onResize(const std::vector<Tensor *> &inputs, co
         bool success = backend()->onAcquireBuffer(mStateCache->mRecurrentState.get(), Backend::STATIC);
         if (!success) return OUT_OF_MEMORY;
         auto rnnDevice = (id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)mStateCache->mRecurrentState->deviceId())->getBuffer();
-        auto rnnPtr = (uint8_t*)rnnDevice.contents + TensorUtils::getDescribe(mStateCache->mRecurrentState.get())->extra.offset;
+        auto rnnPtr = (uint8_t*)rnnDevice.contents + TensorUtils::getDescribeOrigin(mStateCache->mRecurrentState.get())->offset;
         ::memset(rnnPtr, 0, batch * H * dk * dv * bytesPerElement);
     } else if (seqLen > 1) {
         // Prefill (seqLen > 1): reset state for new sequence
         if (mStateCache->mConvState.get() != nullptr) {
             auto convDevice = (id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)mStateCache->mConvState->deviceId())->getBuffer();
-            auto convPtr = (uint8_t*)convDevice.contents + TensorUtils::getDescribe(mStateCache->mConvState.get())->extra.offset;
+            auto convPtr = (uint8_t*)convDevice.contents + TensorUtils::getDescribeOrigin(mStateCache->mConvState.get())->offset;
             ::memset(convPtr, 0, mStateCache->mConvState->elementSize() * bytesPerElement);
         }
         auto rnnDevice = (id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)mStateCache->mRecurrentState->deviceId())->getBuffer();
-        auto rnnPtr = (uint8_t*)rnnDevice.contents + TensorUtils::getDescribe(mStateCache->mRecurrentState.get())->extra.offset;
+        auto rnnPtr = (uint8_t*)rnnDevice.contents + TensorUtils::getDescribeOrigin(mStateCache->mRecurrentState.get())->offset;
         ::memset(rnnPtr, 0, mStateCache->mRecurrentState->elementSize() * bytesPerElement);
     }
     // Decode (seqLen == 1): keep existing state untouched

--- a/source/backend/metal/MetalPooling.mm
+++ b/source/backend/metal/MetalPooling.mm
@@ -70,8 +70,8 @@ ErrorCode MetalPooling::onResize(const std::vector<Tensor *> &inputs, const std:
 void MetalPooling::onEncode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs, id<MTLComputeCommandEncoder> encoder) {
     auto input = inputs[0], output = outputs[0];
     [encoder setComputePipelineState:mPipeline];
-    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)input->deviceId())->getBuffer() offset:TensorUtils::getDescribe(input)->extra.offset atIndex:0];
-    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)output->deviceId())->getBuffer() offset:TensorUtils::getDescribe(output)->extra.offset atIndex:1];
+    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)input->deviceId())->getBuffer() offset:TensorUtils::getDescribeOrigin(input)->offset atIndex:0];
+    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)output->deviceId())->getBuffer() offset:TensorUtils::getDescribeOrigin(output)->offset atIndex:1];
     [encoder setBuffer:mConstBuffer offset:0 atIndex:2];
     [encoder dispatchThreadgroups:mGroup threadsPerThreadgroup:mLocal];
 }

--- a/source/backend/metal/MetalReduction.mm
+++ b/source/backend/metal/MetalReduction.mm
@@ -228,8 +228,8 @@ ErrorCode MetalReduction::onResize(const std::vector<Tensor *> &inputs, const st
 void MetalReduction::onEncode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs, id<MTLComputeCommandEncoder> encoder) {
     auto &input = inputs[0], &output = outputs[0];
     [encoder setComputePipelineState:mPipeline];
-    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)input->deviceId())->getBuffer() offset:TensorUtils::getDescribe(input)->extra.offset atIndex:0];
-    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)output->deviceId())->getBuffer() offset:TensorUtils::getDescribe(output)->extra.offset atIndex:1];
+    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)input->deviceId())->getBuffer() offset:TensorUtils::getDescribeOrigin(input)->offset atIndex:0];
+    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)output->deviceId())->getBuffer() offset:TensorUtils::getDescribeOrigin(output)->offset atIndex:1];
     [encoder setBuffer:mConst offset:0 atIndex:2];
     [encoder dispatchThreadgroups:mThreads.first threadsPerThreadgroup:mThreads.second];
 }

--- a/source/backend/metal/MetalSoftmax.mm
+++ b/source/backend/metal/MetalSoftmax.mm
@@ -69,8 +69,8 @@ ErrorCode MetalSoftmax::onResize(const std::vector<Tensor *> &inputs, const std:
 void MetalSoftmax::onEncode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs, id<MTLComputeCommandEncoder> encoder) {
     auto input = inputs[0], output = outputs[0];
     [encoder setComputePipelineState:mPipeline];
-    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)input->deviceId())->getBuffer() offset:TensorUtils::getDescribe(input)->extra.offset atIndex:0];
-    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)output->deviceId())->getBuffer() offset:TensorUtils::getDescribe(output)->extra.offset atIndex:1];
+    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)input->deviceId())->getBuffer() offset:TensorUtils::getDescribeOrigin(input)->offset atIndex:0];
+    [encoder setBuffer:(id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)output->deviceId())->getBuffer() offset:TensorUtils::getDescribeOrigin(output)->offset atIndex:1];
     [encoder setBuffer:mShapeBuffer offset:0 atIndex:2];
 
     [encoder dispatchThreadgroups:mThreads.first threadsPerThreadgroup:mThreads.second];

--- a/source/backend/metal/render/MetalRasterAndInterpolate.mm
+++ b/source/backend/metal/render/MetalRasterAndInterpolate.mm
@@ -31,7 +31,7 @@ static void _setMemChunk(const MemChunk& mem, id<MTLComputeCommandEncoder> encod
     [encoder setBuffer:((MetalRuntimeAllocator::MetalBufferAlloc *)mem.first)->getBuffer() offset:mem.second atIndex:index];
 }
 static void _setTensor(MNN::Tensor* tensor, id<MTLComputeCommandEncoder> encoder, int index) {
-    [encoder setBuffer:((MetalRuntimeAllocator::MetalBufferAlloc *)tensor->deviceId())->getBuffer() offset:TensorUtils::getDescribe(tensor)->extra.offset atIndex:index];
+    [encoder setBuffer:((MetalRuntimeAllocator::MetalBufferAlloc *)tensor->deviceId())->getBuffer() offset:TensorUtils::getDescribeOrigin(tensor)->offset atIndex:index];
 }
 
 class MetalRadixSort {
@@ -401,7 +401,7 @@ public:
         
         MemChunk srcIndex;
         srcIndex.first = (void*)outputs[1]->deviceId();
-        srcIndex.second = TensorUtils::getDescribe(outputs[1])->extra.offset;
+        srcIndex.second = TensorUtils::getDescribeOrigin(outputs[1])->offset;
         auto dstIndex = mBuffer.pointKeysMid;
         mRadixSort->onResize(inputs, outputs, srcIndex, dstIndex);
         memPool->free(mBuffer.pointKeysMid);
@@ -474,7 +474,7 @@ public:
         // Radix sort
         MemChunk srcIndex;
         srcIndex.first = (void*)outputs[1]->deviceId();
-        srcIndex.second = TensorUtils::getDescribe(outputs[1])->extra.offset;
+        srcIndex.second = TensorUtils::getDescribeOrigin(outputs[1])->offset;
         auto dstIndex = mBuffer.pointKeysMid;
         mRadixSort->onEncode(inputs, outputs, encoder, srcIndex, dstIndex, outputs[0]);
     }

--- a/source/backend/musa/core/MusaBackend.cpp
+++ b/source/backend/musa/core/MusaBackend.cpp
@@ -186,7 +186,7 @@ Backend::MemObj* MusaBackend::onAcquire(const Tensor* nativeTensor, StorageType 
     auto host = buffer.ptr();
     ((Tensor*)nativeTensor)->buffer().device = (uint64_t)host;
     auto des = TensorUtils::getDescribe(nativeTensor);
-    des->extra.offset = buffer.second;
+    des->offset = buffer.second;
     return new MusaMemObj(allocator, buffer);
 }
 

--- a/source/backend/vulkan/buffer/backend/VulkanBackend.cpp
+++ b/source/backend/vulkan/buffer/backend/VulkanBackend.cpp
@@ -205,7 +205,7 @@ VULKAN_TENSOR VulkanBackend::getBuffer(const Tensor* tensor) const {
 std::pair<const VulkanBuffer*, size_t> VulkanBackend::getTensorBuffer(const Tensor* tensor) const {
     auto mem = (VulkanBuffer*)(tensor->deviceId());
     MNN_ASSERT(nullptr != mem);
-    return std::make_pair(mem, TensorUtils::getDescribe(tensor)->extra.offset);
+    return std::make_pair(mem, TensorUtils::getDescribeOrigin(tensor)->offset);
 }
 
 size_t VulkanBackend::getTensorSize(const Tensor* tensor) const {
@@ -225,14 +225,14 @@ Backend::MemObj* VulkanBackend::onAcquire(const Tensor* tensor, StorageType stor
         auto newBuffer = mRuntime->mBufferPool->alloc(alignSize);
         auto mem = new VulkanMemRelease(mRuntime->mBufferPool.get(), newBuffer, alignSize);
         MTensor->buffer().device = (uint64_t)(newBuffer.first);
-        des->extra.offset = newBuffer.second;
+        des->offset = newBuffer.second;
         return mem;
     }
     bool seperate  = storageType == Backend::DYNAMIC_SEPERATE;
     auto newBuffer = mCurrentDynamicBufferPool->alloc(alignSize, seperate);
     auto mem = new VulkanMemRelease(mCurrentDynamicBufferPool, newBuffer, alignSize);
     MTensor->buffer().device = (uint64_t)(newBuffer.first);
-    des->extra.offset = newBuffer.second;
+    des->offset = newBuffer.second;
     return mem;
 }
 bool VulkanBackend::onSelectDynamicAllocator(int index, int maxIndex) {
@@ -459,7 +459,7 @@ void VulkanBackend::onCopyBuffer(const Tensor* srcTensor, const Tensor* dstTenso
         _finish();
         auto format = TensorUtils::getDescribe(dstTensor)->dimensionFormat;
         auto buffer = reinterpret_cast<VulkanBuffer*>(dstTensor->deviceId());
-        auto offset = TensorUtils::getDescribe(dstTensor)->extra.offset;
+        auto offset = TensorUtils::getDescribeOrigin(dstTensor)->offset;
         // host->gpu
         if(format != TensorUtils::getDescribe(srcTensor)->dimensionFormat) {
             tempTensor.reset(Tensor::create(dstTensor->shape(), dstTensor->getType(), nullptr, _convert(format)));
@@ -495,7 +495,7 @@ void VulkanBackend::onCopyBuffer(const Tensor* srcTensor, const Tensor* dstTenso
         size_t cpSize = calculateCpSize(dstTensor);
         _requireHostBuffer(cpSize);
         auto buffer = reinterpret_cast<VulkanBuffer*>(srcTensor->deviceId());
-        auto offset = TensorUtils::getDescribe(srcTensor)->extra.offset;
+        auto offset = TensorUtils::getDescribeOrigin(srcTensor)->offset;
         auto cmdbuffer = mCmdBufferForCopy;
         cmdbuffer->begin(0);
         VkBufferCopy bufferCopy;
@@ -517,8 +517,8 @@ void VulkanBackend::onCopyBuffer(const Tensor* srcTensor, const Tensor* dstTenso
         VkBufferCopy bufferCopy;
         size_t cpSize = calculateCpSize(srcTensor);
         bufferCopy.size = cpSize;
-        bufferCopy.dstOffset = TensorUtils::getDescribe(dstTensor)->extra.offset;
-        bufferCopy.srcOffset = TensorUtils::getDescribe(srcTensor)->extra.offset;
+        bufferCopy.dstOffset = TensorUtils::getDescribeOrigin(dstTensor)->offset;
+        bufferCopy.srcOffset = TensorUtils::getDescribeOrigin(srcTensor)->offset;
         vkCmdCopyBuffer(buffer->get(), reinterpret_cast<VulkanBuffer*>(srcTensor->deviceId())->buffer(), reinterpret_cast<VulkanBuffer*>(dstTensor->deviceId())->buffer(),
                         1, &bufferCopy);
         buffer->end();

--- a/source/backend/vulkan/buffer/execution/VulkanBasicExecution.cpp
+++ b/source/backend/vulkan/buffer/execution/VulkanBasicExecution.cpp
@@ -41,7 +41,7 @@ ErrorCode VulkanBasicExecutionDirect::onResize(const std::vector<Tensor *> &inpu
             // The case occured if we don't need the content of input
             continue;
         }
-        auto offset = des->extra.offset;
+        auto offset = des->offset;
         mCmdBuffer->barrierSource(vkTensor->buffer(), offset, vkBn->getTensorSize(input));
     }
 
@@ -79,7 +79,7 @@ ErrorCode VulkanBasicExecutionInDirect::onResize(const std::vector<Tensor *> &in
             // The case occured if we don't need the content of input
             continue;
         }
-        auto offset = des->extra.offset;
+        auto offset = des->offset;
         cmdBuffer->barrierSource(vkTensor->buffer(), offset, vkBn->getTensorSize(input));
     }
     ErrorCode code = NO_ERROR;

--- a/source/backend/vulkan/buffer/execution/VulkanConvolutionImpl.cpp
+++ b/source/backend/vulkan/buffer/execution/VulkanConvolutionImpl.cpp
@@ -126,7 +126,7 @@ public:
             }
             sourceBuffer->unmap();
             sourceWeight->buffer().device = (uint64_t)(sourceBuffer.get());
-            TensorUtils::getDescribe(sourceWeight.get())->extra.offset = 0;
+            TensorUtils::getDescribe(sourceWeight.get())->offset = 0;
 
             std::shared_ptr<VulkanCommandPool::Buffer> prearrangeCmd( vkBn->getPool().allocBuffer());
             for (auto& reg : des->regions) {

--- a/source/backend/vulkan/buffer/execution/VulkanDeconvolution.cpp
+++ b/source/backend/vulkan/buffer/execution/VulkanDeconvolution.cpp
@@ -139,7 +139,7 @@ VulkanDeconvolution* VulkanDeconvolution::create(Backend* bn, const Op* op, OpTy
                 tempWeightData = (const void *)tempWeight;
             }
             auto tempWeightBuffer = reinterpret_cast<VulkanBuffer*>(tempWeightTensor->deviceId());
-            vkBn->copyToGPUBuffer(tempWeightData, tempWeightBuffer->buffer(), tempWeightSize * elementSize, TensorUtils::getDescribe(tempWeightTensor.get())->extra.offset);
+            vkBn->copyToGPUBuffer(tempWeightData, tempWeightBuffer->buffer(), tempWeightSize * elementSize, TensorUtils::getDescribe(tempWeightTensor.get())->offset);
         }
         std::shared_ptr<VulkanCommandPool::Buffer> prearrangeCmd( vkBn->getPool().allocBuffer());
         for (auto& reg : des->regions) {

--- a/source/core/Tensor.cpp
+++ b/source/core/Tensor.cpp
@@ -119,6 +119,7 @@ Tensor::Tensor(bool deepCopy, const Tensor* tensor) {
     mDescribe->mContent = tensor->mDescribe->mContent;
     mDescribe->setBackend(tensor->mDescribe->getBackend());
     mDescribe->mem = tensor->mDescribe->mem;
+    mDescribe->offset = tensor->mDescribe->offset;
     mBuffer.dim = TensorUtils::getDescribe(tensor)->dims;
     mBuffer.type = tensor->getType();
     mBuffer.device = tensor->deviceId();

--- a/source/core/TensorUtils.cpp
+++ b/source/core/TensorUtils.cpp
@@ -477,12 +477,12 @@ bool TensorUtils::refTensorContent(Tensor* dst, const Tensor* src) {
     auto srcDes = TensorUtils::getDescribe(src);
     auto desO = TensorUtils::getDescribeOrigin(dst);
     auto srcDesO = TensorUtils::getDescribeOrigin(src);
-    bool needMalloc = dst->buffer().host != src->buffer().host || dst->buffer().device != src->buffer().device || des->extra.offset != srcDes->extra.offset;
+    bool needMalloc = dst->buffer().host != src->buffer().host || dst->buffer().device != src->buffer().device || desO->offset != srcDesO->offset;
     desO->setBackend(srcDesO->getBackend());
     dst->buffer().host = src->buffer().host;
     dst->buffer().device = src->buffer().device;
     dst->buffer().flags = src->buffer().flags;
-    des->extra.offset = srcDes->extra.offset;
+    desO->offset = srcDesO->offset;
     des->group = -1;
     return needMalloc;
 }

--- a/source/core/TensorUtils.hpp
+++ b/source/core/TensorUtils.hpp
@@ -87,13 +87,6 @@ struct Tensor::InsideDescribe {
     public:
         /** dimension format */
         MNN_DATA_FORMAT dimensionFormat = MNN_DATA_FORMAT_NC4HW4;
-        union {
-            /** Serperate memory offset*/
-            int offset;
-
-            /** function used to free handle */
-            void (*handleFreeFunction)(void*);
-        } extra;
         MemoryType memoryType = MEMORY_BACKEND;
         std::weak_ptr<Command> rasterCommand;
         /** for DEVICE tensor only. */
@@ -120,6 +113,7 @@ struct Tensor::InsideDescribe {
     };
     std::shared_ptr<NativeInsideDescribe> mContent;
     SharedPtr<Backend::MemObj> mem;
+    int offset = 0;
     inline Backend* getBackend() const {
         return backend;
     }

--- a/source/geometry/GeometryGather.cpp
+++ b/source/geometry/GeometryGather.cpp
@@ -362,21 +362,23 @@ public:
             paramSize = dimCount;
         }
         // recompute reshape
-        auto des = TensorUtils::getDescribe(reshapeIndice.get());
-        des->extra.offset = 0;
-        des->memoryType = Tensor::InsideDescribe::MEMORY_VIRTUAL;
-        des->regions = {GeometryComputerUtils::makeRawAddressRef(indice, 0, mSliceN * indiceNd)};
+        auto des = TensorUtils::getDescribeOrigin(reshapeIndice.get());
+        des->offset = 0;
+        auto nativeDes = TensorUtils::getDescribe(reshapeIndice.get());
+        nativeDes->memoryType = Tensor::InsideDescribe::MEMORY_VIRTUAL;
+        nativeDes->regions = {GeometryComputerUtils::makeRawAddressRef(indice, 0, mSliceN * indiceNd)};
         // recompute broadcast
-        des = TensorUtils::getDescribe(broadcastStride.get());
-        des->extra.offset = 0;
-        des->memoryType = Tensor::InsideDescribe::MEMORY_VIRTUAL;
-        des->regions[0].origin = constStride.get();
-        des->regions[0].size[0] = 1;
-        des->regions[0].size[1] = mSliceN;
-        des->regions[0].size[2] = indiceNd;
-        des->regions[0].dst.stride[0] = indiceNd*mSliceN;
-        des->regions[0].dst.stride[1] = indiceNd;
-        des->regions[0].dst.stride[2] = 1;
+        des = TensorUtils::getDescribeOrigin(broadcastStride.get());
+        des->offset = 0;
+        nativeDes = TensorUtils::getDescribe(broadcastStride.get());
+        nativeDes->memoryType = Tensor::InsideDescribe::MEMORY_VIRTUAL;
+        nativeDes->regions[0].origin = constStride.get();
+        nativeDes->regions[0].size[0] = 1;
+        nativeDes->regions[0].size[1] = mSliceN;
+        nativeDes->regions[0].size[2] = indiceNd;
+        nativeDes->regions[0].dst.stride[0] = indiceNd*mSliceN;
+        nativeDes->regions[0].dst.stride[1] = indiceNd;
+        nativeDes->regions[0].dst.stride[2] = 1;
         // recompute loop
         auto loopCmd = cmd.command[cmd.command.size() - 1];
         auto param = loopCmd->op->main_as_LoopParam();

--- a/test/expr/StaticModuleOutputReuseTest.cpp
+++ b/test/expr/StaticModuleOutputReuseTest.cpp
@@ -1,0 +1,247 @@
+#include <MNN/expr/ExprCreator.hpp>
+#include <MNN/expr/Module.hpp>
+
+#include "MNNTestSuite.h"
+#include "TestUtils.h"
+#include "core/TensorUtils.hpp"
+
+using namespace MNN;
+using namespace MNN::Express;
+
+static VARPS makeComplexGraph(VARP x) {
+    // Input: NCHW float, shape {1, 4, 32, 32}
+    // Graph intent:
+    // - Introduce multiple ops (convert/conv/pool/concat/transpose) to increase
+    //   intermediate allocations.
+    // - Keep an early large tensor as an output (Aux) to make later output tensor
+    //   more likely to be allocated with non-zero offset on Metal.
+
+    auto x4 = _Convert(x, NC4HW4);
+
+    auto c0 = _Conv(0.01f, 0.0f, x4, {4, 8}, {3, 3}, SAME, {1, 1}, {1, 1}, 1);
+    c0      = _Relu(c0);
+
+    auto maxP = _MaxPool(c0, {2, 2}, {2, 2}, VALID);
+    auto aveP = _AvePool(c0, {2, 2}, {2, 2}, VALID);
+
+    auto aux = _Concat({maxP, aveP}, 1);
+    aux->setName("Aux");
+
+    auto c1 = _Conv(0.02f, 0.01f, aux, {16, 4}, {1, 1}, SAME, {1, 1}, {1, 1}, 1);
+    c1      = _Relu6(c1);
+
+    auto y = _Convert(c1, NCHW);
+    y      = _Transpose(y, {0, 2, 3, 1});
+    y      = _Transpose(y, {0, 3, 1, 2});
+    y      = y + _Scalar<float>(1.0f);
+    y = _ReduceSum(y, {2}, true);
+    y->setName("Output");
+
+    auto s = _Shape(y);
+    s->setName("Shape");
+
+    return {aux, y, s};
+}
+
+static VARP makeInput(float base) {
+    auto x   = _Input({1, 4, 32, 32}, NCHW, halide_type_of<float>());
+    auto ptr = x->writeMap<float>();
+    for (int i = 0; i < x->getInfo()->size; ++i) {
+        ptr[i] = base + (float)i * 0.001f;
+    }
+    x->unMap();
+    return x;
+}
+
+static bool isMetalRuntime() {
+    auto rtInfo = Express::ExecutorScope::Current()->getRuntime();
+    if (rtInfo.first.empty()) {
+        return false;
+    }
+    return rtInfo.first.begin()->first == MNN_FORWARD_METAL;
+}
+
+class StaticModuleOutputReuseTest : public MNNTestCase {
+public:
+    bool run(int precision) override {
+        auto executor = cloneCurrentExecutor();
+        ExecutorScope scope(executor);
+
+        std::vector<int8_t> buffer;
+        {
+            auto x = _Input({1, 4, 32, 32}, NCHW, halide_type_of<float>());
+            x->setName("Input");
+            auto outputs = makeComplexGraph(x);
+            buffer       = Variable::save(outputs);
+        }
+
+        Module::Config config;
+        config.shapeMutable = true;
+
+        std::shared_ptr<Module> module(
+            Module::load({"Input"}, {"Aux", "Output", "Shape"}, (const uint8_t*)buffer.data(), buffer.size(), &config),
+            Module::destroy);
+        if (nullptr == module) {
+            return false;
+        }
+        {
+            auto x   = _Input({1, 4, 320, 320}, NCHW, halide_type_of<float>());
+            auto ptr = x->writeMap<float>();
+            module->onForward({x});
+        }
+
+        auto input0   = makeInput(0.0f);
+        auto outputs0 = module->onForward({input0});
+        if (outputs0.size() != 3) {
+            return false;
+        }
+
+        auto aux0Info   = outputs0[0]->getInfo();
+        auto output0Info = outputs0[1]->getInfo();
+        auto shape0Info = outputs0[2]->getInfo();
+        if (nullptr == aux0Info || nullptr == output0Info || nullptr == shape0Info) {
+            return false;
+        }
+        if (aux0Info->dim != std::vector<int>({1, 16, 16, 16})) {
+            return false;
+        }
+        if (output0Info->dim != std::vector<int>({1, 4, 1, 16})) {
+            return false;
+        }
+        if (shape0Info->dim != std::vector<int>({4})) {
+            return false;
+        }
+
+        int expectedShape[4] = {1, 4, 1, 16};
+        auto shapeResult0    = outputs0[2]->readMap<int>();
+        if (!checkVector(shapeResult0, expectedShape, 4, 0)) {
+            return false;
+        }
+
+        // Snapshot first inference results. We'll verify they remain unchanged after
+        // the next inference (to catch output buffer reuse issues).
+        std::vector<float> aux0Snapshot(aux0Info->size);
+        std::vector<float> output0Snapshot(output0Info->size);
+        std::vector<int> shape0Snapshot(4);
+        {
+            auto auxPtr = outputs0[0]->readMap<float>();
+            auto outPtr = outputs0[1]->readMap<float>();
+            for (int i = 0; i < aux0Info->size; ++i) {
+                aux0Snapshot[i] = auxPtr[i];
+            }
+            for (int i = 0; i < output0Info->size; ++i) {
+                output0Snapshot[i] = outPtr[i];
+            }
+            for (int i = 0; i < 4; ++i) {
+                shape0Snapshot[i] = shapeResult0[i];
+            }
+        }
+
+        auto aux0Tensor    = outputs0[0]->getTensor();
+        auto output0Tensor = outputs0[1]->getTensor();
+        auto shape0Tensor  = outputs0[2]->getTensor();
+        if (nullptr == aux0Tensor || nullptr == output0Tensor || nullptr == shape0Tensor) {
+            return false;
+        }
+
+        auto aux0DescribeOrigin    = TensorUtils::getDescribeOrigin(aux0Tensor);
+        auto output0DescribeOrigin = TensorUtils::getDescribeOrigin(output0Tensor);
+        auto shape0DescribeOrigin  = TensorUtils::getDescribeOrigin(shape0Tensor);
+        if (nullptr == aux0DescribeOrigin || nullptr == output0DescribeOrigin || nullptr == shape0DescribeOrigin) {
+            return false;
+        }
+
+        int aux0Offset    = aux0DescribeOrigin->offset;
+        int output0Offset = output0DescribeOrigin->offset;
+        int shape0Offset  = shape0DescribeOrigin->offset;
+
+        if (isMetalRuntime() && output0Offset <= 0) {
+            // Not a hard assert: offset depends on allocator strategy / platform.
+            // But the model is designed to make output buffer more likely to be a
+            // non-zero slice inside a shared MTLBuffer.
+            MNN_PRINT("[StaticModuleOutputReuseTest] Metal output offset=%d (aux=%d, shape=%d)\n", output0Offset, aux0Offset,
+                      shape0Offset);
+        }
+
+        auto input1   = makeInput(10.0f);
+        auto outputs1 = module->onForward({input1});
+        for (int i=0; i<10; ++i) {
+            outputs1 = module->onForward({input1});
+        }
+        if (outputs1.size() != 3) {
+            return false;
+        }
+
+        auto aux1Info    = outputs1[0]->getInfo();
+        auto output1Info = outputs1[1]->getInfo();
+        auto shape1Info  = outputs1[2]->getInfo();
+        if (nullptr == aux1Info || nullptr == output1Info || nullptr == shape1Info) {
+            return false;
+        }
+        if (aux1Info->dim != std::vector<int>({1, 16, 16, 16})) {
+            return false;
+        }
+        if (output1Info->dim != std::vector<int>({1, 4, 1, 16})) {
+            return false;
+        }
+        if (shape1Info->dim != std::vector<int>({4})) {
+            return false;
+        }
+
+        auto shapeResult1 = outputs1[2]->readMap<int>();
+        if (!checkVector(shapeResult1, expectedShape, 4, 0)) {
+            return false;
+        }
+
+
+        // Ensure the previous forward's outputs are still valid, and their offsets
+        // stay unchanged after the next forward.
+        auto aux0InfoAfter    = outputs0[0]->getInfo();
+        auto output0InfoAfter = outputs0[1]->getInfo();
+        auto shape0InfoAfter  = outputs0[2]->getInfo();
+        if (nullptr == aux0InfoAfter || nullptr == output0InfoAfter || nullptr == shape0InfoAfter) {
+            return false;
+        }
+        if (aux0InfoAfter->dim != std::vector<int>({1, 16, 16, 16})) {
+            return false;
+        }
+        if (output0InfoAfter->dim != std::vector<int>({1, 4, 1, 16})) {
+            return false;
+        }
+        if (shape0InfoAfter->dim != std::vector<int>({4})) {
+            return false;
+        }
+
+        // Ensure the previous inference results remain unchanged after the next forward.
+        if (!checkVector(outputs0[0]->readMap<float>(), aux0Snapshot.data(), (int)aux0Snapshot.size(), 1e-4f)) {
+            return false;
+        }
+        if (!checkVector(outputs0[1]->readMap<float>(), output0Snapshot.data(), (int)output0Snapshot.size(), 1e-4f)) {
+            return false;
+        }
+        if (!checkVector(outputs0[2]->readMap<int>(), shape0Snapshot.data(), (int)shape0Snapshot.size(), 0)) {
+            return false;
+        }
+
+        auto aux0DescribeAfterOrigin    = TensorUtils::getDescribeOrigin(outputs0[0]->getTensor());
+        auto output0DescribeAfterOrigin = TensorUtils::getDescribeOrigin(outputs0[1]->getTensor());
+        auto shape0DescribeAfterOrigin  = TensorUtils::getDescribeOrigin(outputs0[2]->getTensor());
+        if (nullptr == aux0DescribeAfterOrigin || nullptr == output0DescribeAfterOrigin || nullptr == shape0DescribeAfterOrigin) {
+            return false;
+        }
+
+        if (aux0Offset != aux0DescribeAfterOrigin->offset) {
+            return false;
+        }
+        if (output0Offset != output0DescribeAfterOrigin->offset) {
+            return false;
+        }
+        if (shape0Offset != shape0DescribeAfterOrigin->offset) {
+            return false;
+        }
+
+        return true;
+    }
+};
+
+MNNTestSuiteRegister(StaticModuleOutputReuseTest, "expr/StaticModuleOutputReuseTest");


### PR DESCRIPTION
[修正使用 Metal 后端时，module 在 output 被占用情况下第二次推理后，首次推理的 output offset 被异常覆盖，导致后续结果错误的问题](https://github.com/alibaba/MNN/pull/4364)