### PR TITLE
[LLM:Bugfix] Reset linear-attention states in `llm_demo`

### DIFF
--- a/source/backend/cpu/CPULinearAttention.cpp
+++ b/source/backend/cpu/CPULinearAttention.cpp
@@ -1,3 +1,4 @@
+//
 //  CPULinearAttention.cpp
 //  MNN
 //

--- a/source/backend/cpu/CPULinearAttention.cpp
+++ b/source/backend/cpu/CPULinearAttention.cpp
@@ -76,7 +76,9 @@ ErrorCode CPULinearAttention::onResize(const std::vector<Tensor*>& inputs, const
             if (!success) return OUT_OF_MEMORY;
             ::memset(mStateCache->mRecurrentState->host<int8_t>(), 0, batch * H * dk * dv * mBytes);
         }
-    } else if (seqLen > 1) {
+    }
+
+    if (seqLen > 1) {
         // Prefill: reset state for new sequence, UNLESS:
         // 1. Loading from prefix cache (PendingRead), or
         // 2. Reusing KV from previous inference (reuse_kv=true, i.e. previous != remove)
@@ -306,6 +308,20 @@ void CPULinearAttention::gated_delta_rule_ref(const std::vector<Tensor*>& inputs
 }
 
 ErrorCode CPULinearAttention::onExecute(const std::vector<Tensor*>& inputs, const std::vector<Tensor*>& outputs) {
+    // onResize() may be skipped when shapes are unchanged. Ensure state is reset here too.
+    int seqLen = inputs[0]->length(2);
+    if (seqLen > 1 && mMeta != nullptr && mMeta->previous == mMeta->remove) {
+        bool loadingFromDisk = (mMeta->file_flag == KVMeta::PendingRead && mMeta->file_name.size() > 0);
+        if (!loadingFromDisk) {
+            if (mStateCache->mConvState.get() != nullptr) {
+                ::memset(mStateCache->mConvState->host<int8_t>(), 0, mStateCache->mConvState->elementSize());
+            }
+            if (mStateCache->mRecurrentState.get() != nullptr) {
+                ::memset(mStateCache->mRecurrentState->host<int8_t>(), 0, mStateCache->mRecurrentState->elementSize());
+            }
+        }
+    }
+
     // Load prefix cache from disk (PendingRead)
     if (mMeta != nullptr && mMeta->file_name.size() > 0 && mMeta->file_flag == KVMeta::PendingRead) {
         int layer_index = mMeta->layer_index;

--- a/source/backend/cpu/CPULinearAttention.cpp
+++ b/source/backend/cpu/CPULinearAttention.cpp
@@ -1,4 +1,3 @@
-//
 //  CPULinearAttention.cpp
 //  MNN
 //
@@ -76,9 +75,7 @@ ErrorCode CPULinearAttention::onResize(const std::vector<Tensor*>& inputs, const
             if (!success) return OUT_OF_MEMORY;
             ::memset(mStateCache->mRecurrentState->host<int8_t>(), 0, batch * H * dk * dv * mBytes);
         }
-    }
-
-    if (seqLen > 1) {
+    } else if (seqLen > 1) {
         // Prefill: reset state for new sequence, UNLESS:
         // 1. Loading from prefix cache (PendingRead), or
         // 2. Reusing KV from previous inference (reuse_kv=true, i.e. previous != remove)

--- a/source/backend/cuda/execution/LinearAttentionExecution.cu
+++ b/source/backend/cuda/execution/LinearAttentionExecution.cu
@@ -385,6 +385,7 @@ void gated_delta_rule_prefill_kernel(
 
 CUDALinearAttention::CUDALinearAttention(Backend* backend, const MNN::Op* op) : Execution(backend) {
     mCudaBackend = static_cast<CUDABackend*>(backend);
+    mMeta = (KVMeta*)(backend->getMetaPtr());
     auto param = op->main_as_LinearAttentionParam();
     mAttentionType = param->attn_type()->str();
     mNumKHeads = param->num_k_heads();
@@ -427,11 +428,18 @@ ErrorCode CUDALinearAttention::onResize(const std::vector<Tensor*>& inputs, cons
         if (!success) { MNN_ERROR("LinearAttention: recurrentState STATIC alloc failed\n"); return OUT_OF_MEMORY; }
         cudaMemset(getDevPtr<void>(mStateCache->mRecurrentState.get()), 0, rnnStateTotal * sizeof(float));
     } else if (seqLen > 1) {
-        if (mStateCache->mConvState.get() != nullptr)
-            cudaMemset(getDevPtr<void>(mStateCache->mConvState.get()), 0,
-                       mStateCache->mConvState->elementSize() * sizeof(float));
-        cudaMemset(getDevPtr<void>(mStateCache->mRecurrentState.get()), 0,
-                   mStateCache->mRecurrentState->elementSize() * sizeof(float));
+        // Prefill: reset state for new sequence, UNLESS:
+        // 1. Loading from prefix cache (PendingRead), or
+        // 2. Reusing KV from previous inference (reuse_kv=true, i.e. previous != remove)
+        bool loadingFromDisk = (mMeta != nullptr && mMeta->file_flag == KVMeta::PendingRead && mMeta->file_name.size() > 0);
+        bool reusingKV = (mMeta != nullptr && mMeta->previous != mMeta->remove);
+        if (!loadingFromDisk && !reusingKV) {
+            if (mStateCache->mConvState.get() != nullptr)
+                cudaMemset(getDevPtr<void>(mStateCache->mConvState.get()), 0,
+                           mStateCache->mConvState->elementSize() * sizeof(float));
+            cudaMemset(getDevPtr<void>(mStateCache->mRecurrentState.get()), 0,
+                       mStateCache->mRecurrentState->elementSize() * sizeof(float));
+        }
     }
 
     int convOutSize = batch * convDim * seqLen;
@@ -451,6 +459,20 @@ ErrorCode CUDALinearAttention::onResize(const std::vector<Tensor*>& inputs, cons
 }
 
 ErrorCode CUDALinearAttention::onExecute(const std::vector<Tensor*>& inputs, const std::vector<Tensor*>& outputs) {
+    // onResize() may be skipped when shapes are unchanged. Ensure state is reset here too.
+    int seqLen = inputs[0]->length(2);
+    if (seqLen > 1 && mMeta != nullptr && mMeta->previous == mMeta->remove) {
+        bool loadingFromDisk = (mMeta->file_flag == KVMeta::PendingRead && mMeta->file_name.size() > 0);
+        if (!loadingFromDisk) {
+            if (mStateCache->mConvState.get() != nullptr) {
+                cudaMemset(getDevPtr<void>(mStateCache->mConvState.get()), 0,
+                           mStateCache->mConvState->elementSize() * sizeof(float));
+            }
+            cudaMemset(getDevPtr<void>(mStateCache->mRecurrentState.get()), 0,
+                       mStateCache->mRecurrentState->elementSize() * sizeof(float));
+        }
+    }
+
     auto qkvTensor = inputs[0];
     auto gateTensor = inputs[1];
     auto betaTensor = inputs[2];

--- a/source/backend/cuda/execution/LinearAttentionExecution.hpp
+++ b/source/backend/cuda/execution/LinearAttentionExecution.hpp
@@ -3,6 +3,7 @@
 
 #include "core/Execution.hpp"
 #include "backend/cuda/core/CUDABackend.hpp"
+#include "core/KVMeta.hpp"
 
 namespace MNN {
 namespace CUDA {
@@ -34,6 +35,7 @@ private:
 
     // Persistent state shared between prefill/decode via onClone
     std::shared_ptr<CUDAStateCache> mStateCache;
+    KVMeta* mMeta = nullptr;
 
     // Temporary GPU buffers (DYNAMIC)
     std::shared_ptr<Tensor> mConvOut;           // [B, D, L] conv output after SiLU

--- a/source/backend/metal/MetalLinearAttention.hpp
+++ b/source/backend/metal/MetalLinearAttention.hpp
@@ -13,6 +13,7 @@
 #import "MetalExecution.hpp"
 #import "MetalBackend.hpp"
 #include "MNN_generated.h"
+#include "core/KVMeta.hpp"
 
 #if MNN_METAL_ENABLED
 #ifdef MNN_SUPPORT_TRANSFORMER_FUSE
@@ -42,6 +43,8 @@ private:
 
     // Persistent state buffers shared between prefill and decode via onClone
     std::shared_ptr<MetalStateCache> mStateCache;
+
+    KVMeta* mMeta = nullptr;
 
     // Temporary buffer (DYNAMIC)
     std::shared_ptr<Tensor> mConvOut;         // [B, D, L]

--- a/source/backend/metal/MetalLinearAttention.mm
+++ b/source/backend/metal/MetalLinearAttention.mm
@@ -46,6 +46,7 @@ MetalLinearAttention::MetalLinearAttention(Backend *backend, const MNN::Op* op)
     mStateCache.reset(new MetalStateCache);
 
     auto mtbn = static_cast<MetalBackend *>(backend);
+    mMeta = (KVMeta*)(mtbn->getMetaPtr());
     auto context = (__bridge MNNMetalContext *)mtbn->context();
     mParamBuffer = [context newDeviceBuffer:sizeof(LinearAttnParam) access:CPUWriteOnly];
 
@@ -166,15 +167,21 @@ ErrorCode MetalLinearAttention::onResize(const std::vector<Tensor *> &inputs, co
         auto rnnPtr = (uint8_t*)rnnDevice.contents + TensorUtils::getDescribeOrigin(mStateCache->mRecurrentState.get())->offset;
         ::memset(rnnPtr, 0, batch * H * dk * dv * bytesPerElement);
     } else if (seqLen > 1) {
-        // Prefill (seqLen > 1): reset state for new sequence
-        if (mStateCache->mConvState.get() != nullptr) {
-            auto convDevice = (id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)mStateCache->mConvState->deviceId())->getBuffer();
-            auto convPtr = (uint8_t*)convDevice.contents + TensorUtils::getDescribeOrigin(mStateCache->mConvState.get())->offset;
-            ::memset(convPtr, 0, mStateCache->mConvState->elementSize() * bytesPerElement);
+        // Prefill: reset state for new sequence, UNLESS:
+        // 1. Loading from prefix cache (PendingRead), or
+        // 2. Reusing KV from previous inference (reuse_kv=true, i.e. previous != remove)
+        bool loadingFromDisk = (mMeta != nullptr && mMeta->file_flag == KVMeta::PendingRead && mMeta->file_name.size() > 0);
+        bool reusingKV = (mMeta != nullptr && mMeta->previous != mMeta->remove);
+        if (!loadingFromDisk && !reusingKV) {
+            if (mStateCache->mConvState.get() != nullptr) {
+                auto convDevice = (id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)mStateCache->mConvState->deviceId())->getBuffer();
+                auto convPtr = (uint8_t*)convDevice.contents + TensorUtils::getDescribeOrigin(mStateCache->mConvState.get())->offset;
+                ::memset(convPtr, 0, mStateCache->mConvState->elementSize() * bytesPerElement);
+            }
+            auto rnnDevice = (id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)mStateCache->mRecurrentState->deviceId())->getBuffer();
+            auto rnnPtr = (uint8_t*)rnnDevice.contents + TensorUtils::getDescribeOrigin(mStateCache->mRecurrentState.get())->offset;
+            ::memset(rnnPtr, 0, mStateCache->mRecurrentState->elementSize() * bytesPerElement);
         }
-        auto rnnDevice = (id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)mStateCache->mRecurrentState->deviceId())->getBuffer();
-        auto rnnPtr = (uint8_t*)rnnDevice.contents + TensorUtils::getDescribeOrigin(mStateCache->mRecurrentState.get())->offset;
-        ::memset(rnnPtr, 0, mStateCache->mRecurrentState->elementSize() * bytesPerElement);
     }
     // Decode (seqLen == 1): keep existing state untouched
 
@@ -204,6 +211,23 @@ ErrorCode MetalLinearAttention::onResize(const std::vector<Tensor *> &inputs, co
 }
 
 void MetalLinearAttention::onEncode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs, id<MTLComputeCommandEncoder> encoder) {
+    // onResize() may be skipped when shapes are unchanged. Ensure state is reset here too.
+    if (inputs[0]->length(2) > 1 && mMeta != nullptr && mMeta->previous == mMeta->remove) {
+        bool loadingFromDisk = (mMeta->file_flag == KVMeta::PendingRead && mMeta->file_name.size() > 0);
+        if (!loadingFromDisk) {
+            auto mtbn = static_cast<MetalBackend *>(backend());
+            int bytesPerElement = mtbn->useFp16InsteadFp32() ? 2 : 4;
+            if (mStateCache->mConvState.get() != nullptr) {
+                auto convDevice = (id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)mStateCache->mConvState->deviceId())->getBuffer();
+                auto convPtr = (uint8_t*)convDevice.contents + TensorUtils::getDescribeOrigin(mStateCache->mConvState.get())->offset;
+                ::memset(convPtr, 0, mStateCache->mConvState->elementSize() * bytesPerElement);
+            }
+            auto rnnDevice = (id<MTLBuffer>)((MetalRuntimeAllocator::MetalBufferAlloc *)mStateCache->mRecurrentState->deviceId())->getBuffer();
+            auto rnnPtr = (uint8_t*)rnnDevice.contents + TensorUtils::getDescribeOrigin(mStateCache->mRecurrentState.get())->offset;
+            ::memset(rnnPtr, 0, mStateCache->mRecurrentState->elementSize() * bytesPerElement);
+        }
+    }
+
     auto qkv = inputs[0];
     int batch = qkv->length(0);
     int convDim = qkv->length(1);

--- a/source/backend/opencl/execution/buffer/LinearAttentionBufExecution.cpp
+++ b/source/backend/opencl/execution/buffer/LinearAttentionBufExecution.cpp
@@ -18,6 +18,7 @@ namespace OpenCL {
 LinearAttentionBufExecution::LinearAttentionBufExecution(const MNN::Op *op, Backend *backend)
     : CommonExecution(backend, op) {
     mOpenCLBackend = static_cast<OpenCLBackend *>(backend);
+    mMeta = (KVMeta*)(backend->getMetaPtr());
     auto param = op->main_as_LinearAttentionParam();
     mAttentionType = param->attn_type()->str();
     mNumKHeads = param->num_k_heads();
@@ -88,25 +89,31 @@ ErrorCode LinearAttentionBufExecution::onResize(const std::vector<Tensor *> &inp
             }
         }
     } else if (seqLen > 1) {
-        // Prefill (seqLen > 1): reset state for new sequence
-        {
-            cl_int res;
-            int bufferBytes = mStateCache->mRecurrentState->elementSize() * bytesPerElement;
-            void* mapPtr = runtime->commandQueue().enqueueMapBuffer(
-                openCLBuffer(mStateCache->mRecurrentState.get()), true, CL_MAP_WRITE, 0, bufferBytes, nullptr, nullptr, &res);
-            if (mapPtr != nullptr && res == CL_SUCCESS) {
-                ::memset(mapPtr, 0, bufferBytes);
-                runtime->commandQueue().enqueueUnmapMemObject(openCLBuffer(mStateCache->mRecurrentState.get()), mapPtr);
+        // Prefill: reset state for new sequence, UNLESS:
+        // 1. Loading from prefix cache (PendingRead), or
+        // 2. Reusing KV from previous inference (reuse_kv=true, i.e. previous != remove)
+        bool loadingFromDisk = (mMeta != nullptr && mMeta->file_flag == KVMeta::PendingRead && mMeta->file_name.size() > 0);
+        bool reusingKV = (mMeta != nullptr && mMeta->previous != mMeta->remove);
+        if (!loadingFromDisk && !reusingKV) {
+            {
+                cl_int res;
+                int bufferBytes = mStateCache->mRecurrentState->elementSize() * bytesPerElement;
+                void* mapPtr = runtime->commandQueue().enqueueMapBuffer(
+                    openCLBuffer(mStateCache->mRecurrentState.get()), true, CL_MAP_WRITE, 0, bufferBytes, nullptr, nullptr, &res);
+                if (mapPtr != nullptr && res == CL_SUCCESS) {
+                    ::memset(mapPtr, 0, bufferBytes);
+                    runtime->commandQueue().enqueueUnmapMemObject(openCLBuffer(mStateCache->mRecurrentState.get()), mapPtr);
+                }
             }
-        }
-        if (mStateCache->mConvState.get() != nullptr) {
-            cl_int res;
-            int bufferBytes = mStateCache->mConvState->elementSize() * bytesPerElement;
-            void* mapPtr = runtime->commandQueue().enqueueMapBuffer(
-                openCLBuffer(mStateCache->mConvState.get()), true, CL_MAP_WRITE, 0, bufferBytes, nullptr, nullptr, &res);
-            if (mapPtr != nullptr && res == CL_SUCCESS) {
-                ::memset(mapPtr, 0, bufferBytes);
-                runtime->commandQueue().enqueueUnmapMemObject(openCLBuffer(mStateCache->mConvState.get()), mapPtr);
+            if (mStateCache->mConvState.get() != nullptr) {
+                cl_int res;
+                int bufferBytes = mStateCache->mConvState->elementSize() * bytesPerElement;
+                void* mapPtr = runtime->commandQueue().enqueueMapBuffer(
+                    openCLBuffer(mStateCache->mConvState.get()), true, CL_MAP_WRITE, 0, bufferBytes, nullptr, nullptr, &res);
+                if (mapPtr != nullptr && res == CL_SUCCESS) {
+                    ::memset(mapPtr, 0, bufferBytes);
+                    runtime->commandQueue().enqueueUnmapMemObject(openCLBuffer(mStateCache->mConvState.get()), mapPtr);
+                }
             }
         }
     }
@@ -718,9 +725,40 @@ ErrorCode LinearAttentionBufExecution::onExecuteChunkedPrefill(const std::vector
 }
 
 ErrorCode LinearAttentionBufExecution::onExecute(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) {
+    // onResize() may be skipped when shapes are unchanged. Ensure state is reset here too.
+    int seqLen = inputs[0]->length(2);
+    if (seqLen > 1 && mMeta != nullptr && mMeta->previous == mMeta->remove) {
+        bool loadingFromDisk = (mMeta->file_flag == KVMeta::PendingRead && mMeta->file_name.size() > 0);
+        if (!loadingFromDisk) {
+            auto runtime = mOpenCLBackend->getOpenCLRuntime();
+            int bytesPerElement = mOpenCLBackend->fpBytes();
+            if (mStateCache->mConvState.get() != nullptr) {
+                cl_int res;
+                int bufferBytes = mStateCache->mConvState->elementSize() * bytesPerElement;
+                void* mapPtr = runtime->commandQueue().enqueueMapBuffer(
+                    openCLBuffer(mStateCache->mConvState.get()), true, CL_MAP_WRITE, 0, bufferBytes, nullptr, nullptr, &res);
+                if (mapPtr != nullptr && res == CL_SUCCESS) {
+                    ::memset(mapPtr, 0, bufferBytes);
+                    runtime->commandQueue().enqueueUnmapMemObject(openCLBuffer(mStateCache->mConvState.get()), mapPtr);
+                }
+            }
+            {
+                cl_int res;
+                int bufferBytes = mStateCache->mRecurrentState->elementSize() * bytesPerElement;
+                void* mapPtr = runtime->commandQueue().enqueueMapBuffer(
+                    openCLBuffer(mStateCache->mRecurrentState.get()), true, CL_MAP_WRITE, 0, bufferBytes, nullptr, nullptr, &res);
+                if (mapPtr != nullptr && res == CL_SUCCESS) {
+                    ::memset(mapPtr, 0, bufferBytes);
+                    runtime->commandQueue().enqueueUnmapMemObject(openCLBuffer(mStateCache->mRecurrentState.get()), mapPtr);
+                }
+            }
+        }
+    }
+
     if (mUseChunkedPrefill) {
         return onExecuteChunkedPrefill(inputs, outputs);
     }
+
     auto runtime = mOpenCLBackend->getOpenCLRuntime();
     int convStateSize = inputs[3]->length(2) - 1;
 

--- a/source/backend/opencl/execution/buffer/LinearAttentionBufExecution.hpp
+++ b/source/backend/opencl/execution/buffer/LinearAttentionBufExecution.hpp
@@ -13,6 +13,7 @@
 
 #include "backend/opencl/execution/image/CommonExecution.hpp"
 #include "core/OpCommonUtils.hpp"
+#include "core/KVMeta.hpp"
 
 namespace MNN {
 namespace OpenCL {
@@ -47,6 +48,7 @@ private:
 
     // Persistent state buffers shared between prefill and decode via onClone
     std::shared_ptr<OpenCLStateCache> mStateCache;
+    KVMeta* mMeta = nullptr;
     // Temporary conv output: [B * D * L]
     std::shared_ptr<Tensor> mConvOut;
 

--- a/source/backend/vulkan/buffer/execution/VulkanLinearAttention.cpp
+++ b/source/backend/vulkan/buffer/execution/VulkanLinearAttention.cpp
@@ -234,7 +234,8 @@ ErrorCode VulkanLinearAttention::onEncode(const std::vector<Tensor*>& inputs, co
         return code;
     }
     const bool reusingKV = (nullptr != mMeta && mMeta->previous != mMeta->remove);
-    if (seqLen > 1 && !reusingKV) {
+    const bool loadingFromDisk = (mMeta != nullptr && mMeta->file_flag == KVMeta::PendingRead && mMeta->file_name.size() > 0);
+    if (seqLen > 1 && !reusingKV && !loadingFromDisk) {
         code = resetPersistentState(vkBn);
         if (NO_ERROR != code) {
             return code;

--- a/source/backend/vulkan/buffer/execution/VulkanLinearAttention.hpp
+++ b/source/backend/vulkan/buffer/execution/VulkanLinearAttention.hpp
@@ -10,7 +10,6 @@
 #define VulkanLinearAttention_hpp
 
 #include "VulkanBasicExecution.hpp"
-#include "core/KVMeta.hpp"
 
 #ifdef MNN_SUPPORT_TRANSFORMER_FUSE
 

--- a/source/backend/vulkan/buffer/execution/VulkanLinearAttention.hpp
+++ b/source/backend/vulkan/buffer/execution/VulkanLinearAttention.hpp
@@ -10,6 +10,7 @@
 #define VulkanLinearAttention_hpp
 
 #include "VulkanBasicExecution.hpp"
+#include "core/KVMeta.hpp"
 
 #ifdef MNN_SUPPORT_TRANSFORMER_FUSE
 

--- a/transformers/llm/engine/demo/llm_demo.cpp
+++ b/transformers/llm/engine/demo/llm_demo.cpp
@@ -250,6 +250,8 @@ void chat(Llm* llm) {
         }
         if (user_str == "/reset") {
             llm->reset();
+            messages.clear();
+            messages.emplace_back("system", "You are a helpful assistant.");
             std::cout << "\nA: reset done." << std::endl;
             continue;
         }


### PR DESCRIPTION
## Description

Linear-attention introduced from Qwen3.5 don't clear `conv_state` and `recurrent_state` when calling `/reset` in llm_demo. In this case, qwen3.5 still has history info stored in states after calling `/reset`.

This pr clears all `conv_state` and `recurrent_state` in all backends after llm is reset. Plus, we also clear all history messages in `llm_demo` after reseting.

### With reset

<details><summary>After reseting, llm have no memory about full context.</summary>
<p>




```txt
User: 翻译这段话: I could be bounded in a nutshell and count myself a king of infinite space

A: 这句话的中文翻译如下：

我可以将其概括为有限，并且我自己可以被称为“无限空间”中的“国王”。

或者更地道地表达为：
我可以有限度地概括，我自己可以成为“无限空间”中的“国王”。

**原句分析：**
*   **I could be bounded in a nutshell and count myself a king of infinite space**
    *   **bounded in a nutshell**: 用一句话或有限个词来概括（有限度）。
    *   **count myself a king of infinite space**: 我自己可以被称为“无限空间”中的“国王”。

User: /reset

A: reset done.

User: 总结上下文

A: 作为一个人工智能助手，我无法直接访问或“总结”您之前提供的对话上下文。我的训练数据是基于过去数千条对话的总结，但**我目前无法访问、查看或引用您之前的任何对话历史**。

为了更准确地帮助到您，请您：
1. **复制并粘贴您之前的对话内容**（例如：之前的提问、回复或之前的对话记录）。
2. 或者告诉我您希望总结什么内容（例如：需要总结的项目、文档、技术文档等）。

一旦您提供上下文，我会立即为您总结，并根据内容为您提供更精准的帮助！ 😊

User: /exit
```


</p>
</details> 

### Without reset

<details><summary>Without reseting, llm could still summarize the context.</summary>
<p>

```txt
User: 翻译这段话:I could be bounded in a nutshell and count myself a king of infinite space

A: 这句话的英文原文是：

"I could be bounded in a nutshell and count myself a king of infinite space."

以下是这句话的中文翻译：

我或许可以用一个简洁而精炼的方式表达，并且我本可以自称是无限空间里的王。

User: /reset

A: reset done.

User: 总结上下文

A: 根据上下文，这段文本主要是在探讨一种关于空间感或无限性的概念（结合前一句提到的“无限空间”和“无限性”）。

以下是总结：

1.  **核心概念**：作者探讨了一种通过“简洁而精炼”的比喻来描述无限性（如“一个简洁而精炼的比喻”）以及将其量化（“量化”）无限空间的能力。
2.  **核心观点**：作者试图通过一个具体的例子来说明这种无限性的概念，并以此作为论点（“我或许可以用一个简洁而精炼的比喻……"）。
3.  **语境氛围**：整体语气似乎是在探讨一种哲学或数学层面的无限性概念，强调这种概念的精确性和可描述性（“一个简洁而精炼的比喻”和“量化”）。

简而言之，这是在讨论如何通过一种比喻性的方式来定义或量化无限的性质。

User: /exit
```


</p>
</details> 

## Module

<!-- Which module does this PR affect? e.g. LLM, CPU, Metal, CUDA, OpenCL, Core, Infra -->

- `LLM`: reset messages
- `CPU` / `Metal` / `CUDA` / `OpenCL`: reset states when `seqLen > 1 && mMeta->previous == mMeta->remove` 

## Type

- [ ] Feature
- [x] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [ ] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [ ] Tested on relevant platform(s)
- [x] No unrelated format or style changes included
