### PR TITLE
[LLM,CPU:Bugfix] Fix crash on corrupted prefix kvcache and size_t narrowing in expandKVCacheInDisk

### DIFF
--- a/source/backend/cpu/CPUKVCacheManager.cpp
+++ b/source/backend/cpu/CPUKVCacheManager.cpp
@@ -191,13 +191,17 @@ void CPUKVCacheManager::moveKVCacheFromMemToDisk(int oldMaxLength) {
 /*
 **  @brief  Expand the size of kvcache files in disk
 */
-void CPUKVCacheManager::expandKVCacheInDisk(int oldMaxLength, int oldKeySize, int oldValueSize, int keySize, int valueSize, file_t specKeyFile, file_t specValueFile) {
+void CPUKVCacheManager::expandKVCacheInDisk(size_t oldMaxLength, size_t oldKeySize, size_t oldValueSize, size_t keySize,
+                                            size_t valueSize, file_t specKeyFile, file_t specValueFile) {
     // Step 1: Copy the old kvcache from files to temporary buffers in memory
     auto prevKeySizePerHead = oldKeySize / mKvNumHead;
     auto prevValueSizePerHead = oldValueSize / mKvNumHead;
     std::shared_ptr<Tensor> prevKey, prevValue;
-    prevKey.reset(Tensor::createDevice<int8_t>({mKvNumHead, prevKeySizePerHead}));
-    prevValue.reset(Tensor::createDevice<int8_t>({mKvNumHead, prevValueSizePerHead}));
+    // NOTE: Tensor shape is std::vector<int>. prevKeySizePerHead is size_t after
+    // the int -> size_t fix; cast back to int here. In realistic models a single
+    // head's cache is far below 2 GB, so the narrowing is safe in practice.
+    prevKey.reset(Tensor::createDevice<int8_t>({mKvNumHead, (int)prevKeySizePerHead}));
+    prevValue.reset(Tensor::createDevice<int8_t>({mKvNumHead, (int)prevValueSizePerHead}));
 
     mBackend->onAcquireBuffer(prevKey.get(), Backend::STATIC);
     mBackend->onAcquireBuffer(prevValue.get(), Backend::STATIC);

--- a/source/backend/cpu/CPUKVCacheManager.hpp
+++ b/source/backend/cpu/CPUKVCacheManager.hpp
@@ -41,7 +41,8 @@ private:
     
     void expandKVCacheInMem(int oldMaxLength);
     void moveKVCacheFromMemToDisk(int oldMaxLength);
-    void expandKVCacheInDisk(int oldMaxLength, int oldKeySize, int oldValueSize, int keySize, int valueSize, file_t specKeyFile = INVALID_FILE, file_t specValueFile = INVALID_FILE);
+    void expandKVCacheInDisk(size_t oldMaxLength, size_t oldKeySize, size_t oldValueSize, size_t keySize,
+                             size_t valueSize, file_t specKeyFile = INVALID_FILE, file_t specValueFile = INVALID_FILE);
     template <typename T> void ProcessKey(const Tensor* key, int seq_len, int kv_h);
     template <typename T> void ProcessValue(const Tensor* value, int seq_len, int kv_h);
     template <typename T> void moveKV(int src, int dst, int size);

--- a/transformers/llm/engine/src/llm.cpp
+++ b/transformers/llm/engine/src/llm.cpp
@@ -1218,6 +1218,71 @@ bool Llm::setPrefixCacheFile(const std::string& filename, int flag) {
             break;
         }
     }
+
+    // Further check: the real .k/.v data files must exist, be non-empty, and have consistent
+    // sizes across layers. This guards against cases where _sync markers remain but the
+    // actual data files were deleted / truncated / partially written, which would otherwise
+    // lead to a crash in CPUKVCacheManager::onAlloc (e.g. memset on a null mmap address).
+    if (mIsPrefixFileExist) {
+        size_t refKeySize = 0;
+        size_t refValueSize = 0;
+        for (int i = 0; i < mConfig->layer_nums(); i++) {
+            auto base = MNNFilePathConcat(mConfig->prefix_cache_path(), mPrefixCacheFileName) + "_" + std::to_string(i);
+            auto k_data = base + ".k";
+            auto v_data = base + ".v";
+            if (!MNNFileExist(k_data.c_str()) || !MNNFileExist(v_data.c_str())) {
+                MNN_PRINT("Prefix cache data file missing: %s or %s\n", k_data.c_str(), v_data.c_str());
+                mIsPrefixFileExist = false;
+                break;
+            }
+            auto kfd = MNNOpenFile(k_data.c_str(), MNN_FILE_READ);
+            auto vfd = MNNOpenFile(v_data.c_str(), MNN_FILE_READ);
+            size_t kSize = (kfd == INVALID_FILE) ? INVALID_SIZE : MNNGetFileSize(kfd);
+            size_t vSize = (vfd == INVALID_FILE) ? INVALID_SIZE : MNNGetFileSize(vfd);
+            if (kfd != INVALID_FILE)
+                MNNCloseFile(kfd);
+            if (vfd != INVALID_FILE)
+                MNNCloseFile(vfd);
+            if (kSize == INVALID_SIZE || kSize == 0 || vSize == INVALID_SIZE || vSize == 0) {
+                MNN_PRINT("Prefix cache data file has invalid size: %s(%zu) %s(%zu)\n", k_data.c_str(), kSize,
+                          v_data.c_str(), vSize);
+                mIsPrefixFileExist = false;
+                break;
+            }
+            if (i == 0) {
+                refKeySize = kSize;
+                refValueSize = vSize;
+            } else if (kSize != refKeySize || vSize != refValueSize) {
+                // All layers share the same model shape, so their .k (and .v) files must
+                // have identical sizes. Any mismatch means the cache directory has been
+                // corrupted / partially overwritten and must be rebuilt.
+                MNN_PRINT("Prefix cache size mismatch at layer %d: k=%zu(ref=%zu) v=%zu(ref=%zu)\n", i, kSize,
+                          refKeySize, vSize, refValueSize);
+                mIsPrefixFileExist = false;
+                break;
+            }
+        }
+    }
+
+    // If the cache is deemed unusable (missing / truncated / size-mismatched /
+    // partially written), wipe all related files under prefix_cache_path for this
+    // filename so that the subsequent PendingWrite path starts from a clean slate.
+    // This is especially important for the _sync.k / _sync.v markers, which would
+    // otherwise remain and mislead the next run into thinking the cache is valid.
+    // MNNRemoveFile is a no-op on non-existent files, so this is safe to run
+    // unconditionally whenever mIsPrefixFileExist is false.
+    if (!mIsPrefixFileExist) {
+        for (int i = 0; i < mConfig->layer_nums(); i++) {
+            auto base = MNNFilePathConcat(mConfig->prefix_cache_path(), mPrefixCacheFileName) + "_" + std::to_string(i);
+            MNNRemoveFile((base + ".k").c_str());
+            MNNRemoveFile((base + ".v").c_str());
+            MNNRemoveFile((base + "_sync.k").c_str());
+            MNNRemoveFile((base + "_sync.v").c_str());
+        }
+        MNN_PRINT("Prefix cache unusable, cleaned up stale files under %s for %s\n",
+                  mConfig->prefix_cache_path().c_str(), mPrefixCacheFileName.c_str());
+    }
+
     return mIsPrefixFileExist;
 }
 


### PR DESCRIPTION
## Description

修复 LLM 推理在加载磁盘前缀 KV-Cache（prefix cache）时，因缓存文件缺失/损坏导致的 `SIGSEGV (SEGV_ACCERR at 0x0)` 崩溃；同时加固 `CPUKVCacheManager::expandKVCacheInDisk` 的字节尺寸参数类型，消除大模型长上下文场景下的 `int` 窄化隐患。

具体包含两项改动：

1. **`Llm::setPrefixCacheFile` 校验加固 + 脏文件清理**（`transformers/llm/engine/src/llm.cpp`）
   - 原实现只校验 `_sync.k` / `_sync.v` 标记文件的存在性，当真实的 `.k` / `.v` 数据文件被删除或截断时校验会误判通过，后续 `CPUKVCacheManager::onAlloc` 的 PendingRead 路径里 `MNNGetFileSize(INVALID_FILE)` 返回 `(size_t)-1` 污染 `keySize`，最终在 `memset(mMapKeyAddr, 0, keySize)` 上崩溃。
   - 现在在 sync 校验通过后，对每一层额外检查：`.k` / `.v` 数据文件都存在、大小非 0 且不为 `INVALID_SIZE`、所有层的 `.k` 大小完全相同、所有层的 `.v` 大小完全相同（transformer 各层 KV 布局一致，任何尺寸不一致均说明缓存已损坏）。
   - 一旦判定缓存不可用，无条件清理该 filename 对应的全部四类文件（`.k` / `.v` / `_sync.k` / `_sync.v`），避免残留的 sync 标记误导下次启动，保证后续 PendingWrite 路径从完全干净的状态重建缓存。

2. **`CPUKVCacheManager::expandKVCacheInDisk` 参数类型修正**（`source/backend/cpu/CPUKVCacheManager.hpp` / `.cpp`）
   - 函数签名原本把 `oldMaxLength` / `oldKeySize` / `oldValueSize` / `keySize` / `valueSize` 都声明为 `int`，但其调用链上下游（`MNNGetFileSize`、`mmapKVCache`、`resetKVCacheFileSize`、`memset` / `memcpy`）全部使用 `size_t`。在大模型 / 长上下文（单层 KV ≥ 2GB）场景下会发生 `size_t → int` 隐式窄化，int 溢出为负数再扩回 `size_t` 时符号位扩展成巨大数值，导致下游 API 行为错乱或崩溃。
   - 5 个参数统一改为 `size_t`；`Tensor::createDevice` 要求 `vector<int>` shape 的两处补充显式 `(int)` 强转，避免 brace-init 窄化编译错误。

## Module

LLM / CPU

## Type

- [ ] Feature
- [x] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [x] Tested on relevant platform(s)
- [x] No unrelated format or style changes included
