### PR TITLE
[QNN:Bugfix] Stabilize QNN LLM export/runtime and fix deepstack profile

### DIFF
--- a/source/backend/qnn/CMakeLists.txt
+++ b/source/backend/qnn/CMakeLists.txt
@@ -2,7 +2,8 @@ option(MNN_QNN_CONVERT_MODE "Enable the Convert mode of the QNN backend." OFF)
 
 file(GLOB BACKEND_SRCS ${CMAKE_CURRENT_LIST_DIR}/backend/*)
 file(GLOB EXECUTION_SRCS ${CMAKE_CURRENT_LIST_DIR}/execution/*)
-set(MNN_QNN_SRCS ${BACKEND_SRCS} ${EXECUTION_SRCS})
+set(MNN_QNN_SRCS ${BACKEND_SRCS} ${EXECUTION_SRCS}
+    ${CMAKE_SOURCE_DIR}/3rd_party/flatbuffers/src/util.cpp)
 
 # Prefer CMake variable QNN_SDK_ROOT (passed via -DQNN_SDK_ROOT=...), fallback to environment
 set(_QNN_ROOT "$ENV{QNN_SDK_ROOT}")

--- a/source/backend/qnn/backend/QNNBackend.cpp
+++ b/source/backend/qnn/backend/QNNBackend.cpp
@@ -12,6 +12,11 @@
 // #define MNN_OPEN_TIME_TRACE
 #include <MNN/AutoTime.hpp>
 #include "core/FileLoader.hpp"
+#include <cstdlib>
+
+#if !defined(__aarch64__) && !defined(__arm__)
+typedef uint16_t __fp16;
+#endif
 // #define QNN_PROFILE_OP
 // #define QNN_PROFILE_SUMMARIZE
 // #define QNN_VERBOSE
@@ -37,11 +42,32 @@ struct QnnContext {
 static QnnContext gContext;
 static std::mutex gQnnContextMutex;
 
+#ifdef ENABLE_QNN_CONVERT_MODE
+static bool useConvertorInterface() {
+    const char* forceConvertor = std::getenv("MNN_QNN_USE_CONVERTOR_INTERFACE");
+    return forceConvertor != nullptr && forceConvertor[0] == '1';
+}
+#endif
+
 static void createQnnContext(){
     std::lock_guard<std::mutex> lck(gQnnContextMutex);
     QNN_INTERFACE_VER_TYPE qnnInterface{};
-#ifndef ENABLE_QNN_CONVERT_MODE
-    {
+#ifdef ENABLE_QNN_CONVERT_MODE
+    bool useConvertor = useConvertorInterface();
+#else
+    bool useConvertor = false;
+#endif
+    if (!useConvertor) {
+        bool needLoadSymbol = (QNN::QnnInterface_getProviders == nullptr);
+#ifdef MNN_WITH_PLUGIN
+        needLoadSymbol = needLoadSymbol || (QNN::QnnSystemInterface_getProviders == nullptr);
+#endif
+        if (needLoadSymbol && !QNN::loadQNNSymbol()) {
+            MNN_ERROR("MNN_QNN: Failed to load QNN symbols for runtime execution.\n");
+            return;
+        }
+    }
+    if (!useConvertor) {
         QnnInterface_t** interfaceProviders = nullptr;
         uint32_t numProviders = 0;
         if (QNN::QnnInterface_getProviders((const QnnInterface_t***)&interfaceProviders, &numProviders) != QNN_SUCCESS) {
@@ -70,8 +96,11 @@ static void createQnnContext(){
             return;
         }
     }
-#else
-    qnnInterface = QNN::gQnnConvertorInterface;
+#ifdef ENABLE_QNN_CONVERT_MODE
+    else {
+        MNN_PRINT("MNN_QNN: Using convertor interface (MNN_QNN_USE_CONVERTOR_INTERFACE=1).\n");
+        qnnInterface = QNN::gQnnConvertorInterface;
+    }
 #endif
 
     // Create Log.
@@ -133,9 +162,8 @@ static void createQnnContext(){
 
     // Create System Interface
     QNN_SYSTEM_INTERFACE_VER_TYPE systemInterface{};
-#ifndef ENABLE_QNN_CONVERT_MODE
-    #ifdef MNN_WITH_PLUGIN
-    {
+#ifdef MNN_WITH_PLUGIN
+    if (!useConvertor) {
         QnnSystemInterface_t** interfaceProviders = nullptr;
         uint32_t numProviders = 0;
         if (QNN::QnnSystemInterface_getProviders((const QnnSystemInterface_t***)&interfaceProviders, &numProviders) != QNN_SUCCESS) {
@@ -164,9 +192,11 @@ static void createQnnContext(){
             return;
         }
     }
-    #endif
-#else
-    systemInterface = QNN::gQnnConvertorSystemInterface;
+#endif
+#ifdef ENABLE_QNN_CONVERT_MODE
+    if (useConvertor) {
+        systemInterface = QNN::gQnnConvertorSystemInterface;
+    }
 #endif
 
 
@@ -459,6 +489,28 @@ static bool computeIndex(PluginContext* ctx, int & index) {
             index = si;
             return true;
         }
+    }
+    MNN_ERROR("MNN_QNN: Plugin shape profile miss. input_count=%d, dim_sum=%d, profile_count=%d\n", (int)inputs.size(), dimSum, indexNumber);
+    for (int i = 0; i < inputs.size(); ++i) {
+        auto inputDim = inputs[i]->dimensions();
+        MNN_ERROR("  input[%d] rank=%d shape=", i, inputDim);
+        for (int j = 0; j < inputDim; ++j) {
+            MNN_ERROR("%d%s", inputs[i]->length(j), (j + 1 == inputDim) ? "" : "x");
+        }
+        MNN_ERROR("\n");
+    }
+    for (int si = 0; si < indexNumber; ++si) {
+        auto dstSi = attrAllShape->list()->i()->data() + si * dimSum;
+        MNN_ERROR("  profile[%d]=", si);
+        for (int i = 0; i < inputs.size(); ++i) {
+            auto inputDim = inputs[i]->dimensions();
+            MNN_ERROR("%s", (i == 0) ? "" : " | ");
+            for (int j = 0; j < inputDim; ++j) {
+                MNN_ERROR("%d%s", dstSi[j], (j + 1 == inputDim) ? "" : "x");
+            }
+            dstSi += inputDim;
+        }
+        MNN_ERROR("\n");
     }
     return false;
 }
@@ -850,27 +902,106 @@ public:
 
         // 1. Set mGraphsInfo and mGraphCount from the buffer.
         {
-            QnnSystemContext_Handle_t systemContextHandle = nullptr;
-            if (QNN_SUCCESS != QNN::gContext.systemInterface.systemContextCreate(&systemContextHandle)) {
-                MNN_ERROR("Could not create system context handle.");
+            bool hasSystemInterfaceFns =
+                QNN::gContext.systemInterface.systemContextCreate != nullptr &&
+                QNN::gContext.systemInterface.systemContextGetBinaryInfo != nullptr &&
+                QNN::gContext.systemInterface.systemContextFree != nullptr;
+            bool hasDirectSystemFns =
+                QNN::QnnSystemContext_create != nullptr &&
+                QNN::QnnSystemContext_getBinaryInfo != nullptr &&
+                QNN::QnnSystemContext_free != nullptr;
+            if (!hasSystemInterfaceFns && !hasDirectSystemFns) {
+                MNN_ERROR("QNN: system interface is not initialized correctly.\n");
                 return false;
             }
+            QnnSystemContext_Handle_t systemContextHandle = nullptr;
             Qnn_ContextBinarySize_t binarySize = 0;
             const QnnSystemContext_BinaryInfo_t* binaryInfo = nullptr;
-            CALL_QNN(QNN::gContext.systemInterface.systemContextGetBinaryInfo(systemContextHandle, buffer, size, &binaryInfo,&binarySize));
-            copyMetadataToGraphsInfo(binaryInfo, mGraphsInfo, mGraphCount);
-            if (QNN_SUCCESS != QNN::gContext.systemInterface.systemContextFree(systemContextHandle)) {
-                MNN_ERROR("Could not free system context handle.");
+
+            bool parsed = false;
+            if (hasSystemInterfaceFns) {
+                auto createStatus = QNN::gContext.systemInterface.systemContextCreate(&systemContextHandle);
+                MNN_PRINT("QNN: systemContextCreate status=%llu(code=%u), handle=%p, path=%s\n",
+                          (unsigned long long)createStatus, (unsigned int)QNN_GET_ERROR_CODE(createStatus), systemContextHandle, path.c_str());
+                if (QNN_SUCCESS == createStatus) {
+                    auto getInfoStatus = QNN::gContext.systemInterface.systemContextGetBinaryInfo(
+                        systemContextHandle, buffer, size, &binaryInfo, &binarySize);
+                    MNN_PRINT("QNN: systemContextGetBinaryInfo status=%llu(code=%u), info=%p, infoSize=%llu, path=%s\n",
+                              (unsigned long long)getInfoStatus, (unsigned int)QNN_GET_ERROR_CODE(getInfoStatus),
+                              binaryInfo, (unsigned long long)binarySize, path.c_str());
+                    if (QNN_SUCCESS == getInfoStatus && binaryInfo != nullptr) {
+                        parsed = true;
+                    } else if (QNN::gContext.systemInterface.systemContextGetMetaData != nullptr) {
+                        auto getMetaStatus = QNN::gContext.systemInterface.systemContextGetMetaData(
+                            systemContextHandle, buffer, size, &binaryInfo);
+                        MNN_PRINT("QNN: systemContextGetMetaData status=%llu(code=%u), info=%p, path=%s\n",
+                                  (unsigned long long)getMetaStatus, (unsigned int)QNN_GET_ERROR_CODE(getMetaStatus),
+                                  binaryInfo, path.c_str());
+                        if (QNN_SUCCESS == getMetaStatus && binaryInfo != nullptr) {
+                            parsed = true;
+                        }
+                    }
+                    if (parsed) {
+                        if (!copyMetadataToGraphsInfo(binaryInfo, mGraphsInfo, mGraphCount)) {
+                            MNN_ERROR("QNN: failed to copy binary metadata: %s\n", path.c_str());
+                            parsed = false;
+                        }
+                    }
+                    QNN::gContext.systemInterface.systemContextFree(systemContextHandle);
+                    systemContextHandle = nullptr;
+                }
+            }
+
+            if (!parsed && hasDirectSystemFns) {
+                auto createStatus = QNN::QnnSystemContext_create(&systemContextHandle);
+                if (QNN_SUCCESS == createStatus) {
+                    auto getInfoStatus = QNN::QnnSystemContext_getBinaryInfo(
+                        systemContextHandle, reinterpret_cast<const uint8_t*>(buffer), size, &binaryInfo, &binarySize);
+                    MNN_PRINT("QNN: direct QnnSystemContext_getBinaryInfo status=%llu(code=%u), info=%p, infoSize=%llu, path=%s\n",
+                              (unsigned long long)getInfoStatus, (unsigned int)QNN_GET_ERROR_CODE(getInfoStatus),
+                              binaryInfo, (unsigned long long)binarySize, path.c_str());
+                    if (QNN_SUCCESS == getInfoStatus && binaryInfo != nullptr) {
+                        parsed = true;
+                        if (!copyMetadataToGraphsInfo(binaryInfo, mGraphsInfo, mGraphCount)) {
+                            MNN_ERROR("QNN: failed to copy binary metadata (direct): %s\n", path.c_str());
+                            parsed = false;
+                        }
+                    }
+                    QNN::QnnSystemContext_free(systemContextHandle);
+                    systemContextHandle = nullptr;
+                }
+            }
+
+            if (!parsed) {
+                MNN_ERROR("QNN: failed to parse binary metadata: %s\n", path.c_str());
+                return false;
+            }
+            if (mGraphCount == 0 || mGraphsInfo == nullptr) {
+                MNN_ERROR("QNN: no graph metadata parsed from binary: %s\n", path.c_str());
                 return false;
             }
         }
 
         // 2. Retrieve graphs.
         {
-            auto error = QNN::gContext.interface.contextValidateBinary(QNN::gContext.backendHandle, QNN::gContext.deviceHandle, mQnnContextConfig, buffer, size);
-            if (QNN_SUCCESS != error) {
-                MNN_ERROR("QNN: Failed to validate binary: %d\n", (int) error);
+            if (QNN::gContext.interface.contextCreateFromBinary == nullptr ||
+                QNN::gContext.interface.graphRetrieve == nullptr) {
+                MNN_ERROR("QNN: context interface is not initialized correctly.\n");
                 return false;
+            }
+            if (QNN::gContext.interface.contextValidateBinary != nullptr) {
+                auto error = QNN::gContext.interface.contextValidateBinary(QNN::gContext.backendHandle, QNN::gContext.deviceHandle, mQnnContextConfig, buffer, size);
+                if (QNN_SUCCESS != error) {
+                    if (QNN_GET_ERROR_CODE(error) == QNN_COMMON_ERROR_NOT_SUPPORTED) {
+                        MNN_PRINT("QNN: contextValidateBinary is not supported by backend, skip validate. status=%llu(code=%u)\n",
+                                  (unsigned long long)error, (unsigned int)QNN_GET_ERROR_CODE(error));
+                    } else {
+                        MNN_ERROR("QNN: Failed to validate binary: %d\n", (int) error);
+                        return false;
+                    }
+                }
+            } else {
+                MNN_PRINT("QNN: contextValidateBinary is nullptr, skip validate.\n");
             }
 
             // Create Graph profile
@@ -879,6 +1010,10 @@ public:
             CALL_QNN(QNN::gContext.interface.contextCreateFromBinary(QNN::gContext.backendHandle, QNN::gContext.deviceHandle, mQnnContextConfig, buffer, size, &mQnnContextHandle, mQnnProfileHandle));
 
             mQnnGraphHandleVec.resize(mGraphCount, nullptr);
+            if (allGraphName.size() != mGraphCount) {
+                MNN_ERROR("QNN: graph name count mismatch. binary=%d attr=%d path=%s\n", (int)mGraphCount, (int)allGraphName.size(), path.c_str());
+                return false;
+            }
 
             std::vector<GraphInfo*> sortedGraphsInfo(mGraphCount, nullptr);
             std::map<std::string, GraphInfo*> graphInfoMap;
@@ -888,7 +1023,10 @@ public:
 
             for (int i = 0; i < mGraphCount; ++i) {
                 auto it = graphInfoMap.find(allGraphName[i]);
-                MNN_ASSERT(it != graphInfoMap.end());
+                if (it == graphInfoMap.end()) {
+                    MNN_ERROR("QNN: can not find graph '%s' in binary '%s'.\n", allGraphName[i].c_str(), path.c_str());
+                    return false;
+                }
                 sortedGraphsInfo[i] = it->second;
             }
             for (int i = 0; i < mGraphCount; ++i) {
@@ -930,8 +1068,20 @@ public:
         return nullptr;
     }
     void setupAddress(const std::vector<std::pair<const MNN::Tensor *, std::string>>& inputs, std::vector<std::pair<const MNN::Tensor *, std::string>>& outputs, int shapeIndex) {
+        if (mGraphsInfo == nullptr || shapeIndex < 0 || shapeIndex >= mGraphCount) {
+            MNN_ERROR("QNN: invalid graph index %d (graph_count=%d).\n", shapeIndex, (int)mGraphCount);
+            return;
+        }
         GraphInfo* graph = mGraphsInfo[shapeIndex];
+        if (graph == nullptr) {
+            MNN_ERROR("QNN: graph info is nullptr for index %d.\n", shapeIndex);
+            return;
+        }
         Qnn_GraphHandle_t qnnGraphHandle = mQnnGraphHandleVec[shapeIndex];
+        if (qnnGraphHandle == nullptr) {
+            MNN_ERROR("QNN: graph handle is nullptr for index %d.\n", shapeIndex);
+            return;
+        }
 
         // MNN_PRINT("%s, Input:%d, output:%d\n", mPath.c_str(), inputs.size(), outputs.size());
         for (int i=0; i<inputs.size(); ++i) {
@@ -998,12 +1148,30 @@ public:
         }
     }
 
-    void invokModel(int shapeIndex) {
+    bool invokModel(int shapeIndex) {
+        if (mGraphsInfo == nullptr || shapeIndex < 0 || shapeIndex >= mGraphCount) {
+            MNN_ERROR("QNN: invalid invoke graph index %d (graph_count=%d).\n", shapeIndex, (int)mGraphCount);
+            return false;
+        }
+        if (shapeIndex >= mQnnGraphHandleVec.size() || mQnnGraphHandleVec[shapeIndex] == nullptr) {
+            MNN_ERROR("QNN: graph handle is nullptr on invoke, index=%d.\n", shapeIndex);
+            return false;
+        }
         GraphInfo* graph = mGraphsInfo[shapeIndex];
+        if (graph == nullptr) {
+            MNN_ERROR("QNN: graph info is nullptr on invoke, index=%d.\n", shapeIndex);
+            return false;
+        }
         Qnn_GraphHandle_t qnnGraphHandle = mQnnGraphHandleVec[shapeIndex];
-        CALL_QNN(QNN::gContext.interface.graphExecute(qnnGraphHandle, graph->inputTensors, graph->numInputTensors, \
-            graph->outputTensors, graph->numOutputTensors, mQnnProfileHandle, nullptr));
+        auto executeStatus = QNN::gContext.interface.graphExecute(qnnGraphHandle, graph->inputTensors, graph->numInputTensors, \
+            graph->outputTensors, graph->numOutputTensors, mQnnProfileHandle, nullptr);
+        if (QNN_SUCCESS != executeStatus) {
+            MNN_ERROR("QNN: graphExecute failed, status=%llu(code=%u), graphIndex=%d.\n",
+                      (unsigned long long)executeStatus, (unsigned int)QNN_GET_ERROR_CODE(executeStatus), shapeIndex);
+            return false;
+        }
         MNN::QNN::doProfile(QNN::gContext.interface, mQnnProfileHandle);
+        return true;
     }
 };
 
@@ -1169,6 +1337,10 @@ public:
             return false;
         }
         mShapeIndex = shapeIndex;
+        if (!mRawExecutor) {
+            MNN_ERROR("MNN_QNN: RawExecutor is nullptr in resize.\n");
+            return false;
+        }
 
         auto inputs = ctx->getAttr("inputs")->list();
         auto inputTensor = ctx->inputs();
@@ -1198,6 +1370,10 @@ public:
             }
             std::vector<RPCBuffer*> statesOutput(mStateInput.size());
             for (int i=0; i<mStateInput.size(); ++i) {
+                if (mShapeIndex < 0 || mShapeIndex >= mStateInput[i].update.size()) {
+                    MNN_ERROR("QNN: invalid state update index %d (size=%d) for state %d.\n", mShapeIndex, (int)mStateInput[i].update.size(), i);
+                    return false;
+                }
                 statesOutput[i] = mStateInput[i].update[mShapeIndex].get();
             }
 
@@ -1208,8 +1384,17 @@ public:
 
     bool compute(CPUKernelContext* ctx) override {
         AUTOTIME;
+        if (!mRawExecutor) {
+            MNN_ERROR("MNN_QNN: RawExecutor is nullptr in compute.\n");
+            return false;
+        }
         int shapeIndex = mShapeIndex;
-        std::string graphName = ctx->getAttr("allGraphName")->list()->s()->GetAsString(shapeIndex)->str();
+        auto allGraphNameList = ctx->getAttr("allGraphName")->list()->s();
+        if (shapeIndex < 0 || shapeIndex >= allGraphNameList->size()) {
+            MNN_ERROR("MNN_QNN: invalid shapeIndex=%d, allGraphName size=%d.\n", shapeIndex, allGraphNameList->size());
+            return false;
+        }
+        std::string graphName = allGraphNameList->GetAsString(shapeIndex)->str();
 
         #ifdef QNN_VERBOSE
         MNN_PRINT("Graph name:%s, %d\n", graphName.c_str(), shapeIndex);
@@ -1223,6 +1408,10 @@ public:
         // If has remove, remove invalid state
         auto meta = (KVMeta*)(ctx->backend()->getMetaPtr());
         if (nullptr != meta && mStateInput.size() > 0) {
+            if (mMask == nullptr || mMask->mPtr == nullptr) {
+                MNN_ERROR("QNN: mask buffer is nullptr.\n");
+                return false;
+            }
             auto maskPtr = (__fp16*)mMask->mPtr;
             if (meta->remove > 0) {
                 if (meta->remove > mStateCurrent) {
@@ -1235,12 +1424,19 @@ public:
                 }
             }
         }
-        mRawExecutor->invokModel(shapeIndex);
+        if (!mRawExecutor->invokModel(shapeIndex)) {
+            MNN_ERROR("MNN_QNN: invoke failed for shapeIndex=%d.\n", shapeIndex);
+            return false;
+        }
         for (int i=0; i<mOutputs.size(); ++i) {
             ctx->backend()->onCopyBuffer(mRealOutputs[i].get(), outputTensor[i]);
         }
         // Update State
         if (nullptr != meta && mStateInput.size() > 0) {
+            if (mMask == nullptr || mMask->mPtr == nullptr) {
+                MNN_ERROR("QNN: mask buffer is nullptr in state update.\n");
+                return false;
+            }
             auto maskPtr = (__fp16*)mMask->mPtr;
             if (meta->add + mStateCurrent > mStateMaxSize) {
                 MNN_ERROR("QNN: Error: KV length %d larger than max size = %d\n", meta->add + mStateCurrent, mStateMaxSize);
@@ -1251,9 +1447,17 @@ public:
             }
             // Temply use StateOutputs[0] size to compute seq_len
             int bytes = 2;
+            if (mShapeIndex < 0 || mShapeIndex >= mSeqLen.size()) {
+                MNN_ERROR("QNN: invalid mShapeIndex=%d for seq len size=%d.\n", mShapeIndex, (int)mSeqLen.size());
+                return false;
+            }
             int seqLen = mSeqLen[mShapeIndex];
             for (int i=0; i<mStateInput.size(); ++i) {
                 auto& input = mStateInput[i];
+                if (mShapeIndex < 0 || mShapeIndex >= input.update.size() || input.update[mShapeIndex] == nullptr) {
+                    MNN_ERROR("QNN: invalid state update buffer for state %d, shapeIndex=%d.\n", i, mShapeIndex);
+                    return false;
+                }
                 for (int y=0; y<input.outside; ++y) {
                     auto dstOffset = y * input.inside * mStateMaxSize + mStateCurrent * input.inside;
                     auto srcOffset = y * input.inside * seqLen;
@@ -1730,23 +1934,38 @@ int QnnBackend::getTensorIdx(const Tensor * tensor) const {
     int idx = -1;
     if (iter == mTensorMap.end()) {
         std::string tName = "QnnTensor_" + std::to_string(mTensorCounter);;
-        if (TensorUtils::getDescribe(tensor)->usage != Tensor::InsideDescribe::Usage::CONSTANT) {
-            MNN_PRINT("Tensor usage is %d.\n", (int) TensorUtils::getDescribe(tensor)->usage);
-        }
+        auto usage = TensorUtils::getDescribe(tensor)->usage;
         #ifdef QNN_VERBOSE
-        MNN_PRINT("qnn tenor usage:%d, dimension:%d\n", TensorUtils::getDescribe(tensor)->usage, tensor->dimensions());
+        MNN_PRINT("qnn tenor usage:%d, dimension:%d\n", usage, tensor->dimensions());
         #endif
-        MNN_ASSERT(TensorUtils::getDescribe(tensor)->usage == Tensor::InsideDescribe::Usage::CONSTANT);
-        // MNN_ASSERT(tensor->dimensions() <= 2);
+        if (usage != Tensor::InsideDescribe::Usage::CONSTANT) {
+            MNN_PRINT("MNN_QNN: Tensor not in map and usage=%d, treating as static for graph construction.\n", (int) usage);
+        }
         std::vector<uint32_t> tDims = getNHWCShape(tensor);
+        uint32_t numElement = 1;
+        for (auto d : tDims) {
+            numElement *= d;
+        }
         Qnn_DataType_t tDataType;
         std::shared_ptr<QNNTensorWrapper> qnnTensorWrapper;
+        std::vector<uint8_t> zeroBuffer;
         if (tensor->getType().code == halide_type_int && tensor->getType().bits == 32) {
             tDataType = QNN_DATATYPE_INT_32;
-            qnnTensorWrapper = QNNTensorWrapper::createStaticTensor(tName, tDataType, tDims, tensor->host<int>());
+            const void* hostPtr = tensor->host<int>();
+            if (!hostPtr) {
+                zeroBuffer.resize(numElement * sizeof(int32_t), 0);
+                hostPtr = zeroBuffer.data();
+            }
+            qnnTensorWrapper = QNNTensorWrapper::createStaticTensor(tName, tDataType, tDims, hostPtr);
         } else if (tensor->getType().code == halide_type_float) {
             tDataType = mUseFP16 ? QNN_DATATYPE_FLOAT_16 : QNN_DATATYPE_FLOAT_32;
-            qnnTensorWrapper = QNNTensorWrapper::createStaticFloatTensor(tName, tDataType, tDims, tensor->host<float>());
+            const float* hostPtr = tensor->host<float>();
+            std::vector<float> zeroFloatBuffer;
+            if (!hostPtr) {
+                zeroFloatBuffer.resize(numElement, 0.0f);
+                hostPtr = zeroFloatBuffer.data();
+            }
+            qnnTensorWrapper = QNNTensorWrapper::createStaticFloatTensor(tName, tDataType, tDims, hostPtr);
         } else {
             MNN_ASSERT(false);
         }

--- a/source/backend/qnn/backend/QNNPerf.cpp
+++ b/source/backend/qnn/backend/QNNPerf.cpp
@@ -12,17 +12,29 @@ namespace MNN {
 namespace QNN {
 
 QNNPerf::QNNPerf(const QNN_INTERFACE_VER_TYPE * qnnInterface) {
-    MNN_ASSERT(qnnInterface != nullptr);
+    if (nullptr == qnnInterface || qnnInterface->deviceGetInfrastructure == nullptr) {
+        MNN_PRINT("MNN_QNN: QNN perf infra is unavailable, skip power tuning.\n");
+        return;
+    }
     mQnnInterface = qnnInterface;
 
     QnnDevice_Infrastructure_t deviceInfra = nullptr;
     CALL_QNN(mQnnInterface->deviceGetInfrastructure(&deviceInfra));
+    if (nullptr == deviceInfra) {
+        MNN_PRINT("MNN_QNN: device infra is null, skip power tuning.\n");
+        return;
+    }
     QnnHtpDevice_Infrastructure_t *htpInfra  = static_cast<QnnHtpDevice_Infrastructure_t *>(deviceInfra);
+    if (nullptr == htpInfra || nullptr == htpInfra->perfInfra.createPowerConfigId) {
+        MNN_PRINT("MNN_QNN: HTP perf infra is unavailable, skip power tuning.\n");
+        return;
+    }
     mPerfInfra = htpInfra->perfInfra;
 
     uint32_t deviceId = 0;
     uint32_t coreId   = 0;
     CALL_QNN(mPerfInfra.createPowerConfigId(deviceId, coreId, &mPowerConfigId));
+    mValid = true;
 
     mPowerConfigBurst = {
         .option       = QNN_HTP_PERF_INFRASTRUCTURE_POWER_CONFIGOPTION_DCVS_V3,
@@ -73,11 +85,17 @@ QNNPerf::QNNPerf(const QNN_INTERFACE_VER_TYPE * qnnInterface) {
 
 // destory power config
 QNNPerf::~QNNPerf() {
+    if (!mValid || mPerfInfra.destroyPowerConfigId == nullptr) {
+        return;
+    }
     CALL_QNN(mPerfInfra.destroyPowerConfigId(mPowerConfigId));
 }
 
 
 void QNNPerf::setRpcLatencyAndPolling() {
+    if (!mValid || mPerfInfra.setPowerConfig == nullptr) {
+        return;
+    }
     // set RPC Control Latency
     QnnHtpPerfInfrastructure_PowerConfig_t rpcControlLatency;            // refer QnnHtpPerfInfrastructure.h
     ::memset(&rpcControlLatency, 0, sizeof(rpcControlLatency));
@@ -98,6 +116,9 @@ void QNNPerf::setRpcLatencyAndPolling() {
 }
 
 void QNNPerf::setPowerConfigBurst() {
+    if (!mValid || mPerfInfra.setPowerConfig == nullptr) {
+        return;
+    }
     #ifdef QNN_VERBOSE
     MNN_PRINT("MNN QNN set burst mode\n");
     #endif
@@ -106,6 +127,9 @@ void QNNPerf::setPowerConfigBurst() {
 }
 
 void QNNPerf::setPowerConfigBalanced() {
+    if (!mValid || mPerfInfra.setPowerConfig == nullptr) {
+        return;
+    }
     const QnnHtpPerfInfrastructure_PowerConfig_t *powerConfigs[] = {&mPowerConfigBalanced, NULL};
     CALL_QNN(mPerfInfra.setPowerConfig(mPowerConfigId, powerConfigs));
 }

--- a/source/backend/qnn/backend/QNNPerf.hpp
+++ b/source/backend/qnn/backend/QNNPerf.hpp
@@ -25,9 +25,10 @@ public:
     void setPowerConfigBalanced();
 
 private:
+    bool mValid = false;
     const QNN_INTERFACE_VER_TYPE * mQnnInterface = nullptr;
     QnnHtpDevice_PerfInfrastructure_t mPerfInfra{};
-    uint32_t mPowerConfigId;
+    uint32_t mPowerConfigId = 0;
     QnnHtpPerfInfrastructure_PowerConfig_t mPowerConfigBurst{};
     QnnHtpPerfInfrastructure_PowerConfig_t mPowerConfigBalanced{};
 };

--- a/source/backend/qnn/backend/QNNUtils.cpp
+++ b/source/backend/qnn/backend/QNNUtils.cpp
@@ -48,6 +48,9 @@ void QnnHalfToFloat(const int16_t* src, float* dst, size_t size) {
 QnnInterface_getProviders_t QnnInterface_getProviders = nullptr;
 #ifdef MNN_WITH_PLUGIN
 QnnSystemInterface_getProviders_t QnnSystemInterface_getProviders = nullptr;
+QnnSystemContext_create_t QnnSystemContext_create = nullptr;
+QnnSystemContext_getBinaryInfo_t QnnSystemContext_getBinaryInfo = nullptr;
+QnnSystemContext_free_t QnnSystemContext_free = nullptr;
 #endif
 bool loadQNNSymbol() {
     LibHandle qnnLibHandle = nullptr;
@@ -93,6 +96,9 @@ bool loadQNNSymbol() {
         MNN_PRINT("MNN_QNN: Failed to load symbol <QnnSystemInterface_getProviders>. dlerror returns %s.\n", errorSym);
         return false;
     }
+    QnnSystemContext_create = (QnnSystemContext_create_t)dlsym(qnnSystemHandle, "QnnSystemContext_create");
+    QnnSystemContext_getBinaryInfo = (QnnSystemContext_getBinaryInfo_t)dlsym(qnnSystemHandle, "QnnSystemContext_getBinaryInfo");
+    QnnSystemContext_free = (QnnSystemContext_free_t)dlsym(qnnSystemHandle, "QnnSystemContext_free");
     #endif
 #endif
 
@@ -154,6 +160,7 @@ void registerQNNOps() {
     #endif
     ___QNNQuantCreator__OpType_FloatToInt8__();
     ___QNNDeQuantCreator__OpType_Int8ToFloat__();
+    ___QNNIm2ColCreator__OpType_Im2Col__();
 }
 
 Tensor::DimensionType gQnnTensorDimType = Tensor::TENSORFLOW;

--- a/source/backend/qnn/backend/QNNUtils.hpp
+++ b/source/backend/qnn/backend/QNNUtils.hpp
@@ -11,6 +11,7 @@
 
 #include "QnnInterface.h"
 #include "System/QnnSystemInterface.h"
+#include "System/QnnSystemContext.h"
 #include "QnnCommon.h"
 #include "QnnLog.h"
 #include "QnnTypes.h"
@@ -65,6 +66,17 @@ extern QnnInterface_getProviders_t QnnInterface_getProviders;
 typedef Qnn_ErrorHandle_t (*QnnSystemInterface_getProviders_t)(const QnnSystemInterface_t*** providerList,
                                                   uint32_t* numProviders);
 extern QnnSystemInterface_getProviders_t QnnSystemInterface_getProviders;
+typedef Qnn_ErrorHandle_t (*QnnSystemContext_create_t)(QnnSystemContext_Handle_t* sysCtxHandle);
+typedef Qnn_ErrorHandle_t (*QnnSystemContext_getBinaryInfo_t)(
+    QnnSystemContext_Handle_t sysCtxHandle,
+    const uint8_t* binaryBuffer,
+    uint64_t binaryBufferSize,
+    const QnnSystemContext_BinaryInfo_t** binaryInfo,
+    Qnn_ContextBinarySize_t* binaryInfoSize);
+typedef Qnn_ErrorHandle_t (*QnnSystemContext_free_t)(QnnSystemContext_Handle_t sysCtxHandle);
+extern QnnSystemContext_create_t QnnSystemContext_create;
+extern QnnSystemContext_getBinaryInfo_t QnnSystemContext_getBinaryInfo;
+extern QnnSystemContext_free_t QnnSystemContext_free;
 #endif
 
 bool loadQNNSymbol();
@@ -112,6 +124,7 @@ extern void ___QNNAttentionCreator__OpType_Attention__();
 #endif
 extern void ___QNNQuantCreator__OpType_FloatToInt8__();
 extern void ___QNNDeQuantCreator__OpType_Int8ToFloat__();
+extern void ___QNNIm2ColCreator__OpType_Im2Col__();
 
 void registerQNNOps();
 

--- a/source/backend/qnn/execution/QNNBinary.cpp
+++ b/source/backend/qnn/execution/QNNBinary.cpp
@@ -156,25 +156,17 @@ public:
             {BinaryOpOperation_POW, "ElementWisePower"},
             {BinaryOpOperation_REALDIV, "ElementWiseDivide"},
             {BinaryOpOperation_MINIMUM, "ElementWiseMinimum"},
-            {BinaryOpOperation_MAXIMUM, "ElementWiseMaximum"}
-            // {BinaryOpOperation_GREATER, ""},
-            // {BinaryOpOperation_GREATER_EQUAL, ""},
-            // {BinaryOpOperation_LESS, ""},
-            // {BinaryOpOperation_FLOORDIV, ""},
-            // {BinaryOpOperation_SquaredDifference, ""},
-            // {BinaryOpOperation_LESS_EQUAL, ""},
-            // {BinaryOpOperation_FLOORMOD, ""},
-            // {BinaryOpOperation_EQUAL, ""},
-            // {BinaryOpOperation_MOD, ""},
-            // {BinaryOpOperation_ATAN2, ""},
-            // {BinaryOpOperation_LOGICALOR, ""},
-            // {BinaryOpOperation_NOTEQUAL, ""},
-            // {BinaryOpOperation_BITWISE_AND, ""},
-            // {BinaryOpOperation_BITWISE_OR, ""},
-            // {BinaryOpOperation_BITWISE_XOR, ""},
-            // {BinaryOpOperation_LOGICALXOR, ""},
-            // {BinaryOpOperation_LEFTSHIFT, ""},
-            // {BinaryOpOperation_RIGHTSHIFT, ""}
+            {BinaryOpOperation_MAXIMUM, "ElementWiseMaximum"},
+            {BinaryOpOperation_GREATER, "ElementWiseGreater"},
+            {BinaryOpOperation_GREATER_EQUAL, "ElementWiseGreaterEqual"},
+            {BinaryOpOperation_LESS, "ElementWiseLess"},
+            {BinaryOpOperation_FLOORDIV, "ElementWiseFloorDiv"},
+            {BinaryOpOperation_LESS_EQUAL, "ElementWiseLessEqual"},
+            {BinaryOpOperation_FLOORMOD, "ElementWiseFmod"},
+            {BinaryOpOperation_EQUAL, "ElementWiseEqual"},
+            {BinaryOpOperation_MOD, "ElementWiseMod"},
+            {BinaryOpOperation_LOGICALOR, "ElementWiseOr"},
+            {BinaryOpOperation_NOTEQUAL, "ElementWiseNotEqual"}
         };
 
         std::map<EltwiseType, std::string> eltwiseMap {

--- a/source/backend/qnn/execution/QNNIm2Col.cpp
+++ b/source/backend/qnn/execution/QNNIm2Col.cpp
@@ -1,0 +1,86 @@
+//
+//  QNNIm2Col.cpp
+//  MNN
+//
+//  Copyright © 2018, Alibaba Group Holding Limited
+//
+
+#include "QNNIm2Col.hpp"
+
+namespace MNN {
+namespace QNN {
+#ifdef ENABLE_QNN_ONLINE_FINALIZE
+
+ErrorCode QNNIm2Col::onEncode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) {
+    auto conv2D = mOp->main_as_Convolution2D();
+    auto common = conv2D->common();
+
+    int kernelH = common->kernelY();
+    int kernelW = common->kernelX();
+    int strideH = common->strideY();
+    int strideW = common->strideX();
+    int dilationH = common->dilateY();
+    int dilationW = common->dilateX();
+    int padY = common->padY();
+    int padX = common->padX();
+
+    auto input = inputs[0];
+    auto output = outputs[0];
+
+    // QNN Im2Col: input [batch, H, W, C] -> output [batch, C*kH*kW, L]
+    // MNN Im2Col: output is 2D [batch*L, C*kH*kW]
+    // We need a 3D stage tensor for QNN, then reshape to MNN's 2D output.
+    int batch = input->length(0);
+    int inH = input->length(1);
+    int inW = input->length(2);
+    int inC = input->length(3);
+    int outH = (inH + 2 * padY - dilationH * (kernelH - 1) - 1) / strideH + 1;
+    int outW = (inW + 2 * padX - dilationW * (kernelW - 1) - 1) / strideW + 1;
+    int L = outH * outW;
+    int colSize = inC * kernelH * kernelW;
+
+    Qnn_DataType_t dataType = mBackend->getNativeTensor(input)->v1.dataType;
+
+    std::vector<uint32_t> stageShape = {(uint32_t)batch, (uint32_t)colSize, (uint32_t)L};
+    auto stageWrapper = this->createStageTensor("im2col_3d", dataType, stageShape);
+
+    std::vector<uint32_t> kernelData = {(uint32_t)kernelH, (uint32_t)kernelW};
+    std::vector<uint32_t> strideData = {(uint32_t)strideH, (uint32_t)strideW};
+    std::vector<uint32_t> padAmountData = {(uint32_t)padY, (uint32_t)padY, (uint32_t)padX, (uint32_t)padX};
+    std::vector<uint32_t> dilationData = {(uint32_t)dilationH, (uint32_t)dilationW};
+
+    this->createParamTensor("kernel_size", QNN_DATATYPE_UINT_32, {2}, (void *)kernelData.data());
+    this->createParamTensor("stride", QNN_DATATYPE_UINT_32, {2}, (void *)strideData.data());
+    this->createParamTensor("pad_amount", QNN_DATATYPE_UINT_32, {2, 2}, (void *)padAmountData.data());
+    this->createParamTensor("dilation", QNN_DATATYPE_UINT_32, {2}, (void *)dilationData.data());
+
+    {
+        CLEAR_BEFORE_ADDING_NODE;
+        std::string name = mNodeName + "_Im2Col";
+        mNodeType = "Im2Col";
+        for (int i = 0; i < mParamTensorWrappers.size(); i++) {
+            mParams.push_back(*(mParamTensorWrappers[i]->getNativeParam()));
+        }
+        mInputs.push_back(*(mBackend->getNativeTensor(input)));
+        mOutputs.push_back(*(stageWrapper->getNativeTensor()));
+        mBackend->addNodeToGraph(mOpConfigVersion, name.c_str(), mPackageName.c_str(), mNodeType.c_str(), mParams, mInputs, mOutputs);
+    }
+
+    this->addNodeCommonReshape("Reshape", *(stageWrapper->getNativeTensor()), *(mBackend->getNativeTensor(output)));
+
+    return NO_ERROR;
+}
+
+
+class QNNIm2ColCreator : public QnnBackend::Creator {
+public:
+    virtual QNNCommonExecution * onCreate(const std::vector<Tensor*>& inputs, const std::vector<Tensor*>& outputs, const MNN::Op* op,
+                                Backend* backend) const override {
+        return new QNNIm2Col(backend, op);
+    }
+};
+
+REGISTER_QNN_OP_CREATOR(QNNIm2ColCreator, OpType_Im2Col)
+#endif
+} // end namespace QNN
+} // end namespace MNN

--- a/source/backend/qnn/execution/QNNIm2Col.hpp
+++ b/source/backend/qnn/execution/QNNIm2Col.hpp
@@ -1,0 +1,27 @@
+//
+//  QNNIm2Col.hpp
+//  MNN
+//
+//  Copyright © 2018, Alibaba Group Holding Limited
+//
+
+#ifndef MNN_QNNIM2COL_HPP
+#define MNN_QNNIM2COL_HPP
+
+#include "QNNCommonExecution.hpp"
+#include "QnnTypes.h"
+
+namespace MNN {
+namespace QNN {
+#ifdef ENABLE_QNN_ONLINE_FINALIZE
+
+class QNNIm2Col : public QNNCommonExecution {
+public:
+    QNNIm2Col(Backend *backend, const Op *op) : QNNCommonExecution(backend, op) {}
+    virtual ErrorCode onEncode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) override;
+};
+#endif
+} // end namespace QNN
+} // end namespace MNN
+
+#endif

--- a/source/backend/qnn/execution/QNNPermute.cpp
+++ b/source/backend/qnn/execution/QNNPermute.cpp
@@ -40,11 +40,44 @@ ErrorCode QNNPermute::onEncode(const std::vector<Tensor *> &inputs, const std::v
         }
     } else {
         auto permutation = inputs[1]->host<int32_t>();
-        for (int i = 0; i < dim; i++) {
-            mapRaw[i] = (uint32_t)permutation[i];
+        if (permutation) {
+            for (int i = 0; i < dim; i++) {
+                mapRaw[i] = (uint32_t)permutation[i];
+            }
+        } else {
+            for (int i = 0; i < dim; i++) {
+                mapRaw[i] = (uint32_t)i;
+            }
         }
     }
-    
+
+    // When tensor is NC4HW4, QNN sees NHWC layout via getNHWCShape.
+    // The permutation from MNN is in NCHW order and must be remapped.
+    // NCHW dim mapping to NHWC: 0->0, 1->dim-1, k(2..dim-1)->k-1
+    auto dataFormat = TensorUtils::getDescribe(input)->dimensionFormat;
+    if (dataFormat == MNN_DATA_FORMAT_NC4HW4 && dim > 2) {
+        // nchw2nhwc[i] = where NCHW dim i appears in NHWC
+        std::vector<int> nchw2nhwc(dim);
+        nchw2nhwc[0] = 0;
+        nchw2nhwc[1] = dim - 1;
+        for (int i = 2; i < dim; i++) {
+            nchw2nhwc[i] = i - 1;
+        }
+        // nhwc2nchw is the inverse
+        std::vector<int> nhwc2nchw(dim);
+        for (int i = 0; i < dim; i++) {
+            nhwc2nchw[nchw2nhwc[i]] = i;
+        }
+        // Convert: nhwcPerm[nhwcPos] = nchw2nhwc[nchwPerm[nhwc2nchw[nhwcPos]]]
+        std::vector<uint32_t> nhwcPerm(dim);
+        for (int i = 0; i < dim; i++) {
+            int ncPos = nhwc2nchw[i];
+            int ncDst = (int)mapRaw[ncPos];
+            nhwcPerm[i] = (uint32_t)nchw2nhwc[ncDst];
+        }
+        mapRaw = nhwcPerm;
+    }
+
     this->createParamTensor("perm", QNN_DATATYPE_UINT_32, {(uint32_t) dim}, mapRaw.data());
     this->addNodeCommon(inputs, outputs, 1, 1);
     return NO_ERROR;

--- a/source/backend/qnn/npu_convert.py
+++ b/source/backend/qnn/npu_convert.py
@@ -20,6 +20,8 @@ cache_dir = 'res'
 if 'cache' in post_treat:
     cache_dir = post_treat['cache']
 clean_tmp = True
+weight_sharing_enabled = os.environ.get("MNN_QNN_WEIGHT_SHARING", "0") == "1"
+print('weight_sharing_enabled:', weight_sharing_enabled)
 context_config = {
     "backend_extensions": {
         "shared_library_path": os.path.join(qnn_sdk, "lib","x86_64-linux-clang","libQnnHtpNetRunExtensions.so"),
@@ -53,7 +55,7 @@ htp_backend_extensions = {
         }
     ],
     "context": {
-        "weight_sharing_enabled": True
+        "weight_sharing_enabled": weight_sharing_enabled
     }
 }
 
@@ -94,6 +96,5 @@ for key in post_treat["merge"]:
     if clean_tmp:
         for workdir in workdirs:
             os.popen("rm -rf " + workdir).read()
-
 
 

--- a/tools/cpp/CMakeLists.txt
+++ b/tools/cpp/CMakeLists.txt
@@ -45,6 +45,9 @@ add_executable(testModel.out ${CMAKE_CURRENT_LIST_DIR}/testModel.cpp)
 list(APPEND MNN_CPP_TOOLS testModel.out)
 
 add_executable(compilefornpu ${CMAKE_CURRENT_LIST_DIR}/compilefornpu.cpp ${CMAKE_CURRENT_LIST_DIR}/../../3rd_party/flatbuffers/src/util.cpp)
+set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/../../3rd_party/flatbuffers/src/util.cpp
+    TARGET_DIRECTORY compilefornpu
+    PROPERTIES COMPILE_FLAGS "-fvisibility=default")
 list(APPEND MNN_CPP_TOOLS compilefornpu)
 
 

--- a/tools/cpp/compilefornpu.cpp
+++ b/tools/cpp/compilefornpu.cpp
@@ -1,6 +1,7 @@
 #include <set>
 #include <map>
 #include <queue>
+#include <cstdlib>
 #include <fstream>
 #include <sstream>
 #include "flatbuffers/flexbuffers.h"
@@ -66,6 +67,47 @@ struct SubModuleIO {
     std::vector<std::vector<int>> kvcache;
     int seqLen = 0;
 };
+
+static bool _isValidShapeVar(const MNN::Express::VARP& var) {
+    auto info = var->getInfo();
+    if (nullptr == info || info->dim.empty()) {
+        return false;
+    }
+    for (auto d : info->dim) {
+        if (d <= 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool _subModuleHasValidShapes(const SubModuleIO& io) {
+    for (const auto& v : io.inputs) {
+        if (!_isValidShapeVar(v)) {
+            return false;
+        }
+    }
+    for (const auto& v : io.outputs) {
+        if (!_isValidShapeVar(v)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static const char* _safeOpName(const Net* net, int opIndex) {
+    if (nullptr == net || nullptr == net->oplists()) {
+        return "unknown";
+    }
+    if (opIndex < 0 || opIndex >= net->oplists()->size()) {
+        return "unknown";
+    }
+    auto op = net->oplists()->GetAs<Op>(opIndex);
+    if (nullptr == op || nullptr == op->name()) {
+        return "unknown";
+    }
+    return op->name()->c_str();
+}
 static void _computeTensorMask(SubModuleInfo& m, const Net* net) {
     /**Compute All SubModule's inputs and outputs*/
     // 0: not use, 1: input, 2: output, 3: mid, 4: valid output
@@ -105,7 +147,7 @@ static bool isBreakOp(const Op* op) {
     if (op->type() == OpType_While && op->main_as_WhileParam() != nullptr) {
         isWhileControlflow = true;
     }
-    if (op->type() == OpType_If || isWhileControlflow || op->type() == OpType_Where || op->type() == OpType_Segment || op->type() == OpType_Unique || op->type() == OpType_NonMaxSuppressionV2) {
+    if (op->type() == OpType_If || isWhileControlflow || op->type() == OpType_Where || op->type() == OpType_Segment || op->type() == OpType_Unique || op->type() == OpType_NonMaxSuppressionV2 || op->type() == OpType_Im2Col) {
         return true;
     }
     if (!_npuSupportOp(op)) {
@@ -868,6 +910,11 @@ int main(int argc, const char* argv[]) {
         gNPUName = document["type"].GetString();
         if (gNPUName == "QNN") {
             MNN_PRINT("Convert for QNN, QualComn's NPU\n");
+#ifdef _WIN32
+            _putenv_s("MNN_QNN_USE_CONVERTOR_INTERFACE", "1");
+#else
+            setenv("MNN_QNN_USE_CONVERTOR_INTERFACE", "1", 1);
+#endif
             gNPUType = MNN_CONVERT_QNN;
             gNeedOffline = true;
             gOfflieSrc = "";
@@ -1074,10 +1121,34 @@ int main(int argc, const char* argv[]) {
         for (int i=0; i<subModulesInfo.size(); ++i) {
             auto& current = subModulesInfo[i];
             std::vector<MNN::Express::VARP> subInputs;
+            bool missingInput = false;
             for (auto index : current.inputs) {
-                subInputs.emplace_back(stackes[index]);
+                auto iter = stackes.find(index);
+                if (iter == stackes.end() || nullptr == iter->second.get()) {
+                    missingInput = true;
+                    break;
+                }
+                subInputs.emplace_back(iter->second);
+            }
+            if (missingInput) {
+                auto firstOpIndex = current.opList.empty() ? -1 : current.opList[0];
+                MNN_PRINT("Skip NPU submodule %d (%s): missing runtime input tensor.\n", i, _safeOpName(net, firstOpIndex));
+                subModulesInfo[i].isBreak = true;
+                continue;
             }
             moduleIO[i] = _getSubModuleIO(subInputs, current, bufferPair.first, bufferPair.second, srcMNN);
+            if (moduleIO[i].outputs.size() != current.outputs.size()) {
+                auto firstOpIndex = current.opList.empty() ? -1 : current.opList[0];
+                MNN_PRINT(
+                    "Skip NPU submodule %d (%s): output count mismatch runtime=%zu expect=%zu.\n",
+                    i,
+                    _safeOpName(net, firstOpIndex),
+                    moduleIO[i].outputs.size(),
+                    current.outputs.size()
+                );
+                subModulesInfo[i].isBreak = true;
+                continue;
+            }
             for (int j=0; j<current.outputs.size(); ++j) {
                 stackes.insert(std::make_pair(current.outputs[j], moduleIO[i].outputs[j]));
             }
@@ -1095,6 +1166,12 @@ int main(int argc, const char* argv[]) {
                 }
             }
             if (!hasConvolution) {
+                subModulesInfo[i].isBreak = true;
+                continue;
+            }
+            if (!_subModuleHasValidShapes(moduleIO[i])) {
+                auto firstOpIndex = subModulesInfo[i].opList.empty() ? -1 : subModulesInfo[i].opList[0];
+                MNN_PRINT("Skip NPU submodule %d (%s): unresolved runtime shape detected.\n", i, _safeOpName(net, firstOpIndex));
                 subModulesInfo[i].isBreak = true;
             }
         }

--- a/transformers/llm/engine/src/omni.cpp
+++ b/transformers/llm/engine/src/omni.cpp
@@ -1238,7 +1238,68 @@ VARP Omni::gen_position_ids(int seq_len) {
 
 std::vector<Express::VARP> Omni::forwardRaw(Express::VARP hiddenState, Express::VARP mask, Express::VARP inputPos, Express::VARPS extraArgs) {
     MNN::Express::ExecutorScope s(mExecutor);
-    extraArgs.insert(extraArgs.end(), mExtraArgs.begin(), mExtraArgs.end());
+    // Qwen3-VL deepstack profile contract:
+    // - prefill (seq > 1): deepstack uses (seq, hidden)
+    // - decode  (seq = 1): deepstack keeps scalar placeholder (1, 1)
+    // Keep this aligned with exported QNN profiles to avoid shape-profile miss.
+    if (mConfig->has_deepstack() && !mExtraArgs.empty()) {
+        auto deepstack = mExtraArgs[0];
+        auto deepInfo = deepstack.get() ? deepstack->getInfo() : nullptr;
+        auto hiddenInfo = hiddenState.get() ? hiddenState->getInfo() : nullptr;
+        int targetSeq = 0;
+        int targetHidden = 0;
+        if (hiddenInfo && !hiddenInfo->dim.empty()) {
+            const auto& hdim = hiddenInfo->dim;
+            targetHidden = hdim.back();
+            // Hidden state layout may vary across backends/model variants.
+            // Infer seq len from all dims except the last hidden-size dim.
+            for (int i = 0; i + 1 < hdim.size(); ++i) {
+                targetSeq = std::max(targetSeq, hdim[i]);
+            }
+            if (targetSeq == 0) {
+                targetSeq = 1;
+            }
+        }
+        if (deepInfo && deepInfo->dim.size() >= 3 && targetSeq > 0 && targetHidden > 0) {
+            int desiredSeq = (targetSeq > 1) ? targetSeq : 1;
+            int desiredHidden = (targetSeq > 1) ? targetHidden : 1;
+            if (deepInfo->dim[1] != desiredSeq || deepInfo->dim[2] != desiredHidden) {
+                auto oldDims = deepInfo->dim;
+                auto newDims = oldDims;
+                newDims[1] = desiredSeq;
+                newDims[2] = desiredHidden;
+                auto padded = _Input(newDims, deepInfo->order, deepInfo->type);
+                ::memset(padded->writeMap<void>(), 0, padded->getInfo()->size * deepInfo->type.bytes());
+
+                int batch = oldDims[0];
+                int oldSeq = oldDims[1];
+                int newSeq = newDims[1];
+                int oldHidden = oldDims[2];
+                int newHidden = newDims[2];
+                int copySeq = oldSeq < newSeq ? oldSeq : newSeq;
+                int copyHidden = oldHidden < newHidden ? oldHidden : newHidden;
+                auto src = deepstack->readMap<float>();
+                auto dst = padded->writeMap<float>();
+                for (int b = 0; b < batch; ++b) {
+                    for (int sIdx = 0; sIdx < copySeq; ++sIdx) {
+                        auto srcOffset = (b * oldSeq + sIdx) * oldHidden;
+                        auto dstOffset = (b * newSeq + sIdx) * newHidden;
+                        ::memcpy(dst + dstOffset, src + srcOffset, copyHidden * sizeof(float));
+                    }
+                }
+                extraArgs.push_back(padded);
+            } else {
+                extraArgs.push_back(deepstack);
+            }
+        } else {
+            extraArgs.push_back(deepstack);
+        }
+        for (size_t i = 1; i < mExtraArgs.size(); ++i) {
+            extraArgs.push_back(mExtraArgs[i]);
+        }
+    } else {
+        extraArgs.insert(extraArgs.end(), mExtraArgs.begin(), mExtraArgs.end());
+    }
     auto outputs = Llm::forwardRaw(hiddenState, mask, inputPos, extraArgs);
     if (mTalker && outputs.size() > 1) {
         mTalker->addTalkerEmbeds(outputs[1]);

--- a/transformers/llm/engine/tools/CMakeLists.txt
+++ b/transformers/llm/engine/tools/CMakeLists.txt
@@ -10,3 +10,6 @@ target_include_directories(generateLlmIO PRIVATE ${CMAKE_CURRENT_LIST_DIR}/../sr
 target_include_directories(quantize_llm PRIVATE ${CMAKE_CURRENT_LIST_DIR}/../src)
 target_link_libraries(ppl_eval ${LLM_DEPS})
 target_include_directories(ppl_eval PRIVATE ${CMAKE_CURRENT_LIST_DIR}/../src)
+add_executable(generateVisualIO ${CMAKE_CURRENT_LIST_DIR}/generateVisualIO.cpp)
+target_link_libraries(generateVisualIO ${LLM_DEPS})
+target_include_directories(generateVisualIO PRIVATE ${CMAKE_CURRENT_LIST_DIR}/../src)

--- a/transformers/llm/engine/tools/generateLlmIO.cpp
+++ b/transformers/llm/engine/tools/generateLlmIO.cpp
@@ -37,7 +37,7 @@ static void saveInputOutputs(const MNN::Express::Module::Info* info, std::vector
     MNN_PRINT("Successfully generate %s and %s.\n", inputPath.c_str(), outputPath.c_str());
 }
 
-static void createInputsForLLM(int seqLen, int hiddenSize, const std::string& attentionMaskType, bool lastLogit, std::vector<MNN::Express::VARP>& inputs) {
+static void createInputsForLLM(int seqLen, int hiddenSize, const std::string& attentionMaskType, bool lastLogit, bool hasDeepstack, bool isMrope, std::vector<MNN::Express::VARP>& inputs) {
     if (attentionMaskType != "float") {
         MNN_ERROR("Don't support Attention Mask Type other than 'float', currently.\n");
         return;
@@ -59,16 +59,29 @@ static void createInputsForLLM(int seqLen, int hiddenSize, const std::string& at
     }
     inputs.push_back(attentionMask);
 
-    MNN::Express::VARP positionIds = MNN::Express::_Input({1, seqLen}, MNN::Express::NCHW, halide_type_of<int>());
+    int posDim = isMrope ? 3 : 1;
+    MNN::Express::VARP positionIds = MNN::Express::_Input({posDim, seqLen}, MNN::Express::NCHW, halide_type_of<int>());
     int * positionIdsData = positionIds->writeMap<int>();
-    for (int i = 0; i < seqLen; i++) {
-        positionIdsData[i] = i;
+    for (int d = 0; d < posDim; d++) {
+        for (int i = 0; i < seqLen; i++) {
+            positionIdsData[d * seqLen + i] = i;
+        }
     }
     inputs.push_back(positionIds);
 
     int logitsIndexValue = lastLogit ? -1 : 0;
     MNN::Express::VARP logitsIndex = MNN::Express::_Const((const void *) &logitsIndexValue, {1}, MNN::Express::NHWC, halide_type_of<int>());
     inputs.push_back(logitsIndex);
+
+    if (hasDeepstack) {
+        // Qwen3-VL prefill path expects deepstack with hidden size, while decode
+        // keeps a scalar placeholder to align runtime single-token behavior.
+        int deepstackSeq = lastLogit ? 1 : seqLen;
+        int deepstackHidden = lastLogit ? 1 : hiddenSize;
+        MNN::Express::VARP deepstackEmbeds = MNN::Express::_Input({3, deepstackSeq, deepstackHidden}, MNN::Express::NCHW, halide_type_of<float>());
+        ::memset(deepstackEmbeds->writeMap<float>(), 0, 3 * deepstackSeq * deepstackHidden * sizeof(float));
+        inputs.push_back(deepstackEmbeds);
+    }
 
     return;
 }
@@ -125,6 +138,8 @@ static bool generateForModel(const std::string& modelPath, const std::string& ou
 
     int hiddenSize;
     std::string attentionMaskType;
+    bool hasDeepstack = false;
+    bool isMrope = false;
     {
         std::ifstream ifs(jsonPath);
         if (!ifs.is_open()) {
@@ -153,6 +168,13 @@ static bool generateForModel(const std::string& modelPath, const std::string& ou
         attentionMaskType = doc["attention_mask"].GetString();
 
         isEmbedding = isEmbeddingModel(doc);
+
+        if (doc.HasMember("has_deepstack") && doc["has_deepstack"].IsBool()) {
+            hasDeepstack = doc["has_deepstack"].GetBool();
+        }
+        if (doc.HasMember("is_mrope") && doc["is_mrope"].IsBool()) {
+            isMrope = doc["is_mrope"].GetBool();
+        }
     }
 
     MNN::ScheduleConfig config;
@@ -165,6 +187,9 @@ static bool generateForModel(const std::string& modelPath, const std::string& ou
     } else {
         inputNames = {"input_ids", "attention_mask", "position_ids", "logits_index"};
         outputNames = {"logits"};
+        if (hasDeepstack) {
+            inputNames.push_back("deepstack_embeds");
+        }
     }
     net.reset(MNN::Express::Module::load(inputNames, outputNames, modelPath.c_str(), rtmgr), MNN::Express::Module::destroy);
     if (nullptr == net.get()) {
@@ -178,7 +203,7 @@ static bool generateForModel(const std::string& modelPath, const std::string& ou
         if (isEmbedding) {
             createInputsForEmbedding(blockSize, hiddenSize, attentionMaskType, inputs);
         } else {
-            createInputsForLLM(blockSize, hiddenSize, attentionMaskType, false, inputs);
+            createInputsForLLM(blockSize, hiddenSize, attentionMaskType, false, hasDeepstack, isMrope, inputs);
         }
         outputs = net->onForward(inputs);
         if (outputs.empty()) {
@@ -191,7 +216,7 @@ static bool generateForModel(const std::string& modelPath, const std::string& ou
     if (!isEmbedding) {
         std::vector<MNN::Express::VARP> inputs;
         std::vector<MNN::Express::VARP> outputs;
-        createInputsForLLM(1, hiddenSize, attentionMaskType, true, inputs);
+        createInputsForLLM(1, hiddenSize, attentionMaskType, true, hasDeepstack, isMrope, inputs);
         outputs = net->onForward(inputs);
         if (outputs.empty()) {
             MNN_ERROR("Failed to run decode forward for QNN IO generation.\n");

--- a/transformers/llm/engine/tools/generateVisualIO.cpp
+++ b/transformers/llm/engine/tools/generateVisualIO.cpp
@@ -1,0 +1,247 @@
+#include <fstream>
+#include <string>
+#include <vector>
+#include <memory>
+#include <cstdlib>
+#include <ctime>
+#include <cmath>
+#include <algorithm>
+#include <sstream>
+
+#include <MNN/expr/Module.hpp>
+#include <MNN/expr/ExprCreator.hpp>
+#include <MNN/expr/Executor.hpp>
+#include "core/MNNFileUtils.h"
+
+#include "rapidjson/document.h"
+#include "rapidjson/istreamwrapper.h"
+
+#include <limits>
+
+using namespace MNN::Express;
+
+static void saveInputOutputs(const Module::Info* info,
+                             std::vector<VARP> inputs,
+                             std::vector<VARP> outputs,
+                             const std::string& outputDir,
+                             const std::string& tag) {
+    for (int i = 0; i < (int)info->inputNames.size() && i < (int)inputs.size(); ++i) {
+        inputs[i].fix(VARP::CONSTANT);
+        inputs[i]->setName(info->inputNames[i]);
+    }
+    for (int i = 0; i < (int)info->outputNames.size() && i < (int)outputs.size(); ++i) {
+        outputs[i]->setName(info->outputNames[i]);
+    }
+    auto subDir = MNNFilePathConcat(outputDir, tag);
+    MNNCreateDir(subDir.c_str());
+
+    std::string inputPath = MNNFilePathConcat(subDir, "input.mnn");
+    std::string outputPath = MNNFilePathConcat(subDir, "output.mnn");
+    Variable::save(inputs, inputPath.c_str());
+    Variable::save(outputs, outputPath.c_str());
+    MNN_PRINT("Successfully generate %s and %s.\n", inputPath.c_str(), outputPath.c_str());
+}
+
+struct VisualSize {
+    int width;
+    int height;
+};
+
+static std::vector<VisualSize> parseVisualSizes(const std::string& sizesStr) {
+    std::vector<VisualSize> sizes;
+    if (sizesStr.empty()) {
+        return sizes;
+    }
+    std::stringstream ss(sizesStr);
+    std::string item;
+    while (std::getline(ss, item, ',')) {
+        auto xpos = item.find('x');
+        if (xpos == std::string::npos) continue;
+        int w = std::atoi(item.substr(0, xpos).c_str());
+        int h = std::atoi(item.substr(xpos + 1).c_str());
+        if (w > 0 && h > 0) {
+            sizes.push_back({w, h});
+        }
+    }
+    return sizes;
+}
+
+static bool generateVisualIO(const std::string& modelDir,
+                              const std::string& outputDir,
+                              int imgWidth, int imgHeight,
+                              int numGridPerSide) {
+    std::string modelPath = MNNFilePathConcat(modelDir, "visual.mnn");
+    std::string weightPath = modelPath + ".weight";
+
+    MNN::ScheduleConfig config;
+    std::shared_ptr<Executor::RuntimeManager> rtmgr(
+        Executor::RuntimeManager::createRuntimeManager(config));
+    rtmgr->setExternalFile(weightPath.c_str());
+
+    Module::Config module_config;
+    module_config.shapeMutable = true;
+    module_config.rearrange = true;
+    std::shared_ptr<Module> net(
+        Module::load({}, {}, modelPath.c_str(), rtmgr, &module_config),
+        Module::destroy);
+    if (nullptr == net.get()) {
+        MNN_ERROR("Failed to load visual module from %s.\n", modelPath.c_str());
+        return false;
+    }
+
+    const auto& inputNames = net->getInfo()->inputNames;
+    bool isQwen3VL = inputNames.size() == 5 &&
+                     inputNames[3] == "idx_tensor";
+    const int patch_size = isQwen3VL ? 16 : 14;
+    constexpr int temporal_patch_size = 2;
+    constexpr int merge_size = 2;
+    const int align_size = patch_size * merge_size;
+
+    int alignedH = (int)(round(imgHeight / (float)align_size)) * align_size;
+    int alignedW = (int)(round(imgWidth / (float)align_size)) * align_size;
+    if (alignedH < align_size) alignedH = align_size;
+    if (alignedW < align_size) alignedW = align_size;
+
+    int temporal = 2;
+    int channel = 3;
+    int grid_t = temporal / temporal_patch_size;
+    int grid_h = alignedH / patch_size;
+    int grid_w = alignedW / patch_size;
+    int seq_len = grid_t * grid_h * grid_w;
+    int patch_dim = channel * temporal_patch_size * patch_size * patch_size;
+
+    MNN_PRINT("Visual IO: imgSize=%dx%d aligned=%dx%d grid=%dx%d seq_len=%d isQwen3VL=%d\n",
+              imgWidth, imgHeight, alignedW, alignedH, grid_w, grid_h, seq_len, isQwen3VL);
+
+    VARP patches = _Input({seq_len, patch_dim}, NCHW, halide_type_of<float>());
+    auto patchData = patches->writeMap<float>();
+    for (int i = 0; i < seq_len * patch_dim; ++i) {
+        patchData[i] = (float)(rand()) / RAND_MAX;
+    }
+
+    VARP position_ids = _Input({2, seq_len}, NCHW, halide_type_of<int>());
+    auto hpos_ptr = position_ids->writeMap<int>();
+    auto wpos_ptr = hpos_ptr + seq_len;
+    const int wblock_size = merge_size * merge_size;
+    const int hblock_size = wblock_size * grid_w / merge_size;
+    for (int i = 0; i < grid_h; i++) {
+        int h_idx = i / merge_size, h_off = i % merge_size;
+        for (int j = 0; j < grid_w; j++) {
+            int w_idx = j / merge_size, w_off = j % merge_size;
+            int index = h_idx * hblock_size + w_idx * wblock_size + h_off * 2 + w_off;
+            if (index < seq_len) {
+                hpos_ptr[index] = i;
+                wpos_ptr[index] = j;
+            }
+        }
+    }
+
+    VARP attention_mask = _Input({1, seq_len, seq_len}, NCHW, halide_type_of<float>());
+    ::memset(attention_mask->writeMap<float>(), 0, seq_len * seq_len * sizeof(float));
+
+    VARPS moduleInputs = {patches, position_ids, attention_mask};
+
+    if (isQwen3VL) {
+        int num_patches = grid_h * grid_w;
+        std::vector<float> h_idxs(grid_h), w_idxs(grid_w);
+        for (int i = 0; i < grid_h; ++i) {
+            h_idxs[i] = (grid_h > 1) ?
+                static_cast<float>(i) * (numGridPerSide - 1) / (grid_h - 1) : 0.0f;
+        }
+        for (int i = 0; i < grid_w; ++i) {
+            w_idxs[i] = (grid_w > 1) ?
+                static_cast<float>(i) * (numGridPerSide - 1) / (grid_w - 1) : 0.0f;
+        }
+        auto idx_tensor = _Input({4, num_patches}, NCHW, halide_type_of<int>());
+        auto weight_tensor = _Input({4, num_patches}, NCHW, halide_type_of<float>());
+        auto idx_ptr = idx_tensor->writeMap<int>();
+        auto weight_ptr = weight_tensor->writeMap<float>();
+        for (int i = 0; i < grid_h; ++i) {
+            int h_floor = static_cast<int>(h_idxs[i]);
+            int h_ceil = std::min(h_floor + 1, numGridPerSide - 1);
+            float dh = h_idxs[i] - h_floor;
+            for (int j = 0; j < grid_w; ++j) {
+                int w_floor = static_cast<int>(w_idxs[j]);
+                int w_ceil = std::min(w_floor + 1, numGridPerSide - 1);
+                float dw = w_idxs[j] - w_floor;
+                int idx = i * grid_w + j;
+                idx_ptr[0 * num_patches + idx] = h_floor * numGridPerSide + w_floor;
+                idx_ptr[1 * num_patches + idx] = h_floor * numGridPerSide + w_ceil;
+                idx_ptr[2 * num_patches + idx] = h_ceil * numGridPerSide + w_floor;
+                idx_ptr[3 * num_patches + idx] = h_ceil * numGridPerSide + w_floor;
+                weight_ptr[0 * num_patches + idx] = (1.0f - dh) * (1.0f - dw);
+                weight_ptr[1 * num_patches + idx] = (1.0f - dh) * dw;
+                weight_ptr[2 * num_patches + idx] = dh * (1.0f - dw);
+                weight_ptr[3 * num_patches + idx] = dh * dw;
+            }
+        }
+        idx_tensor = _Reshape(idx_tensor, {4, grid_t, grid_h / merge_size, merge_size, grid_w / merge_size, merge_size});
+        idx_tensor = _Permute(idx_tensor, {0, 1, 2, 4, 3, 5});
+        idx_tensor = _Reshape(idx_tensor, {4, -1});
+        weight_tensor = _Reshape(weight_tensor, {4, grid_t, grid_h / merge_size, merge_size, grid_w / merge_size, merge_size});
+        weight_tensor = _Permute(weight_tensor, {0, 1, 2, 4, 3, 5});
+        weight_tensor = _Reshape(weight_tensor, {4, -1});
+        moduleInputs.push_back(idx_tensor);
+        moduleInputs.push_back(weight_tensor);
+    }
+
+    auto outputs = net->onForward(moduleInputs);
+    if (outputs.empty()) {
+        MNN_ERROR("Failed to run visual forward for size %dx%d.\n", imgWidth, imgHeight);
+        return false;
+    }
+
+    std::string tag = std::to_string(imgWidth) + "x" + std::to_string(imgHeight);
+    saveInputOutputs(net->getInfo(), moduleInputs, outputs, outputDir, tag);
+    return true;
+}
+
+int main(int argc, char* argv[]) {
+    if (argc < 3) {
+        MNN_PRINT("Usage: ./generateVisualIO modelDir outputDir [sizes]\n");
+        MNN_PRINT("  sizes: comma separated WxH pairs, e.g. 416x416,384x416\n");
+        MNN_PRINT("  default size: 420x420\n");
+        return 1;
+    }
+
+    srand(time(NULL));
+    std::string modelDir = argv[1];
+    std::string outputDir = argv[2];
+    MNNCreateDir(outputDir.c_str());
+
+    std::string llmConfigPath = MNNFilePathConcat(modelDir, "llm_config.json");
+    int numGridPerSide = 48;
+    {
+        std::ifstream ifs(llmConfigPath);
+        if (ifs.is_open()) {
+            rapidjson::IStreamWrapper isw(ifs);
+            rapidjson::Document doc;
+            doc.ParseStream(isw);
+            if (!doc.HasParseError() && doc.IsObject()) {
+                if (doc.HasMember("num_grid_per_side") && doc["num_grid_per_side"].IsInt()) {
+                    numGridPerSide = doc["num_grid_per_side"].GetInt();
+                }
+            }
+        }
+    }
+    MNN_PRINT("num_grid_per_side = %d\n", numGridPerSide);
+
+    std::vector<VisualSize> sizes;
+    if (argc >= 4) {
+        sizes = parseVisualSizes(argv[3]);
+    }
+    if (sizes.empty()) {
+        sizes.push_back({420, 420});
+    }
+
+    for (auto& sz : sizes) {
+        MNN_PRINT("Generating visual IO for size %dx%d ...\n", sz.width, sz.height);
+        if (!generateVisualIO(modelDir, outputDir, sz.width, sz.height, numGridPerSide)) {
+            MNN_ERROR("Failed for size %dx%d\n", sz.width, sz.height);
+            return 1;
+        }
+    }
+
+    MNN_PRINT("All visual IO generated successfully.\n");
+    return 0;
+}

--- a/transformers/llm/export/npu/generate_llm_qnn.py
+++ b/transformers/llm/export/npu/generate_llm_qnn.py
@@ -1,132 +1,348 @@
 #!/usr/bin/python
 
-import sys
-import os
 import argparse
-import subprocess
 import json
+import os
 import shutil
-
-def makeIO(args):
-    exe = os.path.join(os.getcwd(), args.mnn_path, "generateLlmIO")
-    output = os.path.join(args.cache_path, 'testdir')
-    process = subprocess.Popen(exe + " " + args.model + " " + output + ' %d' %args.chunk_size, bufsize=1, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, shell=True)
-    for line in process.stdout:
-        print(line, end='')
-    process.wait()
-    return process.returncode
-
-def seperate(args):
-    exe = os.path.join(os.getcwd(), args.mnn_path, "compilefornpu")
-    model = os.path.join(os.getcwd(), args.model, 'llm.mnn')
-    print("model:", model)
-    config = {
-        "type":"QNN",
-        "skips":[
-        ],
-        "testdir":[
-        ],
-        "KVCACHE_SIZE_LIMIT":args.max_history_token,
-        "cache":"qnn"
-    }
-    config['testdir'].append(os.path.join("testdir", '1'))
-    config['testdir'].append(os.path.join("testdir", '%d' %args.chunk_size))
-    cache = os.path.join(os.getcwd(), args.cache_path)
-    with open(os.path.join(cache, 'qnn.json'), 'w') as f:
-        f.write(json.dumps(config, indent=4))
-
-    process = subprocess.Popen(exe + ' ' + model + ' qnn/llm.mnn qnn.json', bufsize=1, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd = cache, text=True, shell=True)
-    for line in process.stdout:
-        print(line, end='')
-
-    process.wait()
-    return process.returncode
-
-def compile_qnn(args):
-    exe = os.path.join(os.getcwd(), args.mnn_path, "..", "source", "backend", "qnn", "npu_convert.py")
-    cache = os.path.join(os.getcwd(), args.cache_path)
-    process = subprocess.Popen("python3 " + exe + ' npu_postreat.json %d ' %args.soc_id + ' ' + args.dsp_arch, bufsize=1, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd = cache, text=True, shell=True)
-    for line in process.stdout:
-        print(line, end='')
-    process.wait()
-    return process.returncode
-
-def output_qnn(args):
-    if os.path.exists(os.path.join(args.model, 'qnn')):
-        shutil.rmtree(os.path.join(args.model, 'qnn'))
-    shutil.move(os.path.join(args.cache_path, 'qnn'), os.path.join(args.model, 'qnn'))
-    config_npu = {
-        "llm_model": "qnn/llm.mnn",
-        "backend_type": "cpu",
-        "thread_num": 1,
-        "precision": "low",
-        "chunk_limits":[args.chunk_size, 1],
-        "memory": "low",
-        "sampler_type": "penalty",
-        "penalty": 1.1
-    }
-    with open(os.path.join(args.model, "config_qnn.json"), 'w') as f:
-        f.write(json.dumps(config_npu, indent = 4))
-    shutil.rmtree(args.cache_path)
-
+import subprocess
 import time
 
+
+def tool_path(args, name):
+    return os.path.normpath(os.path.join(os.getcwd(), args.mnn_path, name))
+
+
+def qnn_convert_script(args):
+    return os.path.normpath(os.path.join(os.getcwd(), args.mnn_path, "..", "source", "backend", "qnn", "npu_convert.py"))
+
+
+def run_and_stream(cmd, cwd=None, env=None):
+    process = subprocess.Popen(
+        cmd,
+        cwd=cwd,
+        env=env,
+        bufsize=1,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    for line in process.stdout:
+        print(line, end="")
+    process.wait()
+    return process.returncode
+
+
+def make_llm_io(args, cache_dir):
+    output = os.path.join(cache_dir, "testdir")
+    if os.path.isdir(output):
+        shutil.rmtree(output)
+    cmd = [tool_path(args, "generateLlmIO"), args.model, output, str(args.chunk_size)]
+    code = run_and_stream(cmd)
+    return code, list_llm_testdirs(output)
+
+
+def separate_llm(args, cache_dir, testdirs):
+    model = os.path.join(os.getcwd(), args.model, "llm.mnn")
+    print("model:", model)
+    if not testdirs:
+        testdirs = [str(args.chunk_size), "1"]
+    config = {
+        "type": "QNN",
+        "skips": [],
+        "testdir": [os.path.join("testdir", name) for name in testdirs],
+        "KVCACHE_SIZE_LIMIT": args.max_history_token,
+        "cache": "qnn",
+    }
+    with open(os.path.join(cache_dir, "qnn.json"), "w", encoding="utf-8") as f:
+        f.write(json.dumps(config, indent=4))
+    cmd = [tool_path(args, "compilefornpu"), model, "qnn/llm.mnn", "qnn.json"]
+    return run_and_stream(cmd, cwd=cache_dir)
+
+
+def list_visual_testdirs(testdir_root):
+    subdirs = []
+    if not os.path.isdir(testdir_root):
+        return subdirs
+    for name in sorted(os.listdir(testdir_root)):
+        path = os.path.join(testdir_root, name)
+        if os.path.isdir(path):
+            subdirs.append(name)
+    return subdirs
+
+
+def list_llm_testdirs(testdir_root):
+    subdirs = []
+    if not os.path.isdir(testdir_root):
+        return subdirs
+    for name in sorted(os.listdir(testdir_root), key=lambda x: int(x) if x.isdigit() else x):
+        path = os.path.join(testdir_root, name)
+        if os.path.isdir(path) and name.isdigit():
+            subdirs.append(name)
+    return subdirs
+
+
+def reorder_llm_testdirs(testdirs, chunk_size):
+    if not testdirs:
+        return testdirs
+    ordered = []
+    chunk_name = str(chunk_size)
+    if chunk_name in testdirs:
+        ordered.append(chunk_name)
+    if "1" in testdirs and "1" not in ordered:
+        ordered.append("1")
+    for name in testdirs:
+        if name not in ordered:
+            ordered.append(name)
+    return ordered
+
+
+def make_visual_io(args, cache_dir):
+    output = os.path.join(cache_dir, "testdir")
+    if os.path.isdir(output):
+        shutil.rmtree(output)
+    cmd = [tool_path(args, "generateVisualIO"), args.model, output]
+    if args.visual_sizes:
+        cmd.append(args.visual_sizes)
+    code = run_and_stream(cmd)
+    return code, list_visual_testdirs(output)
+
+
+def separate_visual(args, cache_dir, testdirs):
+    model = os.path.join(os.getcwd(), args.model, "visual.mnn")
+    print("visual model:", model)
+    config = {
+        "type": "QNN",
+        "skips": [],
+        "testdir": [os.path.join("testdir", name) for name in testdirs],
+        "cache": "qnn",
+        "graph_name": "visual_graph",
+    }
+    with open(os.path.join(cache_dir, "qnn.json"), "w", encoding="utf-8") as f:
+        f.write(json.dumps(config, indent=4))
+    cmd = [tool_path(args, "compilefornpu"), model, "qnn/visual.mnn", "qnn.json"]
+    return run_and_stream(cmd, cwd=cache_dir)
+
+
+def has_npu_subgraphs(cache_dir):
+    postreat = os.path.join(cache_dir, "npu_postreat.json")
+    if not os.path.exists(postreat):
+        return False
+    with open(postreat, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    merges = data.get("merge", {})
+    for key, srcs in merges.items():
+        for src in srcs:
+            src_dir = os.path.join(cache_dir, src)
+            if os.path.isdir(src_dir) and any(f.endswith(".cpp") for f in os.listdir(src_dir)):
+                return True
+    return False
+
+
+def compile_qnn(args, cache_dir):
+    qnn_root = os.environ.get("QNN_SDK_ROOT", "")
+    child_env = os.environ.copy()
+    if qnn_root:
+        qnn_lib = os.path.join(qnn_root, "lib", "x86_64-linux-clang")
+        child_env["LD_LIBRARY_PATH"] = qnn_lib
+    cmd = ["python3", qnn_convert_script(args), "npu_postreat.json", str(args.soc_id), args.dsp_arch]
+    return run_and_stream(cmd, cwd=cache_dir, env=child_env)
+
+
+def merge_dir(src_dir, dst_dir):
+    if not os.path.isdir(src_dir):
+        return
+    os.makedirs(dst_dir, exist_ok=True)
+    for name in os.listdir(src_dir):
+        src = os.path.join(src_dir, name)
+        dst = os.path.join(dst_dir, name)
+        if os.path.isdir(src):
+            merge_dir(src, dst)
+            continue
+        if os.path.exists(dst):
+            os.remove(dst)
+        shutil.move(src, dst)
+
+
+def visual_qnn_complete(visual_cache_dir):
+    qnn_dir = os.path.join(visual_cache_dir, "qnn")
+    if not os.path.isdir(qnn_dir):
+        return False
+    visual_mnn = os.path.join(qnn_dir, "visual.mnn")
+    if not os.path.isfile(visual_mnn):
+        return False
+
+    postreat = os.path.join(visual_cache_dir, "npu_postreat.json")
+    if not os.path.isfile(postreat):
+        return False
+
+    try:
+        with open(postreat, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        return False
+
+    merges = data.get("merge", {})
+    if not merges:
+        return False
+    for dst in merges.keys():
+        dst_name = os.path.basename(dst)
+        if not os.path.isfile(os.path.join(qnn_dir, dst_name)):
+            return False
+    return True
+
+
+def output_qnn(args, has_visual):
+    cache_root = os.path.join(os.getcwd(), args.cache_path)
+    final_qnn_dir = os.path.join(args.model, "qnn")
+    if os.path.exists(final_qnn_dir):
+        shutil.rmtree(final_qnn_dir)
+    os.makedirs(final_qnn_dir, exist_ok=True)
+    merge_dir(os.path.join(cache_root, "llm", "qnn"), final_qnn_dir)
+
+    visual_qnn_converted = False
+    if has_visual:
+        visual_cache_dir = os.path.join(cache_root, "visual")
+        visual_qnn_dir = os.path.join(cache_root, "visual", "qnn")
+        if visual_qnn_complete(visual_cache_dir):
+            merge_dir(visual_qnn_dir, final_qnn_dir)
+            visual_qnn_converted = True
+            visual_weight = os.path.join(args.model, "visual.mnn.weight")
+            if os.path.isfile(visual_weight):
+                shutil.copy2(visual_weight, os.path.join(final_qnn_dir, "visual.mnn.weight"))
+        else:
+            print("Warning: visual qnn artifacts are incomplete, fallback to CPU visual model")
+
+    config_path = os.path.join(args.model, "config.json")
+    config_npu = {}
+    if os.path.exists(config_path):
+        with open(config_path, "r", encoding="utf-8") as f:
+            config_npu = json.load(f)
+    config_npu.update(
+        {
+            "llm_model": "qnn/llm.mnn",
+            "llm_weight": "llm.mnn.weight",
+            "backend_type": "cpu",
+            "thread_num": 1,
+            "precision": "low",
+            "chunk_limits": [args.chunk_size, 1],
+            "memory": "low",
+            "sampler_type": "penalty",
+            "penalty": 1.1,
+            "npu_model_dir": ".",
+        }
+    )
+    if has_visual:
+        if visual_qnn_converted:
+            config_npu["visual_model"] = "qnn/visual.mnn"
+        else:
+            config_npu["visual_model"] = "visual.mnn"
+    with open(os.path.join(args.model, "config_qnn.json"), "w", encoding="utf-8") as f:
+        f.write(json.dumps(config_npu, indent=4, ensure_ascii=False))
+    shutil.rmtree(cache_root)
+
+
+def run_step(title, fn):
+    print(title)
+    start = time.time()
+    result = fn()
+    end = time.time()
+    print("Cost: ", end - start, " s")
+    return result
+
+
 def convert(args):
-    cache = os.path.join(os.getcwd(), args.cache_path)
-    os.makedirs(cache, exist_ok=True)
-    sta = time.time()
-    print("Step1: Make IO")
-    code = makeIO(args)
-    end = time.time()
-    print("Cost: ", end - sta, ' s')
-    if code != 0:
-        raise RuntimeError(f"Step1 failed with exit code {code}")
-    sta = end
-    print("Step2: Seperate Model")
-    code = seperate(args)
-    end = time.time()
-    print("Cost: ", end - sta, ' s')
+    cache_root = os.path.join(os.getcwd(), args.cache_path)
+    llm_cache = os.path.join(cache_root, "llm")
+    visual_cache = os.path.join(cache_root, "visual")
+    os.makedirs(llm_cache, exist_ok=True)
+    has_visual = os.path.exists(os.path.join(args.model, "visual.mnn"))
+
+    code_llm, llm_testdirs = run_step("Step1: Make LLM IO", lambda: make_llm_io(args, llm_cache))
+    if code_llm != 0:
+        raise RuntimeError(f"Step1 failed with exit code {code_llm}")
+    if not llm_testdirs:
+        raise RuntimeError("Step1 failed: no llm testdirs were generated")
+    llm_testdirs = reorder_llm_testdirs(llm_testdirs, args.chunk_size)
+
+    code = run_step("Step2: Seperate LLM Model", lambda: separate_llm(args, llm_cache, llm_testdirs))
     if code != 0:
         raise RuntimeError(f"Step2 failed with exit code {code}")
-    sta = end
-    print("Step3: Compile to QNN")
-    code = compile_qnn(args)
-    end = time.time()
-    print("Cost: ", end - sta, ' s')
+
+    code = run_step("Step3: Compile LLM to QNN", lambda: compile_qnn(args, llm_cache))
     if code != 0:
         raise RuntimeError(f"Step3 failed with exit code {code}")
-    print("Step4: Move result file to ", args.model)
-    output_qnn(args)
 
+    if has_visual:
+        os.makedirs(visual_cache, exist_ok=True)
+
+        code_vis, testdirs = run_step(
+            "Step4: Make Visual IO",
+            lambda: make_visual_io(args, visual_cache),
+        )
+        if code_vis != 0:
+            raise RuntimeError(f"Step4 failed with exit code {code_vis}")
+
+        code = run_step(
+            "Step5: Separate Visual Model",
+            lambda: separate_visual(args, visual_cache, testdirs),
+        )
+        if code != 0:
+            raise RuntimeError(f"Step5 failed with exit code {code}")
+
+        if has_npu_subgraphs(visual_cache):
+            code = run_step(
+                "Step6: Compile Visual to QNN",
+                lambda: compile_qnn(args, visual_cache),
+            )
+            if code != 0:
+                print("Warning: Visual QNN compilation failed, will fallback to CPU visual")
+        else:
+            print("No NPU subgraphs for visual model, will use CPU visual")
+
+    step_idx = 7 if has_visual else 4
+    print(f"Step{step_idx}: Move result file to ", args.model)
+    output_qnn(args, has_visual)
     print("End")
 
+
 def main():
-    parser = argparse.ArgumentParser(description='generate_llm_qnn', formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument('--model', type=str, required=True,
-                        help='model(`str` or `os.PathLike`):\nCan be either:')
-    parser.add_argument('--soc_id', type=int, required=True,
-                        help='type(`int`, *optional*):'
-                        '\n\tThe soc_id., for 8gen3 is 57'
-                        )
-    parser.add_argument('--dsp_arch', type=str, required=True,
-                        help='type(`str`, *optional*):'
-                        '\n\tThe dsp_arch, for 8gen3 is v75.'
-                        )
-    parser.add_argument('--mnn_path', type=str, default="../../../build/",
-                        help='mnn build path(`str` or `os.PathLike`):\nCan be either:'
+    parser = argparse.ArgumentParser(description="generate_llm_qnn", formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument("--model", type=str, required=True, help="model(`str` or `os.PathLike`):\nCan be either:")
+    parser.add_argument(
+        "--soc_id",
+        type=int,
+        required=True,
+        help="type(`int`, *optional*):" "\n\tThe soc_id., for 8gen3 is 57",
     )
-    parser.add_argument('--cache_path', type=str, default="tmp",
-                        help='cache path for work'
-                        )
-    parser.add_argument('--chunk_size', type=int, default=128,
-                        help='chunk_size for npu'
-                        )
-    parser.add_argument('--max_history_token', type=int, default=0,
-                        help='max history token, default is 0, which mean no limit for history token number'
-                        )
+    parser.add_argument(
+        "--dsp_arch",
+        type=str,
+        required=True,
+        help="type(`str`, *optional*):" "\n\tThe dsp_arch, for 8gen3 is v75.",
+    )
+    parser.add_argument(
+        "--mnn_path",
+        type=str,
+        default="../../../build/",
+        help="mnn build path(`str` or `os.PathLike`):\nCan be either:",
+    )
+    parser.add_argument("--cache_path", type=str, default="tmp", help="cache path for work")
+    parser.add_argument("--chunk_size", type=int, default=128, help="chunk_size for npu")
+    parser.add_argument(
+        "--max_history_token",
+        type=int,
+        default=0,
+        help="max history token, default is 0, which mean no limit for history token number",
+    )
+    parser.add_argument(
+        "--visual_sizes",
+        type=str,
+        default="",
+        help="optional visual sizes, comma separated, eg: 416x416,384x416",
+    )
     args = parser.parse_args()
     convert(args)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Description

  This PR focuses on QNN LLM runtime/export stability fixes for Android DSP deployment.

  Main changes:
  - Fixes Qwen3-VL deepstack profile compatibility in decode/prefill path (`omni.cpp`) to avoid QNN plugin shape/profile mismatch.
  - Hardens QNN backend context/binary loading and graph execution error handling (`QNNBackend.cpp`, `QNNPerf.*`, `QNNUtils.*`).
  - Extends QNN op support and correctness:
    - Adds `Im2Col` execution support (`QNNIm2Col.*`).
    - Expands binary op mapping (`QNNBinary.cpp`).
    - Fixes NC4HW4->NHWC permute mapping behavior (`QNNPermute.cpp`).
  - Improves QNN conversion toolchain robustness:
    - Safer submodule filtering and shape checks in `compilefornpu.cpp`.
    - Refactors `generate_llm_qnn.py` for LLM/visual split flow and fallback handling.
    - Adds `generateVisualIO.cpp` and updates tool CMake.
    - Makes QNN weight-sharing switch configurable via env in `npu_convert.py`.
  - Removes debug-only behavior from PR scope (no `MNN_LLM_SKIP_TUNING` change included).

  ## Module

  QNN, LLM, Infra (QNN export/toolchain)

  ## Type

  - [ ] Feature
  - [x] Bugfix
  - [ ] Perf
  - [ ] Refact
  - [ ] Style
  - [ ] Doc
  - [ ] Test
  - [ ] Chore

  ## Checklist

  - [x] Commit message follows `[Module:Type] Description` format
  - [x] Code compiles without errors
  - [x] Tested on relevant platform(s)
  - [x] No unrelated format or style changes included