### PR TITLE
[Vulkan:Bugfix] Fix bug for building mnncli with -DMNN_VULKAN=ON

### DIFF
--- a/transformers/diffusion/engine/src/tokenizer.hpp
+++ b/transformers/diffusion/engine/src/tokenizer.hpp
@@ -1,6 +1,7 @@
 #include <vector>
 #include <string>
 #include <unordered_map>
+#include <cstdint>
 
 #ifndef MNN_DIFFUSION_TOKENIZER_HPP
 #define MNN_DIFFUSION_TOKENIZER_HPP


### PR DESCRIPTION
## Description

Fix the building issue of build mnncli with MNN_VULKAN=ON.
I found this while running apps/mnncli/build.sh.

```diff
diff --git a/apps/mnncli/build.sh b/apps/mnncli/build.sh
index 6a608745..4b3f2e02 100755
--- a/apps/mnncli/build.sh
+++ b/apps/mnncli/build.sh
@@ -56,6 +56,7 @@ CMAKE_ARGS=(
     "-DMNN_SEP_BUILD=OFF"
     "-DMNN_USE_OPENCV=ON"
     "-DLLM_SUPPORT_HTTP_RESOURCE=OFF"
+    "-DMNN_VULKAN=ON"
 )
```

```
In file included from /data/src/MNN/transformers/diffusion/engine/src/tokenizer.cpp:5:
/data/src/MNN/transformers/diffusion/engine/src/tokenizer.hpp:54:24: error: 'uint8_t' was not declared in this scope
   54 |     std::unordered_map<uint8_t, wchar_t> b2u_;
      |                        ^~~~~~~
/data/src/MNN/transformers/diffusion/engine/src/tokenizer.hpp:4:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
    3 | #include <unordered_map>
  +++ |+#include <cstdint>
    4 | 
/data/src/MNN/transformers/diffusion/engine/src/tokenizer.hpp:54:40: error: template argument 1 is invalid
   54 |     std::unordered_map<uint8_t, wchar_t> b2u_;
      |                                        ^
/data/src/MNN/transformers/diffusion/engine/src/tokenizer.hpp:54:40: error: template argument 3 is invalid
/data/src/MNN/transformers/diffusion/engine/src/tokenizer.hpp:54:40: error: template argument 4 is invalid
/data/src/MNN/transformers/diffusion/engine/src/tokenizer.hpp:54:40: error: template argument 5 is invalid
/data/src/MNN/transformers/diffusion/engine/src/tokenizer.hpp:55:33: error: 'uint8_t' was not declared in this scope
   55 |     std::unordered_map<wchar_t, uint8_t> u2b_;
```

## Module

<!-- Which module does this PR affect? e.g. LLM, CPU, Metal, CUDA, OpenCL, Core, Infra -->

## Type

- [ ] Feature
- [x] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [ ] Tested on relevant platform(s)
- [x] No unrelated format or style changes included
