### PR TITLE
[QNN:Perf] Parallelize offline graph export with multi-process

### DIFF
--- a/source/backend/qnn/npu_convert.py
+++ b/source/backend/qnn/npu_convert.py
@@ -4,6 +4,8 @@ import json
 import os
 import subprocess
 import json
+import concurrent.futures
+import multiprocessing
 post_treat = {}
 qnn_sdk = os.environ["QNN_SDK_ROOT"]
 print(qnn_sdk)
@@ -20,6 +22,67 @@ cache_dir = 'res'
 if 'cache' in post_treat:
     cache_dir = post_treat['cache']
 clean_tmp = True
+
+
+def run_subprocess(cmd, cwd=None, retries=3):
+    result = None
+    for attempt in range(1, retries + 1):
+        result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+        if result.stdout:
+            print(result.stdout, flush=True)
+        if result.stderr:
+            print(result.stderr, flush=True)
+        if result.returncode == 0:
+            return result
+        print(f"[Retry {attempt}/{retries}] command failed: {' '.join(cmd)}", flush=True)
+    return result
+
+
+def process_src(task):
+    i, src = task
+    graphname = src.split('/')[-1]
+    workdir = os.path.join(os.getcwd(), src)
+    raw_files = sorted(
+        file_name for file_name in os.listdir(workdir)
+        if file_name.endswith(".raw")
+    )
+    if not raw_files:
+        raise RuntimeError(f"No .raw files found for src={src}")
+
+    tar_cmd = ["tar", "-cf", graphname + ".bin", *raw_files]
+    tar_result = run_subprocess(tar_cmd, cwd=workdir, retries=1)
+    if tar_result.returncode != 0:
+        raise RuntimeError(f"Tar failed for src={src}: {' '.join(tar_cmd)}")
+
+    if clean_tmp:
+        rm_raw_result = run_subprocess(["rm", *raw_files], cwd=workdir, retries=1)
+        if rm_raw_result.returncode != 0:
+            raise RuntimeError(f"Remove raw failed for src={src}")
+
+    compile_cmd = [
+        "python3",
+        qnnModelLibGenerator,
+        "-c", os.path.join(workdir, graphname + '.cpp'),
+        "-b", os.path.join(workdir, graphname + '.bin'),
+        "-t", "x86_64-linux-clang",
+        "-o", workdir,
+    ]
+    compile_result = run_subprocess(compile_cmd, retries=3)
+    if compile_result.returncode != 0:
+        raise RuntimeError(f"Compile failed for src={src}: {' '.join(compile_cmd)}")
+
+    if clean_tmp:
+        rm_bin_result = run_subprocess(
+            ["rm", os.path.join(workdir, graphname + '.bin')],
+            retries=1,
+        )
+        if rm_bin_result.returncode != 0:
+            raise RuntimeError(f"Remove bin failed for src={src}")
+
+    lib_path = os.path.join(workdir, 'x86_64-linux-clang', 'lib' + graphname + '.so')
+    return i, graphname, workdir, lib_path
+
+
 context_config = {
     "backend_extensions": {
         "shared_library_path": os.path.join(qnn_sdk, "lib","x86_64-linux-clang","libQnnHtpNetRunExtensions.so"),
@@ -27,8 +90,6 @@ context_config = {
     }
 }
 htp_so = os.path.join(qnn_sdk, 'lib','x86_64-linux-clang','libQnnHtp.so')
-with open('context_config.json', 'w') as f:
-    f.write(json.dumps(context_config, indent=4))
 
 htp_backend_extensions = {
     "graphs": [
@@ -57,43 +118,78 @@ htp_backend_extensions = {
     }
 }
 
-for key in post_treat["merge"]:
+def process_merge(key, merge_index):
     srcs = merges[key]
-    dst = key
-    dstname = key.split('/')
-    dstname = dstname[len(dstname)-1]
-    dstname = dstname.replace('.bin', '')
-    graphs = []
-    libs = []
-    workdirs = []
-    for i,src in enumerate(srcs):
-        # tar
-        graphname = src.split('/')
-        graphname = graphname[len(graphname)-1]
-        graphs.append(graphname)
-        workdir = os.path.join(os.getcwd(), src)
-        workdirs.append(workdir)
-        print(subprocess.run("tar -cf " + graphname + '.bin' + ' *.raw', cwd=workdir, capture_output=True, text=True, shell=True))
-        if clean_tmp:
-            print(subprocess.run('rm *.raw', cwd=workdir, capture_output=True, text=True, shell=True))
-        # Compile
-        compile_cmd = 'python3 ' + qnnModelLibGenerator + ' -c ' + os.path.join(workdir, graphname + '.cpp') + ' -b ' + os.path.join(workdir, graphname + '.bin') + ' -t x86_64-linux-clang -o ' + workdir
-        print(os.popen(compile_cmd).read())
-        if clean_tmp:
-            os.popen("rm " + os.path.join(workdir, graphname + '.bin')).read()
-        libs.append(os.path.join(workdir, 'x86_64-linux-clang', 'lib' + graphname + '.so'))
-    htp_backend_extensions['graphs'][0]['graph_names'] = graphs
-    with open('htp_backend_extensions.json', 'w') as f:
-        f.write(json.dumps(htp_backend_extensions, indent=4))
-    libsStr = ""
-    for i in range(0, len(libs)):
-        if i > 0:
-            libsStr+=','
-        libsStr += libs[i]
-    print(os.popen(qnnContextBinaryGenerator + ' --model ' + libsStr + ' --backend '+ htp_so + ' --binary_file ' + dstname + ' --config_file ./context_config.json ' + ' --output_dir ' + cache_dir).read())
+    dstname = key.split('/')[-1].replace('.bin', '')
+    graphs = [None] * len(srcs)
+    libs = [None] * len(srcs)
+    workdirs = [None] * len(srcs)
+
+    src_workers = max(1, min(os.cpu_count()//2 or 1, len(srcs)))
+    with concurrent.futures.ProcessPoolExecutor(
+        max_workers=src_workers,
+        mp_context=multiprocessing.get_context("fork"),
+    ) as executor:
+        futures = {
+            executor.submit(process_src, (i, src)): src
+            for i, src in enumerate(srcs)
+        }
+        for future in concurrent.futures.as_completed(futures):
+            src = futures[future]
+            try:
+                i, graphname, workdir, lib_path = future.result()
+            except Exception as e:
+                raise RuntimeError(f"Process src failed for {src}: {e}") from e
+            graphs[i] = graphname
+            libs[i] = lib_path
+            workdirs[i] = workdir
+
+    local_htp_backend_extensions = json.loads(json.dumps(htp_backend_extensions))
+    local_context_config = json.loads(json.dumps(context_config))
+    htp_config_path = os.path.abspath(f'htp_backend_extensions_{merge_index}.json')
+    context_config_path = os.path.abspath(f'context_config_{merge_index}.json')
+    local_htp_backend_extensions['graphs'][0]['graph_names'] = graphs
+    local_context_config['backend_extensions']['config_file_path'] = htp_config_path
+
+    with open(htp_config_path, 'w') as f:
+        f.write(json.dumps(local_htp_backend_extensions, indent=4))
+    with open(context_config_path, 'w') as f:
+        f.write(json.dumps(local_context_config, indent=4))
+
+    libs_str = ",".join(libs)
+    context_cmd = [
+        qnnContextBinaryGenerator,
+        "--model", libs_str,
+        "--backend", htp_so,
+        "--binary_file", dstname,
+        "--config_file", context_config_path,
+        "--output_dir", cache_dir,
+    ]
+    context_result = run_subprocess(context_cmd, retries=3)
+    if context_result.returncode != 0:
+        raise RuntimeError(f"Context binary generation failed for key={key}: {' '.join(context_cmd)}")
+
     if clean_tmp:
         for workdir in workdirs:
-            os.popen("rm -rf " + workdir).read()
+            rm_workdir_result = run_subprocess(["rm", "-rf", workdir], retries=1)
+            if rm_workdir_result.returncode != 0:
+                raise RuntimeError(f"Remove workdir failed: {workdir}")
 
+merge_keys = list(post_treat["merge"])
+merge_workers = max(1, min(os.cpu_count()//2 or 1, len(merge_keys)))
+print(f"[Merge Parallel] running {len(merge_keys)} merge task(s), max_workers={merge_workers}", flush=True)
 
-
+with concurrent.futures.ProcessPoolExecutor(
+    max_workers=merge_workers,
+    mp_context=multiprocessing.get_context("fork"),
+) as executor:
+    futures = {
+        executor.submit(process_merge, key, merge_index): key
+        for merge_index, key in enumerate(merge_keys)
+    }
+    for future in concurrent.futures.as_completed(futures):
+        key = futures[future]
+        try:
+            future.result()
+        except Exception as e:
+            raise RuntimeError(f"Merge failed for key {key}: {e}") from e


### PR DESCRIPTION
## Description

This PR accelerates the QNN offline graph export process by introducing two-level parallelization using `concurrent.futures.ProcessPoolExecutor`:

1.  **Outer-level**: Parallel execution across multiple `merge` groups (e.g., `graph_0.bin`, `graph_1.bin`).
2.  **Inner-level**: Parallel compilation of individual graphs (`srcs`) within each `merge` group.

In addition to the performance boost, the PR also refactors the subprocess execution logic for better robustness:
- Replaces unsafe `os.popen()` calls with `subprocess.run()`.
- Adds a retry mechanism for critical steps (e.g., `qnn-model-lib-generator`).
- Implements comprehensive error handling and propagation.
- Uses isolated config files for each merge task to avoid race conditions.
- Ensures reliable cleanup of temporary files and directories.

### Performance Impact
On a machine with 52 CPU cores, exporting the Qwen3-4b model with 38 graphs:
- **Before**: ~776.64 seconds
- **After**: ~98.94 seconds (**~8x speedup**)

## Module

QNN

## Type

- [ ] Feature
- [ ] Bugfix
- [x] Perf
- [x] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [x] Tested on relevant platform(s)
- [x] No unrelated format or style changes included