### PR TITLE
[CPU:Chore] Fix spurious error log when scanning cpufreq policy direc…

### DIFF
--- a/source/backend/cpu/CPURuntime.cpp
+++ b/source/backend/cpu/CPURuntime.cpp
@@ -1602,7 +1602,7 @@ static void _fillInfo(MNNCPUInfo* cpuinfo_isa) {
         CPUGroup group;
         struct dirent* ent;
         while ((ent = readdir(root)) != NULL) {
-            if (ent->d_name[0] != '.') {
+            if (ent->d_name[0] != '.' && ent->d_type == DT_DIR) {
                 std::string policyName = dir + "/" + ent->d_name;
                 std::string cpus = policyName + "/affected_cpus";
                 {


### PR DESCRIPTION
## Description

On Android devices, the following error message appears at runtime:
```
Can't open file:/sys/devices/system/cpu/cpufreq/boost/affected_cpus
```

`/sys/devices/system/cpu/cpufreq/boost/` is a file not a dir

## Module

CPU

## Type

- [ ] Feature
- [ ] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [x] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [x] Tested on relevant platform(s)
- [x] No unrelated format or style changes included
