### PR TITLE
[LLM:Bugfix] Fix weight_dict reinitialization in GPTQ loader

### DIFF
--- a/transformers/llm/export/utils/gptq.py
+++ b/transformers/llm/export/utils/gptq.py
@@ -61,6 +61,7 @@ class MNNWeight:
 
 class GPTQ:
     def __init__(self, gptq_path):
+        self.weight_dict = dict()
         self.load(gptq_path)
 
     def load(self, path):
@@ -83,7 +84,6 @@ class GPTQ:
         return None
 
     def load_safetensor(self, tensor):
-        self.weight_dict = dict()
         with safe_open(tensor, framework="pt") as f:
             for k in f.keys():
                 p, s = self.prefix(k)


### PR DESCRIPTION
## Description

Fix a bug in the GPTQ weight loader where `weight_dict` is reinitialized on every `.safetensors` file load, causing previously loaded weights to be discarded. Move `self.weight_dict = dict()` from `load_safetensor` to `__init__` so that all tensor shards are accumulated correctly when multiple safetensors files exist.

## Module

LLM / Quantization

## Type

- [ ] Feature  
- [x] Bugfix  
- [ ] Perf  
- [ ] Refact  
- [ ] Style  
- [ ] Doc  
- [ ] Test  
- [ ] Chore  

## Checklist

- [x] Commit message follows `[Module:Type] Description` format  
- [x] Code compiles without errors  
- [x] Tested on relevant platform(s)  
- [x] No unrelated format or style changes included  
