### PR TITLE
Add the 0.8.3 model-market entries for Gemma 4, LFM/LFM2.5, and Qwen3.5 Claude 4.6 Opus reasoning-distilled models.

### DIFF
--- a/apps/Android/MnnLlmChat/README.md
+++ b/apps/Android/MnnLlmChat/README.md
@@ -62,6 +62,15 @@ This is our full multimodal language model (LLM) Android app
 
 # Releases
 
+## Version 0.8.3
++ Click here to [download](https://meta.alicdn.com/data/mnn/apks/mnn_chat_0_8_3.apk)
++ Highlights:
+  + Add Gemma 4 model entries, including multimodal E2B/E4B and vision 26B-A4B/31B variants.
+  + Add the LFM model family, covering LFM2/LFM2.5 text, task-specific, vision-language, audio, and MoE variants.
+  + Add Qwen3.5 Claude 4.6 Opus reasoning-distilled model entries.
++ Bugfix:
+  + Clean up Android native linking to match the bundled MNN runtime library packaging.
+
 ## Version 0.8.2.2
 + Click here to [download](https://meta.alicdn.com/data/mnn/apks/mnn_chat_0_8_2_2.apk)
 + Highlights:

--- a/apps/Android/MnnLlmChat/README_CN.md
+++ b/apps/Android/MnnLlmChat/README_CN.md
@@ -59,6 +59,15 @@
   ```
 # Releases
 
+## Version 0.8.3
++ 点击这里 [下载](https://meta.alicdn.com/data/mnn/apks/mnn_chat_0_8_3.apk)
++ 更新亮点：
+  + 新增 Gemma 4 模型条目，包括多模态 E2B/E4B 以及视觉 26B-A4B/31B 版本。
+  + 新增 LFM 模型家族，覆盖 LFM2/LFM2.5 文本、任务增强、视觉语言、音频和 MoE 版本。
+  + 新增 Qwen3.5 Claude 4.6 Opus reasoning-distilled 模型条目。
++ 问题修复：
+  + 清理 Android 原生链接配置，使其与内置 MNN runtime 库打包方式保持一致。
+
 ## Version 0.8.2.2
 + 点击这里 [下载](https://meta.alicdn.com/data/mnn/apks/mnn_chat_0_8_2_2.apk)
 + 更新亮点：

--- a/apps/Android/MnnLlmChat/app/build.gradle
+++ b/apps/Android/MnnLlmChat/app/build.gradle
@@ -69,8 +69,8 @@ android {
         applicationId "com.alibaba.mnnllm.android"
         minSdk 26
         targetSdk 35
-        versionCode 822
-        versionName "0.8.2.2"
+        versionCode 830
+        versionName "0.8.3"
         buildConfigField "boolean", "ENABLE_FIREBASE", enableFirebase ? "true" : "false"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         externalNativeBuild {

--- a/apps/Android/MnnLlmChat/app/src/main/assets/model_market.json
+++ b/apps/Android/MnnLlmChat/app/src/main/assets/model_market.json
@@ -1,5 +1,5 @@
 {
-    "version": "21",
+    "version": "22",
     "tagTranslations": {
         "Vision": "图像理解",
         "Video": "视频理解",
@@ -25,6 +25,7 @@
         "Qwen",
         "DeepSeek",
         "Gemma",
+        "LFM",
         "Smol",
         "stability.ai",
         "Llama",
@@ -43,6 +44,518 @@
         "Lingshu"
     ],
     "models": [
+        {
+            "modelName": "gemma-4-E2B-it-MNN",
+            "tags": [
+                "Vision",
+                "Audio"
+            ],
+            "categories": [
+                "chat",
+                "gemma"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/gemma-4-E2B-it-MNN",
+                "ModelScope": "MNN/gemma-4-E2B-it-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 2,
+            "vendor": "Gemma",
+            "file_size": 3739999029
+        },
+        {
+            "modelName": "gemma-4-E4B-it-MNN",
+            "tags": [
+                "Vision",
+                "Audio"
+            ],
+            "categories": [
+                "chat",
+                "gemma"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/gemma-4-E4B-it-MNN",
+                "ModelScope": "MNN/gemma-4-E4B-it-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 4,
+            "vendor": "Gemma",
+            "file_size": 5542173790
+        },
+        {
+            "modelName": "gemma-4-26B-A4B-it-MNN",
+            "tags": [
+                "Vision"
+            ],
+            "categories": [
+                "chat",
+                "gemma"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/gemma-4-26B-A4B-it-MNN",
+                "ModelScope": "MNN/gemma-4-26B-A4B-it-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 26,
+            "vendor": "Gemma",
+            "file_size": 16542648227
+        },
+        {
+            "modelName": "gemma-4-31B-it-MNN",
+            "tags": [
+                "Vision"
+            ],
+            "categories": [
+                "chat",
+                "gemma"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/gemma-4-31B-it-MNN",
+                "ModelScope": "MNN/gemma-4-31B-it-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 31,
+            "vendor": "Gemma",
+            "file_size": 19893380963
+        },
+        {
+            "modelName": "LFM2-350M-MNN",
+            "tags": [],
+            "categories": [
+                "chat",
+                "lfm"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/LFM2-350M-MNN",
+                "ModelScope": "MNN/LFM2-350M-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 0.35,
+            "vendor": "LFM",
+            "file_size": 223529599
+        },
+        {
+            "modelName": "LFM2-700M-MNN",
+            "tags": [],
+            "categories": [
+                "chat",
+                "lfm"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/LFM2-700M-MNN",
+                "ModelScope": "MNN/LFM2-700M-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 0.7,
+            "vendor": "LFM",
+            "file_size": 466368851
+        },
+        {
+            "modelName": "LFM2-1.2B-MNN",
+            "tags": [],
+            "categories": [
+                "chat",
+                "lfm"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/LFM2-1.2B-MNN",
+                "ModelScope": "MNN/LFM2-1.2B-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 1.2,
+            "vendor": "LFM",
+            "file_size": 734112071
+        },
+        {
+            "modelName": "LFM2-1.2B-Extract-MNN",
+            "tags": [],
+            "categories": [
+                "chat",
+                "lfm"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/LFM2-1.2B-Extract-MNN",
+                "ModelScope": "MNN/LFM2-1.2B-Extract-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 1.2,
+            "vendor": "LFM",
+            "file_size": 734111769
+        },
+        {
+            "modelName": "LFM2-1.2B-RAG-MNN",
+            "tags": [],
+            "categories": [
+                "chat",
+                "lfm"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/LFM2-1.2B-RAG-MNN",
+                "ModelScope": "MNN/LFM2-1.2B-RAG-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 1.2,
+            "vendor": "LFM",
+            "file_size": 734111982
+        },
+        {
+            "modelName": "LFM2-1.2B-Tool-MNN",
+            "tags": [],
+            "categories": [
+                "chat",
+                "lfm"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/LFM2-1.2B-Tool-MNN",
+                "ModelScope": "MNN/LFM2-1.2B-Tool-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 1.2,
+            "vendor": "LFM",
+            "file_size": 734111998
+        },
+        {
+            "modelName": "LFM2.5-1.2B-Base-MNN",
+            "tags": [],
+            "categories": [
+                "chat",
+                "lfm"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/LFM2.5-1.2B-Base-MNN",
+                "ModelScope": "MNN/LFM2.5-1.2B-Base-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 1.2,
+            "vendor": "LFM",
+            "file_size": 734112509
+        },
+        {
+            "modelName": "LFM2.5-1.2B-Instruct-MNN",
+            "tags": [],
+            "categories": [
+                "chat",
+                "lfm"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/LFM2.5-1.2B-Instruct-MNN",
+                "ModelScope": "MNN/LFM2.5-1.2B-Instruct-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 1.2,
+            "vendor": "LFM",
+            "file_size": 734112941
+        },
+        {
+            "modelName": "LFM2.5-1.2B-JP-MNN",
+            "tags": [],
+            "categories": [
+                "chat",
+                "lfm"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/LFM2.5-1.2B-JP-MNN",
+                "ModelScope": "MNN/LFM2.5-1.2B-JP-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 1.2,
+            "vendor": "LFM",
+            "file_size": 734112851
+        },
+        {
+            "modelName": "LFM2.5-1.2B-Thinking-MNN",
+            "tags": [
+                "Think"
+            ],
+            "categories": [
+                "chat",
+                "lfm"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/LFM2.5-1.2B-Thinking-MNN",
+                "ModelScope": "MNN/LFM2.5-1.2B-Thinking-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 1.2,
+            "vendor": "LFM",
+            "file_size": 734112911
+        },
+        {
+            "modelName": "LFM2-2.6B-MNN",
+            "tags": [],
+            "categories": [
+                "chat",
+                "lfm"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/LFM2-2.6B-MNN",
+                "ModelScope": "MNN/LFM2-2.6B-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 2.6,
+            "vendor": "LFM",
+            "file_size": 1610283276
+        },
+        {
+            "modelName": "LFM2-2.6B-Exp-MNN",
+            "tags": [],
+            "categories": [
+                "chat",
+                "lfm"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/LFM2-2.6B-Exp-MNN",
+                "ModelScope": "MNN/LFM2-2.6B-Exp-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 2.6,
+            "vendor": "LFM",
+            "file_size": 1610283391
+        },
+        {
+            "modelName": "LFM2-2.6B-Transcript-MNN",
+            "tags": [],
+            "categories": [
+                "chat",
+                "lfm"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/LFM2-2.6B-Transcript-MNN",
+                "ModelScope": "MNN/LFM2-2.6B-Transcript-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 2.6,
+            "vendor": "LFM",
+            "file_size": 1610283859
+        },
+        {
+            "modelName": "LFM2-24B-A2B-MNN",
+            "tags": [],
+            "categories": [
+                "chat",
+                "lfm"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/LFM2-24B-A2B-MNN",
+                "ModelScope": "MNN/LFM2-24B-A2B-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 24,
+            "vendor": "LFM",
+            "file_size": 14945491712
+        },
+        {
+            "modelName": "LFM2-350M-ENJP-MT-MNN",
+            "tags": [],
+            "categories": [
+                "chat",
+                "lfm"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/LFM2-350M-ENJP-MT-MNN",
+                "ModelScope": "MNN/LFM2-350M-ENJP-MT-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 0.35,
+            "vendor": "LFM",
+            "file_size": 223529429
+        },
+        {
+            "modelName": "LFM2-350M-Extract-MNN",
+            "tags": [],
+            "categories": [
+                "chat",
+                "lfm"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/LFM2-350M-Extract-MNN",
+                "ModelScope": "MNN/LFM2-350M-Extract-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 0.35,
+            "vendor": "LFM",
+            "file_size": 223529638
+        },
+        {
+            "modelName": "LFM2-350M-Math-MNN",
+            "tags": [
+                "Math"
+            ],
+            "categories": [
+                "chat",
+                "lfm"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/LFM2-350M-Math-MNN",
+                "ModelScope": "MNN/LFM2-350M-Math-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 0.35,
+            "vendor": "LFM",
+            "file_size": 223529380
+        },
+        {
+            "modelName": "LFM2-350M-PII-Extract-JP-MNN",
+            "tags": [],
+            "categories": [
+                "chat",
+                "lfm"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/LFM2-350M-PII-Extract-JP-MNN",
+                "ModelScope": "MNN/LFM2-350M-PII-Extract-JP-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 0.35,
+            "vendor": "LFM",
+            "file_size": 223529947
+        },
+        {
+            "modelName": "LFM2-VL-450M-MNN",
+            "tags": [
+                "Vision"
+            ],
+            "categories": [
+                "chat",
+                "lfm"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/LFM2-VL-450M-MNN",
+                "ModelScope": "MNN/LFM2-VL-450M-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 0.45,
+            "vendor": "LFM",
+            "file_size": 327132700
+        },
+        {
+            "modelName": "LFM2-VL-1.6B-MNN",
+            "tags": [
+                "Vision"
+            ],
+            "categories": [
+                "chat",
+                "lfm"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/LFM2-VL-1.6B-MNN",
+                "ModelScope": "MNN/LFM2-VL-1.6B-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 1.6,
+            "vendor": "LFM",
+            "file_size": 1169276117
+        },
+        {
+            "modelName": "LFM2-Audio-1.5B-MNN",
+            "tags": [
+                "Audio"
+            ],
+            "categories": [
+                "chat",
+                "lfm"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/LFM2-Audio-1.5B-MNN",
+                "ModelScope": "MNN/LFM2-Audio-1.5B-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 1.5,
+            "vendor": "LFM",
+            "file_size": 828120793
+        },
+        {
+            "modelName": "Qwen3.5-0.8B-Claude-4.6-Opus-Reasoning-Distilled-MNN",
+            "tags": [
+                "Think",
+                "Vision"
+            ],
+            "extra_tags": [
+                "opencl_warning",
+                "ThinkingSwitch"
+            ],
+            "categories": [
+                "recommended",
+                "qwen"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/Qwen3.5-0.8B-Claude-4.6-Opus-Reasoning-Distilled-MNN",
+                "ModelScope": "MNN/Qwen3.5-0.8B-Claude-4.6-Opus-Reasoning-Distilled-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 0.8,
+            "vendor": "Qwen",
+            "file_size": 544134218
+        },
+        {
+            "modelName": "Qwen3.5-2B-Claude-4.6-Opus-Reasoning-Distilled-MNN",
+            "tags": [
+                "Think",
+                "Vision"
+            ],
+            "extra_tags": [
+                "opencl_warning",
+                "ThinkingSwitch"
+            ],
+            "categories": [
+                "recommended",
+                "qwen"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/Qwen3.5-2B-Claude-4.6-Opus-Reasoning-Distilled-MNN",
+                "ModelScope": "MNN/Qwen3.5-2B-Claude-4.6-Opus-Reasoning-Distilled-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 2,
+            "vendor": "Qwen",
+            "file_size": 1383239575
+        },
+        {
+            "modelName": "Qwen3.5-4B-Claude-4.6-Opus-Reasoning-Distilled-MNN",
+            "tags": [
+                "Think",
+                "Vision"
+            ],
+            "extra_tags": [
+                "opencl_warning",
+                "ThinkingSwitch"
+            ],
+            "categories": [
+                "recommended",
+                "qwen"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/Qwen3.5-4B-Claude-4.6-Opus-Reasoning-Distilled-MNN",
+                "ModelScope": "MNN/Qwen3.5-4B-Claude-4.6-Opus-Reasoning-Distilled-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 4,
+            "vendor": "Qwen",
+            "file_size": 2842506997
+        },
+        {
+            "modelName": "Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-MNN",
+            "tags": [
+                "Think",
+                "Vision"
+            ],
+            "extra_tags": [
+                "opencl_warning",
+                "ThinkingSwitch"
+            ],
+            "categories": [
+                "recommended",
+                "qwen"
+            ],
+            "sources": {
+                "HuggingFace": "taobao-mnn/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-MNN",
+                "ModelScope": "MNN/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 27,
+            "vendor": "Qwen",
+            "file_size": 18858231999
+        },
         {
             "modelName": "Qwen3.5-2B-MNN",
             "tags": [

--- a/apps/Android/MnnLlmChat/app/src/main/cpp/CMakeLists.txt
+++ b/apps/Android/MnnLlmChat/app/src/main/cpp/CMakeLists.txt
@@ -71,13 +71,6 @@ include_directories("${CMAKE_SOURCE_DIR}/third_party")
 add_library(MNN SHARED IMPORTED)
 set_target_properties(MNN PROPERTIES IMPORTED_LOCATION "${LIB_PATH}/libMNN.so")
 
-add_library(llm SHARED IMPORTED)
-set_target_properties(llm PROPERTIES IMPORTED_LOCATION "${LIB_PATH}/libllm.so")
-
-add_library(mnn_Express SHARED IMPORTED)
-set_target_properties(mnn_Express PROPERTIES IMPORTED_LOCATION "${LIB_PATH}/libMNN_Express.so")
-
-
 # Link your native library with the `.so` file
 
 # Specifies libraries CMake should link to your target library. You
@@ -88,8 +81,6 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
         android
         log
         MNN
-        llm
-        mnn_Express
         # MediaCodec libraries for hardware video decoding
         mediandk
 

--- a/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mnnllm/android/model/ModelVendors.kt
+++ b/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mnnllm/android/model/ModelVendors.kt
@@ -15,6 +15,7 @@ object ModelVendors {
     const val Jina = "Jina"
     const val Internlm = "Internlm"
     const val Gemma = "Gemma"
+    const val Lfm = "LFM"
     const val Mimo = "Mimo"
     const val FastVlm = "FastVlm"
     const val OpenElm = "OpenElm"
@@ -24,6 +25,7 @@ object ModelVendors {
         Qwen,
         DeepSeek,
         Gemma,
+        Lfm,
         Smo,
         FastVlm,
         Phi,

--- a/apps/Android/MnnLlmChat/scripts/release.sh
+++ b/apps/Android/MnnLlmChat/scripts/release.sh
@@ -160,6 +160,11 @@ check_requirements() {
     if [[ -z "$KEYSTORE_FILE" || -z "$KEYSTORE_PASSWORD" || -z "$KEY_ALIAS" || -z "$KEY_PASSWORD" ]]; then
         log_warning "Signing configuration not found. Google Play upload will be skipped."
         SKIP_GOOGLE_PLAY_UPLOAD=true
+        unset KEYSTORE_FILE KEYSTORE_PASSWORD KEY_ALIAS KEY_PASSWORD
+    elif [[ ! -f "$KEYSTORE_FILE" ]]; then
+        log_warning "Signing keystore not found at $KEYSTORE_FILE. Building local AAB without signing and skipping Google Play upload."
+        SKIP_GOOGLE_PLAY_UPLOAD=true
+        unset KEYSTORE_FILE KEYSTORE_PASSWORD KEY_ALIAS KEY_PASSWORD
     else
         SKIP_GOOGLE_PLAY_UPLOAD=false
     fi


### PR DESCRIPTION
## Summary
- Bump MnnLlmChat Android to version 0.8.3 / versionCode 830.
- Add the 0.8.3 model-market entries for Gemma 4, LFM/LFM2.5, and Qwen3.5 Claude 4.6 Opus reasoning-distilled models.
- Add LFM to the Android model vendor list and align English/Chinese release notes.
- Let the release script build local AAB artifacts when signing env vars point at a missing keystore, while still skipping Google Play upload.

## Release Artifacts
- CDN APK: https://meta.alicdn.com/data/mnn/apks/mnn_chat_0_8_3.apk
- Local AAB artifact generated at: apps/Android/MnnLlmChat/release_outputs/googleplay/app-googleplay-release.aab

## Verification
- ENABLE_FIREBASE=true ./scripts/release.sh
- ./gradlew :app:assembleStandardDebug
- ./gradlew -PENABLE_FIREBASE=true :app:assembleStandardDebug
- jq empty apps/Android/MnnLlmChat/app/src/main/assets/model_market.json
- bash -n apps/Android/MnnLlmChat/scripts/release.sh
- curl -I -L https://meta.alicdn.com/data/mnn/apks/mnn_chat_0_8_3.apk returned HTTP 200

## Notes
- Google Play upload was skipped because the configured keystore path did not exist and no Play service account was configured locally.