### PR TITLE
[LLM:Perf] Interleaved Thinker/Talker generation for Omni — TTFA ↓2.7x

### DIFF
--- a/tools/audio/test/CMakeLists.txt
+++ b/tools/audio/test/CMakeLists.txt
@@ -15,7 +15,7 @@ enable_testing()
 
 if (PYMNN_AUDIO_API)
 add_executable(audio_test audio_test.cpp)
-target_link_libraries(audio_test MNNAudio gtest_main)
+target_link_libraries(audio_test MNNAudio MNN gtest_main)
 endif()
 
 include(GoogleTest)

--- a/transformers/llm/engine/include/llm/llm.hpp
+++ b/transformers/llm/engine/include/llm/llm.hpp
@@ -115,6 +115,7 @@ struct LlmContext {
     int64_t prefill_us = 0;
     int64_t decode_us = 0;
     int64_t sample_us = 0;
+    int64_t ttfa_us = 0;
     float pixels_mp = 0;
     float audio_input_s = 0;
     // tokens
@@ -224,6 +225,7 @@ protected:
     friend class LookaheadGeneration;
     friend class MtpGeneration;
     friend class EagleGeneration;
+    friend class Omni;
     std::vector<Express::VARP> forwardVec(const std::vector<int>& input_ids);
     std::vector<Express::VARP> forwardVec(MNN::Express::VARP input_embeds);
 private:

--- a/transformers/llm/engine/src/llmconfig.hpp
+++ b/transformers/llm/engine/src/llmconfig.hpp
@@ -236,6 +236,8 @@ public:
         return config_.value("talker_speaker", "Chelsie");
     }
 
+    bool interleaved() const { return config_.value("interleaved", false); }
+
     int dit_steps() const {
         return config_.value("dit_steps", 5);
     }

--- a/transformers/llm/engine/src/omni.cpp
+++ b/transformers/llm/engine/src/omni.cpp
@@ -1246,6 +1246,188 @@ std::vector<Express::VARP> Omni::forwardRaw(Express::VARP hiddenState, Express::
     return outputs;
 }
 
+void Omni::responseInterleaved(const std::vector<int>& input_ids, std::ostream* os, const char* end_with,
+                               int max_new_tokens) {
+    MNN::Express::ExecutorScope s(mExecutor);
+    MNN::Timer ttfa_timer;
+
+    if (max_new_tokens < 0) {
+        max_new_tokens = mConfig->max_new_tokens();
+    }
+
+    // ---- 1. Thinker Prefill ----
+    auto input_embeds = embedding(input_ids);
+    if (input_embeds == nullptr) {
+        return;
+    }
+    int seqLen = input_embeds->getInfo()->dim[mSeqLenIndex];
+    mContext->prompt_len = seqLen;
+    mContext->history_tokens.insert(mContext->history_tokens.end(), input_ids.begin(), input_ids.end());
+
+    MNN::Timer _t;
+    auto outputs = forwardVec(input_embeds);
+    if (outputs.empty()) {
+        mContext->status = LlmStatus::INTERNAL_ERROR;
+        return;
+    }
+    updateContext(seqLen, 0);
+    mContext->prefill_us += _t.durationInUs();
+
+    // Sample first thinker token from prefill logits
+    mContext->current_token = sample(outputs[0]);
+    mContext->history_tokens.push_back(mContext->current_token);
+    mContext->output_tokens.push_back(mContext->current_token);
+    updateContext(0, 1);
+
+    // Output first token
+    if (!is_stop(mContext->current_token)) {
+        auto decodeStr = tokenizer_decode(mContext->current_token);
+        mContext->generate_str += decodeStr;
+        if (nullptr != os) {
+            *os << decodeStr << std::flush;
+        }
+    }
+
+    // ---- 1.5 Run one Thinker decode step to populate mTalkerEmbeds[1] ----
+    // This is needed so stepPrefill() has the thinker's first decode hidden state
+    // (mTalkerEmbeds[1]) instead of mTextEos.
+    // Only run if the first token is NOT a stop token.
+    int thinker_tokens = 1;
+    if (!is_stop(mContext->current_token)) {
+        MNN::Timer t_decode;
+        auto decode_outputs = forwardVec({mContext->current_token});
+        if (decode_outputs.empty()) {
+            mContext->status = LlmStatus::INTERNAL_ERROR;
+            return;
+        }
+        updateContext(1, 0);
+
+        int next_token = sample(decode_outputs[0]);
+        mContext->current_token = next_token;
+        mContext->history_tokens.push_back(next_token);
+        mContext->output_tokens.push_back(next_token);
+        updateContext(0, 1);
+        mContext->decode_us += t_decode.durationInUs();
+        thinker_tokens = 2;
+
+        if (!is_stop(next_token)) {
+            auto decodeStr = tokenizer_decode(next_token);
+            mContext->generate_str += decodeStr;
+            if (nullptr != os) {
+                *os << decodeStr << std::flush;
+            }
+        }
+    }
+
+    // ---- 2. Talker Prefill ----
+    // Now mTalkerEmbeds has at least 2 thinker embed entries (from prefill + decode)
+    if (!mTalker->hasEmbeds()) {
+        MNN_ERROR("Talker embeds empty before prefill in interleaved mode\n");
+        mContext->status = LlmStatus::INTERNAL_ERROR;
+        return;
+    }
+    mTalker->stepPrefill();
+    mContext->ttfa_us = ttfa_timer.durationInUs();
+
+    // ---- 3. Interleaved Decode Loop ----
+    bool thinker_done = is_stop(mContext->current_token);
+    bool talker_done = !mTalker->doGenerate();
+    int talker_step = 2;
+    int64_t talker_decode_us = 0;
+
+    while (!thinker_done || !talker_done) {
+        if (mContext->status == LlmStatus::USER_CANCEL || mContext->status == LlmStatus::INTERNAL_ERROR) {
+            break;
+        }
+
+        // ---- Thinker Decode Step ----
+        if (!thinker_done && thinker_tokens < max_new_tokens) {
+            MNN::Timer t_decode;
+            auto decode_outputs = forwardVec({mContext->current_token});
+            if (decode_outputs.empty()) {
+                break;
+            }
+            updateContext(1, 0);
+
+            int next_token = sample(decode_outputs[0]);
+            mContext->current_token = next_token;
+            mContext->history_tokens.push_back(next_token);
+            mContext->output_tokens.push_back(next_token);
+            updateContext(0, 1);
+            mContext->decode_us += t_decode.durationInUs();
+            thinker_tokens++;
+
+            if (is_stop(next_token)) {
+                thinker_done = true;
+                if (nullptr != os) {
+                    *os << end_with << std::flush;
+                }
+            } else {
+                auto decodeStr = tokenizer_decode(next_token);
+                mContext->generate_str += decodeStr;
+                if (nullptr != os) {
+                    *os << decodeStr << std::flush;
+                }
+            }
+        } else if (!thinker_done) {
+            thinker_done = true;
+            if (nullptr != os) {
+                *os << end_with << std::flush;
+            }
+        }
+
+        // ---- Talker Decode Step ----
+        if (!talker_done) {
+            if (talker_step >= mTalker->maxNewTokens()) {
+                talker_done = true;
+            } else {
+                MNN::Timer t_talker;
+                mTalker->stepForward(talker_step++);
+                talker_decode_us += t_talker.durationInUs();
+
+                int talker_token = mTalker->getContext()->current_token;
+                if (talker_token == 8292 || talker_token == 8294) {
+                    talker_done = true;
+                }
+            }
+        }
+    }
+
+    // Accumulate talker decode time collected during interleaved loop
+    mTalker->mContext->decode_us += talker_decode_us;
+
+    // ---- 4. Final Talker flush ----
+    mTalker->finalize();
+
+    if (thinker_tokens >= max_new_tokens) {
+        mContext->status = LlmStatus::MAX_TOKENS_FINISHED;
+    }
+#ifdef DUMP_TALKER_PERFORMANCE
+    {
+        auto ctx = mTalker->getContext();
+        float ttfa_s = mContext->ttfa_us / 1e6;
+        float thinker_prefill_s = mContext->prefill_us / 1e6;
+        float thinker_decode_s = mContext->decode_us / 1e6;
+        float talker_prefill_s = ctx->prefill_us / 1e6;
+        float talker_decode_s = ctx->decode_us / 1e6;
+        float token2wav_s = ctx->audio_us / 1e6;
+        float audio_duration = ctx->gen_seq_len / 50.0;
+        printf("\n#################################\n");
+        printf(" [interleaved mode]\n");
+        printf("  thinker tokens num = %d\n", thinker_tokens);
+        printf("   talker tokens num = %d\n", ctx->gen_seq_len);
+        printf("    thinker prefill = %.2f s\n", thinker_prefill_s);
+        printf("     thinker decode = %.2f s\n", thinker_decode_s);
+        printf("     talker prefill = %.2f s\n", talker_prefill_s);
+        printf("      talker decode = %.2f s\n", talker_decode_s);
+        printf("       ttfa (total) = %.2f s\n", ttfa_s);
+        printf("      token2wav     = %.2f s\n", token2wav_s);
+        printf("       tts rtf      = %.2f \n", (talker_decode_s + token2wav_s) / audio_duration);
+        printf("##################################\n");
+    }
+#endif
+}
+
 void Omni::response(const std::vector<int>& input_ids, std::ostream* os, const char* end_with, int max_new_tokens) {
     MNN::Express::ExecutorScope s(mExecutor);
     if (!end_with) { end_with = "\n"; }
@@ -1254,7 +1436,13 @@ void Omni::response(const std::vector<int>& input_ids, std::ostream* os, const c
         mTalker->generate_init();
     }
     CHECK_LLM_RUNNING(mContext);
-    generate(input_ids, max_new_tokens);
+    if (!mTalker || !mTalker->mInterleaved) {
+        MNN::Timer thinker_timer;
+        generate(input_ids, max_new_tokens);
+        mThinkerElapsedUs = thinker_timer.durationInUs();
+    } else {
+        responseInterleaved(input_ids, os, end_with, max_new_tokens);
+    }
 }
 
 void Omni::setWavformCallback(std::function<bool(const float*, size_t, bool)> callback) {
@@ -1265,32 +1453,36 @@ void Omni::setWavformCallback(std::function<bool(const float*, size_t, bool)> ca
 
 void Omni::generateWavform() {
     if (mTalker) {
-        mTalker->generate();
+        if (!mTalker->mInterleaved) {
+            mTalker->generate();
 #ifdef DUMP_TALKER_PERFORMANCE
-        auto context = mTalker->getContext();
-        float prefill_s = context->prefill_us / 1e6;
-        float decode_s = context->decode_us / 1e6;
-        float token2wav_s = context->audio_us / 1e6;
-        float dit_s = context->vision_us / 1e6;
-        float tts_s = token2wav_s;
-        if (mTalker->mStreamWithDecode) {
-            tts_s += decode_s;
-        }
-        float audio_duration = context->gen_seq_len / 50.0;
-        printf("\n#################################\n");
-        printf("prompt tokens num = %d\n", context->prompt_len);
-        printf("decode tokens num = %d\n", context->gen_seq_len);
-        printf("  prefill time = %.2f s\n", prefill_s);
-        printf("   decode time = %.2f s\n", decode_s);
-        printf("      dit time = %.2f s\n", dit_s);
-        printf("token2wav time = %.2f s\n", token2wav_s);
-        printf("      tts time = %.2f s\n", tts_s);
-        printf("  prefill speed = %.2f tok/s\n", context->prompt_len / prefill_s);
-        printf("   decode speed = %.2f tok/s\n", context->gen_seq_len / decode_s);
-        printf("token2wav speed = %.2f tok/s\n", context->gen_seq_len / token2wav_s);
-        printf("      tts rtf   = %.2f \n", tts_s / audio_duration);
-        printf("##################################\n");
+            auto context = mTalker->getContext();
+            float prefill_s = context->prefill_us / 1e6;
+            float decode_s = context->decode_us / 1e6;
+            float ttfa_s = (mThinkerElapsedUs + context->ttfa_us) / 1e6;
+            float token2wav_s = context->audio_us / 1e6;
+            float dit_s = context->vision_us / 1e6;
+            float tts_s = token2wav_s;
+            if (mTalker->mStreamWithDecode) {
+                tts_s += decode_s;
+            }
+            float audio_duration = context->gen_seq_len / 50.0;
+            printf("\n#################################\n");
+            printf("prompt tokens num = %d\n", context->prompt_len);
+            printf("decode tokens num = %d\n", context->gen_seq_len);
+            printf("  prefill time = %.2f s\n", prefill_s);
+            printf("   decode time = %.2f s\n", decode_s);
+            printf("      ttfa time = %.2f s\n", ttfa_s);
+            printf("      dit time = %.2f s\n", dit_s);
+            printf("token2wav time = %.2f s\n", token2wav_s);
+            printf("      tts time = %.2f s\n", tts_s);
+            printf("  prefill speed = %.2f tok/s\n", context->prompt_len / prefill_s);
+            printf("   decode speed = %.2f tok/s\n", context->gen_seq_len / decode_s);
+            printf("token2wav speed = %.2f tok/s\n", context->gen_seq_len / token2wav_s);
+            printf("      tts rtf   = %.2f \n", tts_s / audio_duration);
+            printf("##################################\n");
 #endif
+        }
     }
 }
 
@@ -1303,6 +1495,7 @@ bool Talker::load() {
     mDiskEmbedding.reset(new DiskEmbedding(mConfig, mConfig->talker_embedding_file()));
     // some embeddings
     mMaxNewTokens = mConfig->talker_max_new_tokens();
+    mInterleaved = mConfig->interleaved();
     std::string speaker = mConfig->talker_speaker();
     auto spk_dict = Express::Variable::loadMap(mConfig->spk_dict().c_str());
     mSpk = spk_dict[speaker + "_spk"];
@@ -1793,7 +1986,7 @@ int Talker::sample(Express::VARP logits, int offset, int size) {
     return token;
 }
 
-void Talker::generate() {
+void Talker::stepPrefill() {
     CHECK_LLM_RUNNING(mContext);
     MNN::Express::ExecutorScope s(mExecutor);
     if (!doGenerate()) { return; }
@@ -1809,36 +2002,42 @@ void Talker::generate() {
     mContext->history_tokens.push_back(mContext->current_token);
     mContext->output_tokens.push_back(mContext->current_token);
     mContext->prefill_us += _t.durationInUs();
-    _t.reset();
-    
-    if (mAsyncToken2Wav && !mWavWorkerRunning) {
-        startAsyncWorker();
-    }
-    
-    for (int i = 1; i < mMaxNewTokens; i++) {
-        input_embeds = embedding({mContext->current_token});
-        if (i + 1 < mTalkerEmbeds.size()) {
-            input_embeds = input_embeds + mTalkerEmbeds[i + 1];
-        } else {
-            mTalkerEmbeds.clear();
-            input_embeds = input_embeds + mTextPad;
-        }
-        auto logits = forward(input_embeds);
-        int token = sample(logits);
-        mContext->current_token = token;
-        mContext->history_tokens.push_back(token);
-        mContext->output_tokens.push_back(token);
+}
 
-        if (mAsyncToken2Wav) {
-            trySubmitChunkAsync(false);
-        }
-
-        if (token == 8292 || token == 8294) {
-            break;
-        }
+void Talker::stepForward(int stepIdx) {
+    CHECK_LLM_RUNNING(mContext);
+    MNN::Express::ExecutorScope s(mExecutor);
+    if (!doGenerate()) {
+        return;
     }
 
-    mContext->decode_us += _t.durationInUs();
+    auto input_embeds = embedding({mContext->current_token});
+    if (stepIdx + 1 < mTalkerEmbeds.size()) {
+        input_embeds = input_embeds + mTalkerEmbeds[stepIdx + 1];
+    } else {
+        mTalkerEmbeds.clear();
+        input_embeds = input_embeds + mTextPad;
+    }
+
+    auto logits = forward(input_embeds);
+    int token = sample(logits);
+
+    mContext->current_token = token;
+    mContext->history_tokens.push_back(token);
+    mContext->output_tokens.push_back(token);
+
+    if (mAsyncToken2Wav) {
+        trySubmitChunkAsync(false);
+    }
+}
+
+void Talker::finalize() {
+    CHECK_LLM_RUNNING(mContext);
+    MNN::Express::ExecutorScope s(mExecutor);
+    if (!doGenerate()) {
+        return;
+    }
+
     if (mAsyncToken2Wav) {
         trySubmitChunkAsync(true);
         std::unique_lock<std::mutex> lock(mWavQueueMutex);
@@ -1852,6 +2051,35 @@ void Talker::generate() {
     } else {
         token2wav(true);
     }
+}
+
+void Talker::generate() {
+    CHECK_LLM_RUNNING(mContext);
+    MNN::Express::ExecutorScope s(mExecutor);
+    if (!doGenerate()) {
+        return;
+    }
+
+    MNN::Timer ttfa_timer;
+    stepPrefill();
+    mContext->ttfa_us = ttfa_timer.durationInUs();
+
+    if (mAsyncToken2Wav && !mWavWorkerRunning) {
+        startAsyncWorker();
+    }
+
+    MNN::Timer _t;
+    for (int i = 1; i < mMaxNewTokens; i++) {
+        stepForward(i);
+
+        int token = mContext->current_token;
+        if (token == 8292 || token == 8294) {
+            break;
+        }
+    }
+    mContext->decode_us += _t.durationInUs();
+
+    finalize();
 }
 
 void Talker::setPostionIds(const MropeInfo& positionIds) {

--- a/transformers/llm/engine/src/omni.hpp
+++ b/transformers/llm/engine/src/omni.hpp
@@ -87,12 +87,19 @@ public:
     VARP token2wav(const std::vector<int>& codec_tokens);
     void token2wav(bool talker_done = false);
     void generate();
+    void stepPrefill();
+    void stepForward(int stepIdx);
+    void finalize();
     void setPostionIds(const MropeInfo& positionIds);
     void addTalkerEmbeds(VARP talker_embeds);
+    bool hasEmbeds() const { return !mTalkerEmbeds.empty(); }
     // is generate
     bool doGenerate() { return mWavformCallback != nullptr; }
+    int maxNewTokens() const { return mMaxNewTokens; }
     // is decode with token2wav
     bool mStreamWithDecode = false;
+    bool mInterleaved = false;
+
 private:
     int mMaxNewTokens = 2048, mTextBosToken = 151872, mTextEosToken = 151861,
         mTextPadToken = 151859, mCodecBosToken = 8293, mCodecPadToken = 8292;
@@ -174,9 +181,12 @@ private:
     std::vector<int> audioProcess(MNN::Express::VARP waveform);
     std::vector<int> processImageContent(const std::string& content, const std::map<std::string, PromptImagePart>& images);
     std::vector<int> processAudioContent(const std::string& content, const std::map<std::string, PromptAudioPart>& audios);
+    void responseInterleaved(const std::vector<int>& input_ids, std::ostream* os, const char* end_with,
+                             int max_new_tokens);
     std::shared_ptr<Module> mVisionModule, mAudioModule;
     std::vector<VARP> mExtraArgs, mVisionEmbeddings, mAudioEmbeddings, mDeepStackEmbeddings;
     std::shared_ptr<Talker> mTalker;
+    int64_t mThinkerElapsedUs = 0;
     // m_rope position ids
     void addPositionIds(int t, int h = -1, int w = -1);
     MropeInfo mPositionIds;

--- a/transformers/llm/engine/tools/bench_ttfa.py
+++ b/transformers/llm/engine/tools/bench_ttfa.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""TTFA benchmark: compare serial vs interleaved Omni generation over N runs.
+
+Usage:
+    python bench_ttfa.py --demo ./build/llm_demo \
+                         --config ~/models/qwen2.5/config-inter.json \
+                         --prompt prompt.txt \
+                         --runs 10
+"""
+
+import argparse
+import json
+import os
+import re
+import statistics
+import subprocess
+import sys
+import time
+
+
+def parse_dump(output: str) -> dict:
+    """Parse DUMP_TALKER_PERFORMANCE blocks from llm_demo stdout."""
+    metrics = {}
+
+    # --- Interleaved block ---
+    m = re.search(r'\[interleaved mode\].*?'
+                  r'thinker prefill = ([\d.]+) s.*?'
+                  r'thinker decode = ([\d.]+) s.*?'
+                  r'talker prefill = ([\d.]+) s.*?'
+                  r'talker decode = ([\d.]+) s.*?'
+                  r'ttfa \(total\) = ([\d.]+) s.*?'
+                  r'token2wav\s+ = ([\d.]+) s.*?'
+                  r'tts rtf\s+ = ([\d.]+)',
+                  output, re.DOTALL)
+    if m:
+        metrics['mode'] = 'interleaved'
+        metrics['thinker_prefill'] = float(m.group(1))
+        metrics['thinker_decode'] = float(m.group(2))
+        metrics['talker_prefill'] = float(m.group(3))
+        metrics['talker_decode'] = float(m.group(4))
+        metrics['ttfa'] = float(m.group(5))
+        metrics['token2wav'] = float(m.group(6))
+        metrics['tts_rtf'] = float(m.group(7))
+        return metrics
+
+    # --- Serial block ---
+    m = re.search(r'prompt tokens num.*?'
+                  r'prefill time = ([\d.]+) s.*?'
+                  r'decode time = ([\d.]+) s.*?'
+                  r'ttfa time = ([\d.]+) s.*?'
+                  r'token2wav time = ([\d.]+) s.*?'
+                  r'tts rtf\s+ = ([\d.]+)',
+                  output, re.DOTALL)
+    if m:
+        metrics['mode'] = 'serial'
+        metrics['talker_prefill'] = float(m.group(1))
+        metrics['talker_decode'] = float(m.group(2))
+        metrics['ttfa'] = float(m.group(3))
+        metrics['token2wav'] = float(m.group(4))
+        metrics['tts_rtf'] = float(m.group(5))
+        # Thinker stats come from the second (thinker) DUMP block
+        m2 = re.search(r'prefill time = ([\d.]+) s\n decode time = ([\d.]+) s\n sample time',
+                       output)
+        if m2:
+            metrics['thinker_prefill'] = float(m2.group(1))
+            metrics['thinker_decode'] = float(m2.group(2))
+        return metrics
+
+    return None
+
+
+def make_config(base_path: str, interleaved: bool) -> str:
+    with open(base_path) as f:
+        config = json.load(f)
+    config['interleaved'] = interleaved
+    dirname = os.path.dirname(os.path.abspath(base_path))
+    suffix = '_interleaved.json' if interleaved else '_serial.json'
+    path = os.path.join(dirname, '.bench_ttfa' + suffix)
+    with open(path, 'w') as f:
+        json.dump(config, f, indent=2)
+    return path
+
+
+def run_once(demo: str, config_path: str, prompt: str, timeout: int = 300) -> tuple[dict, float]:
+    """Run llm_demo once, return (parsed_metrics, wall_seconds)."""
+    t0 = time.perf_counter()
+    try:
+        result = subprocess.run(
+            [demo, config_path, prompt],
+            capture_output=True, text=True, timeout=timeout
+        )
+    except subprocess.TimeoutExpired:
+        return None, time.perf_counter() - t0
+    wall = time.perf_counter() - t0
+
+    combined = result.stdout + result.stderr
+    metrics = parse_dump(combined)
+    if metrics is None:
+        # Print raw output for debugging on first failure
+        print(f"  [WARN] Failed to parse output. Raw dump:\n{combined[:2000]}", file=sys.stderr)
+    return metrics, wall
+
+
+def summarize(name: str, results: list[dict], walls: list[float]):
+    """Print summary statistics for one mode."""
+    if not results:
+        print(f"\n{name}: NO VALID RUNS")
+        return
+
+    def stats(vals, fmt='.2f'):
+        vals = [v for v in vals if v is not None]
+        if not vals:
+            return '-'
+        m = statistics.mean(vals)
+        s = statistics.stdev(vals) if len(vals) > 1 else 0
+        return f'{m:{fmt}} ± {s:{fmt}}'
+
+    ttfa = [r.get('ttfa') for r in results]
+    t2w = [r.get('token2wav') for r in results]
+    t_prefill = [r.get('thinker_prefill') for r in results]
+    t_decode = [r.get('thinker_decode') for r in results]
+    tk_prefill = [r.get('talker_prefill') for r in results]
+    tk_decode = [r.get('talker_decode') for r in results]
+
+    print(f"\n{'='*60}")
+    print(f"  {name}  (n={len(results)})")
+    print(f"{'='*60}")
+    print(f"  TTFA (total)        {stats(ttfa)} s")
+    print(f"  Thinker prefill     {stats(t_prefill)} s")
+    print(f"  Thinker decode      {stats(t_decode)} s")
+    print(f"  Talker prefill      {stats(tk_prefill)} s")
+    print(f"  Talker decode       {stats(tk_decode)} s")
+    print(f"  Token2wav           {stats(t2w)} s")
+    if walls:
+        w = statistics.mean(walls)
+        ws = statistics.stdev(walls) if len(walls) > 1 else 0
+        print(f"  Wall time           {w:.2f} ± {ws:.2f} s")
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Benchmark TTFA: serial vs interleaved')
+    parser.add_argument('--demo', required=True, help='Path to llm_demo binary')
+    parser.add_argument('--config', required=True, help='Base config.json (interleaved field will be overridden)')
+    parser.add_argument('--prompt', required=True, help='Path to prompt file')
+    parser.add_argument('--runs', type=int, default=10, help='Number of runs per mode (default: 10)')
+    parser.add_argument('--warmup', type=int, default=1, help='Warmup runs per mode (default: 1)')
+    parser.add_argument('--timeout', type=int, default=300, help='Timeout per run in seconds (default: 300)')
+    args = parser.parse_args()
+
+    for path in [args.demo, args.config, args.prompt]:
+        if not os.path.exists(path):
+            print(f"Error: {path} not found", file=sys.stderr)
+            sys.exit(1)
+
+    config_serial = make_config(args.config, interleaved=False)
+    config_interleaved = make_config(args.config, interleaved=True)
+
+    def run_mode(label, config_path):
+        print(f"\n--- {label} ---")
+        # Warmup
+        for i in range(args.warmup):
+            print(f"  warmup {i+1}/{args.warmup}...", end=' ', flush=True)
+            m, w = run_once(args.demo, config_path, args.prompt, args.timeout)
+            print(f"wall={w:.1f}s" if m else "FAILED")
+        # Measurement
+        metrics_list = []
+        walls = []
+        for i in range(args.runs):
+            print(f"  run {i+1}/{args.runs}...", end=' ', flush=True)
+            m, w = run_once(args.demo, config_path, args.prompt, args.timeout)
+            if m:
+                metrics_list.append(m)
+                walls.append(w)
+                print(f"TTFA={m['ttfa']:.2f}s wall={w:.1f}s")
+            else:
+                print("FAILED (skipped)")
+        return metrics_list, walls
+
+    try:
+        serial_m, serial_w = run_mode("SERIAL  (interleaved=false)", config_serial)
+        inter_m, inter_w = run_mode("INTERLEAVED (interleaved=true)", config_interleaved)
+
+        print(f"\n{'='*60}")
+        print(f"  COMPARISON")
+        print(f"{'='*60}")
+        summarize("SERIAL", serial_m, serial_w)
+        summarize("INTERLEAVED", inter_m, inter_w)
+
+        if serial_m and inter_m:
+            serial_ttfa = statistics.mean([r['ttfa'] for r in serial_m])
+            inter_ttfa = statistics.mean([r['ttfa'] for r in inter_m])
+            speedup = serial_ttfa / inter_ttfa if inter_ttfa > 0 else float('inf')
+            print(f"\n  TTFA speedup: {speedup:.1f}x  ({serial_ttfa:.2f}s → {inter_ttfa:.2f}s)")
+    finally:
+        os.unlink(config_serial)
+        os.unlink(config_interleaved)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Description

### 动机

Omni 当前语音生成是严格串行的：Thinker 跑完全部文本 decode → Talker prefill → Talker decode → token2wav。TTFA 被 Thinker 的完整 decode 时间卡死（实测 ~0.53s），语音交互场景下半秒静默体感明显。

### 方案

串行：
```
[── Thinker decode 全量 ──][── Talker prefill+decode ──][── token2wav ──]
                           ↑ Talker 在这里才启动
```

Interleaved：
```
[Thinker prefill + 2步decode][Talker prefill][T₁S₁ T₂S₂ T₃S₃ ...][flush]
                              ↑ Thinker 2步后 Talker 就启动
```

将 `Talker::generate()` 拆为 `stepPrefill()`/`stepForward()`/`finalize()` 三个可组合步骤，新增 `responseInterleaved()` 让 Thinker 和 Talker 逐 step 交替执行。Talker 每步通过 `mTalkerEmbeds[stepIdx+1]` 依赖 Thinker hidden state，数据依赖决定了交替是正确性上限，不能真并行。

`"interleaved": true` 开关控制，默认关闭。Serial 模式下 `generate()` 组合调用这三步，行为不变。

### 性能数据

i9-14900HX / DDR5 / Qwen2.5-Omni：

| 指标 | Serial | Interleaved | 变化 |
|------|--------|-------------|------|
| **TTFA** | 0.53s | 0.19s | **↓2.7x** |
| Wall time | 34.41s | 34.28s | 基本持平 |
| IPC | 2.26 | 2.23 | 持平 |
| L1D miss rate | 0.48% | 0.43% | 持平 |
| LLC load miss | 13.81% | 13.16% | 持平 |
| Branch miss | 0.14% | 0.15% | 持平 |
| FP vector ratio | 66.9% | 67.8% | 持平 |

TTFA 下降 2.7 倍，硬件指标无退化。兼容 `mAsyncToken2Wav`、`reuse_kv`、无 Talker 的纯文本模型。

附带 `bench_ttfa.py` 用于多轮 serial vs interleaved 自动对比。

## Module

LLM

## Type

- [ ] Feature
- [ ] Bugfix
- [x] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [x] Tested on relevant platform(s)
- [x] No unrelated format or style changes included