### PR TITLE
RVV: Optimize common opt functions

### DIFF
--- a/source/backend/cpu/compute/CommonOptFunction.cpp
+++ b/source/backend/cpu/compute/CommonOptFunction.cpp
@@ -33,6 +33,27 @@ using Vec = MNN::Math::Vec<float, 4>;
 #endif
 #endif
 
+#ifdef MNN_USE_RVV
+extern void MNNAbsMaxFP32_RVV(const float* source, float* absmax, size_t src_depth_quad, size_t realSize, int pack);
+extern void MNNAccumulateSequenceNumber_RVV(float* dst, const float* src, int size);
+extern void MNNAsyQuantFunc_RVV(int8_t* dst, const float* src, float* qscale, float* qbias, const size_t* info);
+extern void MNNAsyQuantInfo_FP32_RVV(float* scale, float* bias, float* qscale, float* qbias, float* dstMin,
+                                     float* dstMax, const float* src, const size_t* info);
+extern void MNNDynamicQuantFP32_RVV(const float* src, int8_t* dst, const float* scale, size_t src_depth_quad,
+                                    size_t realSize, int pack, const float* bias);
+extern void MNNPackedMatMul_int8_RVV(float* C, const float* A, const float* B, const size_t* parameter,
+                                     const float* postParameters, const float* bias, const float* k, const float* b);
+extern void MNNPackedMatMulRemain_int8_RVV(float* C, const float* A, const float* B, size_t eSize,
+                                           const size_t* parameter, const float* postParameters, const float* bias,
+                                           const float* k, const float* b);
+extern void MNNReorderWeightInt4_RVV(uint8_t* dest, const uint8_t* source, int32_t* shape, size_t size,
+                                     float* kernelsum);
+extern void MNNSumByAxisLForMatmul_A_RVV(float* dest, int8_t* source, const float* dequantScale,
+                                         ssize_t realDstCount, SumByAxisParams sumParams);
+extern void MNNSumWeightInt8_RVV(float* kernelsum, int8_t* source, size_t outside, size_t reduceAxis, size_t hP,
+                                 size_t lP);
+#endif
+
 #ifndef MNN_USE_SSE
 void MNNInt8ToInt16(int16_t* dest, const int8_t* source, size_t count) {
     // Should not be called
@@ -4759,6 +4780,24 @@ void MNNCoreFunctionInit() {
 #endif
 #endif
 
+#if defined(__riscv) && defined(MNN_USE_RVV)
+    if (gCoreFunction->supportRVV) {
+        gCoreFunction->MNNAccumulateSequenceNumber = MNNAccumulateSequenceNumber_RVV;
+        gCoreFunction->MNNSumByAxisLForMatmul_A = MNNSumByAxisLForMatmul_A_RVV;
+        gCoreFunction->MNNReorderWeightInt4 = MNNReorderWeightInt4_RVV;
+        gCoreFunction->MNNSumWeightInt8 = MNNSumWeightInt8_RVV;
+#ifdef MNN_CPU_WEIGHT_DEQUANT_GEMM
+        gCoreFunction->MNNPackedMatMul_int8 = MNNPackedMatMul_int8_RVV;
+        gCoreFunction->MNNPackedMatMulRemain_int8 = MNNPackedMatMulRemain_int8_RVV;
+#endif
+#ifdef MNN_LOW_MEMORY
+        gCoreFunction->MNNAbsMax = MNNAbsMaxFP32_RVV;
+        gCoreFunction->MNNDynamicQuant = MNNDynamicQuantFP32_RVV;
+        gCoreFunction->MNNAsyQuantFunc = MNNAsyQuantFunc_RVV;
+        gCoreFunction->MNNAsyQuantInfo = MNNAsyQuantInfo_FP32_RVV;
+#endif
+    }
+#endif
 
 #ifdef __aarch64__
 #ifdef MNN_SME2

--- a/source/backend/cpu/riscv/rvv/MNNAbsMaxFP32.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNAbsMaxFP32.cpp
@@ -1,8 +1,9 @@
 #include <riscv_vector.h>
 void MNNAbsMaxFP32(const float* source, float* absmax, size_t src_depth_quad, size_t realSize, int pack) {
     size_t stride = pack * realSize;
+    const size_t vlmax = __riscv_vsetvlmax_e32m1();
     for (size_t i = 0; i < realSize; ++i) {
-        vfloat32m1_t max_v = __riscv_vfmv_v_f_f32m1(0.f, 1);
+        vfloat32m1_t max_v = __riscv_vfmv_v_f_f32m1(0.f, vlmax);
         for (size_t c = 0; c < src_depth_quad; ++c) {
             const float* src = source + c * stride + i * pack;
             size_t n = pack;
@@ -14,8 +15,7 @@ void MNNAbsMaxFP32(const float* source, float* absmax, size_t src_depth_quad, si
                 max_v = __riscv_vfmax_vv_f32m1(max_v, v_abs, vl);
             }
         }
-        size_t vl = __riscv_vsetvl_e32m1(pack);
-        vfloat32m1_t res = __riscv_vfredmax_vs_f32m1_f32m1(max_v, __riscv_vfmv_s_f_f32m1(0.0f, vl), vl);
+        vfloat32m1_t res = __riscv_vfredmax_vs_f32m1_f32m1(max_v, __riscv_vfmv_s_f_f32m1(0.0f, vlmax), vlmax);
         float absmaxVal = __riscv_vfmv_f_s_f32m1_f32(res);
         absmax[i] = absmaxVal;
     }

--- a/source/backend/cpu/riscv/rvv/MNNAbsMaxFP32.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNAbsMaxFP32.cpp
@@ -1,0 +1,22 @@
+#include <riscv_vector.h>
+void MNNAbsMaxFP32(const float* source, float* absmax, size_t src_depth_quad, size_t realSize, int pack) {
+    size_t stride = pack * realSize;
+    for (size_t i = 0; i < realSize; ++i) {
+        vfloat32m1_t max_v = __riscv_vfmv_v_f_f32m1(0.f, 1);
+        for (size_t c = 0; c < src_depth_quad; ++c) {
+            const float* src = source + c * stride + i * pack;
+            size_t n = pack;
+            size_t vl;
+            for (; n > 0; n -= vl, src += vl) {
+                vl = __riscv_vsetvl_e32m1(n);
+                vfloat32m1_t v = __riscv_vle32_v_f32m1(src, vl);
+                vfloat32m1_t v_abs = __riscv_vfabs_v_f32m1(v, vl);
+                max_v = __riscv_vfmax_vv_f32m1(max_v, v_abs, vl);
+            }
+        }
+        size_t vl = __riscv_vsetvl_e32m1(pack);
+        vfloat32m1_t res = __riscv_vfredmax_vs_f32m1_f32m1(max_v, __riscv_vfmv_s_f_f32m1(0.0f, vl), vl);
+        float absmaxVal = __riscv_vfmv_f_s_f32m1_f32(res);
+        absmax[i] = absmaxVal;
+    }
+}

--- a/source/backend/cpu/riscv/rvv/MNNAbsMaxFP32.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNAbsMaxFP32.cpp
@@ -1,5 +1,5 @@
 #include <riscv_vector.h>
-void MNNAbsMaxFP32(const float* source, float* absmax, size_t src_depth_quad, size_t realSize, int pack) {
+void MNNAbsMaxFP32_RVV(const float* source, float* absmax, size_t src_depth_quad, size_t realSize, int pack) {
     size_t stride = pack * realSize;
     const size_t vlmax = __riscv_vsetvlmax_e32m1();
     for (size_t i = 0; i < realSize; ++i) {

--- a/source/backend/cpu/riscv/rvv/MNNAccumulateSequenceNumber.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNAccumulateSequenceNumber.cpp
@@ -1,7 +1,6 @@
 #include <riscv_vector.h>
 void MNNAccumulateSequenceNumber(float* dst, const float* src, int size) {
-    float sum = 0.0f;
-    size_t vl = __riscv_vsetvl_e32m1(4);
+    size_t vl = __riscv_vsetvlmax_e32m1();
     vfloat32m1_t v_sum = __riscv_vfmv_v_f_f32m1(0.0f, vl);
     int n = size;
     for (; n > 0;) {
@@ -11,8 +10,8 @@ void MNNAccumulateSequenceNumber(float* dst, const float* src, int size) {
         n -= vl;
         src += vl;
     }
-    vl = __riscv_vsetvl_e32m1(4);
+    vl = __riscv_vsetvlmax_e32m1();
     vfloat32m1_t v_total = __riscv_vfredusum_vs_f32m1_f32m1(v_sum, __riscv_vfmv_s_f_f32m1(0.0f, vl), vl);
-    sum = __riscv_vfmv_f_s_f32m1_f32(v_total);
+    float sum = __riscv_vfmv_f_s_f32m1_f32(v_total);
     *dst = sum;
 }

--- a/source/backend/cpu/riscv/rvv/MNNAccumulateSequenceNumber.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNAccumulateSequenceNumber.cpp
@@ -1,5 +1,5 @@
 #include <riscv_vector.h>
-void MNNAccumulateSequenceNumber(float* dst, const float* src, int size) {
+void MNNAccumulateSequenceNumber_RVV(float* dst, const float* src, int size) {
     size_t vl = __riscv_vsetvlmax_e32m1();
     vfloat32m1_t v_sum = __riscv_vfmv_v_f_f32m1(0.0f, vl);
     int n = size;

--- a/source/backend/cpu/riscv/rvv/MNNAccumulateSequenceNumber.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNAccumulateSequenceNumber.cpp
@@ -1,0 +1,18 @@
+#include <riscv_vector.h>
+void MNNAccumulateSequenceNumber(float* dst, const float* src, int size) {
+    float sum = 0.0f;
+    size_t vl = __riscv_vsetvl_e32m1(4);
+    vfloat32m1_t v_sum = __riscv_vfmv_v_f_f32m1(0.0f, vl);
+    int n = size;
+    for (; n > 0;) {
+        vl = __riscv_vsetvl_e32m1(n);
+        vfloat32m1_t v_src = __riscv_vle32_v_f32m1(src, vl);
+        v_sum = __riscv_vfadd_vv_f32m1(v_sum, v_src, vl);
+        n -= vl;
+        src += vl;
+    }
+    vl = __riscv_vsetvl_e32m1(4);
+    vfloat32m1_t v_total = __riscv_vfredusum_vs_f32m1_f32m1(v_sum, __riscv_vfmv_s_f_f32m1(0.0f, vl), vl);
+    sum = __riscv_vfmv_f_s_f32m1_f32(v_total);
+    *dst = sum;
+}

--- a/source/backend/cpu/riscv/rvv/MNNAsyQuantFunc.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNAsyQuantFunc.cpp
@@ -1,6 +1,6 @@
 #include <riscv_vector.h>
 
-void MNNAsyQuantFunc(int8_t* dst, const float* src, float* qscale, float* qbias, const size_t* info) {
+void MNNAsyQuantFunc_RVV(int8_t* dst, const float* src, float* qscale, float* qbias, const size_t* info) {
     auto blockNum = info[0];
     auto EP = info[1];
     auto LP = info[2];
@@ -14,7 +14,7 @@ void MNNAsyQuantFunc(int8_t* dst, const float* src, float* qscale, float* qbias,
     const int int8_max = 127;
     const size_t RV_RNU = 0x4;
 
-    const int EP_TILE = 4; // ?? �ɵ���4��8��
+    const int EP_TILE = 4;
 
     for (int n = 0; n < kernelsize; ++n) {
         for (int bk = 0; bk < blockNum; ++bk) {
@@ -26,11 +26,9 @@ void MNNAsyQuantFunc(int8_t* dst, const float* src, float* qscale, float* qbias,
                 const float* srcBase = src + base;
                 int8_t* dstBase = dst + base;
 
-                // ?? EP �ֿ�
                 for (int i = 0; i < EP; i += EP_TILE) {
                     int tile = (i + EP_TILE <= EP) ? EP_TILE : (EP - i);
 
-                    // Ԥȡ��һ�飨pipeline��
                     __builtin_prefetch(srcBase + (i + EP_TILE) * LP, 0, 1);
 
                     for (int t = 0; t < tile; ++t) {
@@ -42,7 +40,6 @@ void MNNAsyQuantFunc(int8_t* dst, const float* src, float* qscale, float* qbias,
 
                         int j = 0;
 
-                        // ?? ������ѭ��
                         while (j < LP) {
                             size_t vl = __riscv_vsetvl_e32m4(LP - j);
 

--- a/source/backend/cpu/riscv/rvv/MNNAsyQuantFunc.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNAsyQuantFunc.cpp
@@ -14,7 +14,7 @@ void MNNAsyQuantFunc(int8_t* dst, const float* src, float* qscale, float* qbias,
     const int int8_max = 127;
     const size_t RV_RNU = 0x4;
 
-    const int EP_TILE = 4; // ?? ¿Éµ÷£¨4»ò8£©
+    const int EP_TILE = 4; // ?? ï¿½Éµï¿½ï¿½ï¿½4ï¿½ï¿½8ï¿½ï¿½
 
     for (int n = 0; n < kernelsize; ++n) {
         for (int bk = 0; bk < blockNum; ++bk) {
@@ -26,11 +26,11 @@ void MNNAsyQuantFunc(int8_t* dst, const float* src, float* qscale, float* qbias,
                 const float* srcBase = src + base;
                 int8_t* dstBase = dst + base;
 
-                // ?? EP ·Ö¿é
+                // ?? EP ï¿½Ö¿ï¿½
                 for (int i = 0; i < EP; i += EP_TILE) {
                     int tile = (i + EP_TILE <= EP) ? EP_TILE : (EP - i);
 
-                    // Ô¤È¡ÏÂÒ»¿é£¨pipeline£©
+                    // Ô¤È¡ï¿½ï¿½Ò»ï¿½é£¨pipelineï¿½ï¿½
                     __builtin_prefetch(srcBase + (i + EP_TILE) * LP, 0, 1);
 
                     for (int t = 0; t < tile; ++t) {
@@ -42,7 +42,7 @@ void MNNAsyQuantFunc(int8_t* dst, const float* src, float* qscale, float* qbias,
 
                         int j = 0;
 
-                        // ?? Ö÷ÏòÁ¿Ñ­»·
+                        // ?? ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ñ­ï¿½ï¿½
                         while (j < LP) {
                             size_t vl = __riscv_vsetvl_e32m4(LP - j);
 

--- a/source/backend/cpu/riscv/rvv/MNNAsyQuantFunc.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNAsyQuantFunc.cpp
@@ -1,0 +1,71 @@
+#include <riscv_vector.h>
+
+void MNNAsyQuantFunc(int8_t* dst, const float* src, float* qscale, float* qbias, const size_t* info) {
+    auto blockNum = info[0];
+    auto EP = info[1];
+    auto LP = info[2];
+    auto kernelsize = info[5];
+    auto blockLU = info[6];
+
+    auto stride0 = blockNum * blockLU * EP * LP;
+    auto stride1 = blockLU * EP * LP;
+
+    const int int8_min = -128;
+    const int int8_max = 127;
+    const size_t RV_RNU = 0x4;
+
+    const int EP_TILE = 4; // ?? 可调（4或8）
+
+    for (int n = 0; n < kernelsize; ++n) {
+        for (int bk = 0; bk < blockNum; ++bk) {
+            const float* scalePtr = qscale + bk * EP;
+            const float* biasPtr = qbias + bk * EP;
+
+            for (int k = 0; k < blockLU; ++k) {
+                int base = n * stride0 + bk * stride1 + k * EP * LP;
+                const float* srcBase = src + base;
+                int8_t* dstBase = dst + base;
+
+                // ?? EP 分块
+                for (int i = 0; i < EP; i += EP_TILE) {
+                    int tile = (i + EP_TILE <= EP) ? EP_TILE : (EP - i);
+
+                    // 预取下一块（pipeline）
+                    __builtin_prefetch(srcBase + (i + EP_TILE) * LP, 0, 1);
+
+                    for (int t = 0; t < tile; ++t) {
+                        float scaleVal = scalePtr[i + t];
+                        float biasVal = biasPtr[i + t];
+
+                        const float* srcZ = srcBase + (i + t) * LP;
+                        int8_t* dstZ = dstBase + (i + t) * LP;
+
+                        int j = 0;
+
+                        // ?? 主向量循环
+                        while (j < LP) {
+                            size_t vl = __riscv_vsetvl_e32m4(LP - j);
+
+                            vfloat32m4_t v = __riscv_vle32_v_f32m4(srcZ + j, vl);
+
+                            v = __riscv_vfmul_vf_f32m4(v, scaleVal, vl);
+                            v = __riscv_vfadd_vf_f32m4(v, biasVal, vl);
+
+                            vint32m4_t vi = __riscv_vfcvt_x_f_v_i32m4_rm(v, RV_RNU, vl);
+
+                            vi = __riscv_vmax_vx_i32m4(vi, int8_min, vl);
+                            vi = __riscv_vmin_vx_i32m4(vi, int8_max, vl);
+
+                            vint16m2_t v16 = __riscv_vncvt_x_x_w_i16m2(vi, vl);
+                            vint8m1_t v8 = __riscv_vncvt_x_x_w_i8m1(v16, vl);
+
+                            __riscv_vse8_v_i8m1(dstZ + j, v8, vl);
+
+                            j += vl;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/source/backend/cpu/riscv/rvv/MNNAsyQuantInfo_FP32.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNAsyQuantInfo_FP32.cpp
@@ -14,10 +14,8 @@ static inline void MNNCountMaxMinValue_RVV(const float* src, float* minVal, floa
     while (offset < size) {
         const size_t vl = __riscv_vsetvl_e32m8(size - offset);
         const vfloat32m8_t value = __riscv_vle32_v_f32m8(src + offset, vl);
-        const vfloat32m1_t minReduce =
-            __riscv_vfredmin_vs_f32m8_f32m1(value, __riscv_vfmv_s_f_f32m1(localMin, 1), vl);
-        const vfloat32m1_t maxReduce =
-            __riscv_vfredmax_vs_f32m8_f32m1(value, __riscv_vfmv_s_f_f32m1(localMax, 1), vl);
+        const vfloat32m1_t minReduce = __riscv_vfredmin_vs_f32m8_f32m1(value, __riscv_vfmv_s_f_f32m1(localMin, 1), vl);
+        const vfloat32m1_t maxReduce = __riscv_vfredmax_vs_f32m8_f32m1(value, __riscv_vfmv_s_f_f32m1(localMax, 1), vl);
         localMin = __riscv_vfmv_f_s_f32m1_f32(minReduce);
         localMax = __riscv_vfmv_f_s_f32m1_f32(maxReduce);
         offset += vl;
@@ -26,8 +24,8 @@ static inline void MNNCountMaxMinValue_RVV(const float* src, float* minVal, floa
     *maxVal = localMax;
 }
 
-void MNNAsyQuantInfo_FP32(float* scale, float* bias, float* qscale, float* qbias, float* dstMin, float* dstMax,
-                          const float* src, const size_t* info) {
+void MNNAsyQuantInfo_FP32_RVV(float* scale, float* bias, float* qscale, float* qbias, float* dstMin, float* dstMax,
+                              const float* src, const size_t* info) {
     const size_t blockNum = info[0];
     const size_t plane = info[1];
     const size_t innerSide = info[2];

--- a/source/backend/cpu/riscv/rvv/MNNAsyQuantInfo_FP32.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNAsyQuantInfo_FP32.cpp
@@ -1,0 +1,118 @@
+#include <riscv_vector.h>
+#include <cfloat>
+#include <cmath>
+#include <cstddef>
+
+#ifndef ALIMIN
+#define ALIMIN(a, b) ((a) < (b) ? (a) : (b))
+#endif
+
+static inline void MNNCountMaxMinValue_RVV(const float* src, float* minVal, float* maxVal, size_t size) {
+    float localMin = FLT_MAX;
+    float localMax = -FLT_MAX;
+    size_t offset = 0;
+    while (offset < size) {
+        const size_t vl = __riscv_vsetvl_e32m8(size - offset);
+        const vfloat32m8_t value = __riscv_vle32_v_f32m8(src + offset, vl);
+        const vfloat32m1_t minReduce =
+            __riscv_vfredmin_vs_f32m8_f32m1(value, __riscv_vfmv_s_f_f32m1(localMin, 1), vl);
+        const vfloat32m1_t maxReduce =
+            __riscv_vfredmax_vs_f32m8_f32m1(value, __riscv_vfmv_s_f_f32m1(localMax, 1), vl);
+        localMin = __riscv_vfmv_f_s_f32m1_f32(minReduce);
+        localMax = __riscv_vfmv_f_s_f32m1_f32(maxReduce);
+        offset += vl;
+    }
+    *minVal = localMin;
+    *maxVal = localMax;
+}
+
+void MNNAsyQuantInfo_FP32(float* scale, float* bias, float* qscale, float* qbias, float* dstMin, float* dstMax,
+                          const float* src, const size_t* info) {
+    const size_t blockNum = info[0];
+    const size_t plane = info[1];
+    const size_t innerSide = info[2];
+    const size_t DST_XUNIT = info[3];
+    const size_t kernelsize = info[5];
+    const size_t blockLU = info[6];
+    const size_t stride0 = blockNum * blockLU * plane * innerSide;
+    const size_t stride1 = blockLU * plane * innerSide;
+    const size_t planeStride = plane * innerSide;
+
+    if (info[7] == 1) {
+        float maxval = 0.0f;
+        float minval = 0.0f;
+        MNNCountMaxMinValue_RVV(src, &minval, &maxval, kernelsize * stride0);
+        if (info[8] == 1 && (maxval - minval) > 1e-7f) {
+            if (minval > 0.0f) {
+                minval = 0.0f;
+            } else if (maxval < 0.0f) {
+                maxval = 0.0f;
+            }
+        }
+        const float range = maxval - minval;
+        if (range <= 1e-7f) {
+            scale[0] = 1.0f;
+            qscale[0] = 1.0f;
+            qbias[0] = -maxval;
+            bias[0] = maxval;
+        } else {
+            qscale[0] = 255.0f / range;
+            scale[0] = range / 255.0f;
+            qbias[0] = -minval * 255.0f / range - 128.0f;
+            bias[0] = minval + 128.0f * range / 255.0f;
+        }
+        return;
+    }
+
+    for (size_t i = 0; i < plane; ++i) {
+        for (size_t bk = 0; bk < blockNum; ++bk) {
+            const float* base = src + i * innerSide + bk * stride1;
+            float localMin = FLT_MAX;
+            float localMax = -FLT_MAX;
+            for (size_t n = 0; n < kernelsize; ++n) {
+                const float* kernelBase = base + n * stride0;
+                for (size_t k = 0; k < blockLU; ++k) {
+                    const float* row = kernelBase + k * planeStride;
+                    size_t j = 0;
+                    while (j < innerSide) {
+                        const size_t vl = __riscv_vsetvl_e32m8(innerSide - j);
+                        const vfloat32m8_t value = __riscv_vle32_v_f32m8(row + j, vl);
+                        const vfloat32m1_t minReduce =
+                            __riscv_vfredmin_vs_f32m8_f32m1(value, __riscv_vfmv_s_f_f32m1(localMin, 1), vl);
+                        const vfloat32m1_t maxReduce =
+                            __riscv_vfredmax_vs_f32m8_f32m1(value, __riscv_vfmv_s_f_f32m1(localMax, 1), vl);
+                        localMin = __riscv_vfmv_f_s_f32m1_f32(minReduce);
+                        localMax = __riscv_vfmv_f_s_f32m1_f32(maxReduce);
+                        j += vl;
+                    }
+                }
+            }
+            const size_t qIndex = i + bk * plane;
+            dstMin[qIndex] = localMin;
+            dstMax[qIndex] = localMax;
+        }
+    }
+
+    for (size_t i = 0; i < plane; ++i) {
+        const size_t step = ALIMIN(DST_XUNIT, plane - (i / DST_XUNIT) * DST_XUNIT);
+        const size_t scaleBase = (i / DST_XUNIT) * DST_XUNIT * blockNum + (i % DST_XUNIT);
+        for (size_t k = 0; k < blockNum; ++k) {
+            const size_t scaleIndex = scaleBase + k * step;
+            const size_t qIndex = i + k * plane;
+            const float maxval = dstMax[qIndex];
+            const float minval = dstMin[qIndex];
+            const float range = maxval - minval;
+            if (std::fabs(range) < 1e-7f) {
+                qscale[qIndex] = 0.0f;
+                qbias[qIndex] = 0.0f;
+                scale[scaleIndex] = 0.0f;
+                bias[scaleIndex] = maxval;
+            } else {
+                qscale[qIndex] = 255.0f / range;
+                qbias[qIndex] = std::round(-minval * 255.0f / range) - 128.0f;
+                scale[scaleIndex] = range / 255.0f;
+                bias[scaleIndex] = minval + (128.0f / 255.0f) * range;
+            }
+        }
+    }
+}

--- a/source/backend/cpu/riscv/rvv/MNNDynamicQuantFP32.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNDynamicQuantFP32.cpp
@@ -17,8 +17,8 @@ void MNNDynamicQuantFP32(const float* src, int8_t* dst, const float* scale, size
             for (; n > 0; n -= vl, srcZ += vl, dstZ += vl) {
                 vl = __riscv_vsetvl_e32m4(n);
                 vfloat32m4_t v = __riscv_vle32_v_f32m4(srcZ, vl);
-                v = __riscv_vfmul_vf_f32m4(v, scaleVal, vl);
-                v = __riscv_vfadd_vf_f32m4(v, biasVal, vl);
+                vfloat32m4_t vbias = __riscv_vfmv_v_f_f32m4(biasVal, vl);
+                v = __riscv_vfmadd_vf_f32m4(v, scaleVal, vbias, vl);
                 vint32m4_t vi = __riscv_vfcvt_x_f_v_i32m4_rm(v, RV_RNU, vl);
                 vi = __riscv_vmax_vx_i32m4(vi, int8_min, vl);
                 vi = __riscv_vmin_vx_i32m4(vi, int8_max, vl);

--- a/source/backend/cpu/riscv/rvv/MNNDynamicQuantFP32.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNDynamicQuantFP32.cpp
@@ -1,0 +1,31 @@
+#include <riscv_vector.h>
+
+void MNNDynamicQuantFP32(const float* src, int8_t* dst, const float* scale, size_t src_depth_quad, size_t realSize,
+                         int pack, const float* bias) {
+    size_t stride = pack * realSize;
+    const int int8_min = -128;
+    const int int8_max = 127;
+    const size_t RV_RNU = 0x4;
+    for (size_t i = 0; i < realSize; ++i) {
+        float scaleVal = scale[i];
+        float biasVal = (bias != nullptr) ? bias[i] : 0.0f;
+        for (size_t c = 0; c < src_depth_quad; ++c) {
+            const float* srcZ = src + c * stride + i * pack;
+            int8_t* dstZ = dst + c * stride + i * pack;
+            size_t n = pack;
+            size_t vl;
+            for (; n > 0; n -= vl, srcZ += vl, dstZ += vl) {
+                vl = __riscv_vsetvl_e32m4(n);
+                vfloat32m4_t v = __riscv_vle32_v_f32m4(srcZ, vl);
+                v = __riscv_vfmul_vf_f32m4(v, scaleVal, vl);
+                v = __riscv_vfadd_vf_f32m4(v, biasVal, vl);
+                vint32m4_t vi = __riscv_vfcvt_x_f_v_i32m4_rm(v, RV_RNU, vl);
+                vi = __riscv_vmax_vx_i32m4(vi, int8_min, vl);
+                vi = __riscv_vmin_vx_i32m4(vi, int8_max, vl);
+                vint16m2_t v16 = __riscv_vncvt_x_x_w_i16m2(vi, vl);
+                vint8m1_t v8 = __riscv_vncvt_x_x_w_i8m1(v16, vl);
+                __riscv_vse8_v_i8m1(dstZ, v8, vl);
+            }
+        }
+    }
+}

--- a/source/backend/cpu/riscv/rvv/MNNDynamicQuantFP32.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNDynamicQuantFP32.cpp
@@ -1,7 +1,7 @@
 #include <riscv_vector.h>
 
-void MNNDynamicQuantFP32(const float* src, int8_t* dst, const float* scale, size_t src_depth_quad, size_t realSize,
-                         int pack, const float* bias) {
+void MNNDynamicQuantFP32_RVV(const float* src, int8_t* dst, const float* scale, size_t src_depth_quad, size_t realSize,
+                             int pack, const float* bias) {
     size_t stride = pack * realSize;
     const int int8_min = -128;
     const int int8_max = 127;

--- a/source/backend/cpu/riscv/rvv/MNNPackedMatMul_int8.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNPackedMatMul_int8.cpp
@@ -6,9 +6,9 @@
 
 #define UP_DIV(x, y) (((x) + (y) - 1) / (y))
 
-void _MNNPackedMatMulRemain_int8(float* C, const float* A, const float* fB, size_t eSize, const size_t* parameter,
-                                 const float* postParameters, const float* bias, int aStride, const float* k,
-                                 const float* b) {
+static void MNNPackedMatMulRemain_int8_RVVImpl(float* C, const float* A, const float* fB, size_t eSize,
+                                               const size_t* parameter, const float* postParameters, const float* bias,
+                                               int aStride, const float* k, const float* b) {
     const int8_t* B = reinterpret_cast<const int8_t*>(fB);
     size_t h = parameter[2];
     size_t l = parameter[1];
@@ -53,15 +53,12 @@ void _MNNPackedMatMulRemain_int8(float* C, const float* A, const float* fB, size
                 float a_val = src[z * aStride];
                 vfloat32m1_t a_v = __riscv_vfmv_v_f_f32m1(a_val, VL);
 
-                // 完全和标量逻辑一致，无精度误差
                 float w_buf[4] = {
                     (float)weight[z * 4 + 0] * alpha[0] + qbias[0], (float)weight[z * 4 + 1] * alpha[1] + qbias[1],
                     (float)weight[z * 4 + 2] * alpha[2] + qbias[2], (float)weight[z * 4 + 3] * alpha[3] + qbias[3]};
 
-                // 正确加载向量（GCC15.1 标准）
                 vfloat32m1_t w_v = __riscv_vle32_v_f32m1(w_buf, VL);
 
-                // 正确 FMA 指令（带 VL）
                 sum_v = __riscv_vfmadd_vv_f32m1(w_v, a_v, sum_v, VL);
             }
 
@@ -72,13 +69,13 @@ void _MNNPackedMatMulRemain_int8(float* C, const float* A, const float* fB, size
     }
 }
 
-void MNNPackedMatMul_int8(float* C, const float* A, const float* B, const size_t* parameter,
-                          const float* postParameters, const float* bias, const float* k, const float* b) {
-    _MNNPackedMatMulRemain_int8(C, A, B, 16, parameter, postParameters, bias, 16, k, b);
+void MNNPackedMatMul_int8_RVV(float* C, const float* A, const float* B, const size_t* parameter,
+                              const float* postParameters, const float* bias, const float* k, const float* b) {
+    MNNPackedMatMulRemain_int8_RVVImpl(C, A, B, 16, parameter, postParameters, bias, 16, k, b);
 }
 
-void MNNPackedMatMulRemain_int8(float* C, const float* A, const float* B, size_t eSize, const size_t* parameter,
-                                const float* postParameters, const float* bias, const float* k, const float* b) {
+void MNNPackedMatMulRemain_int8_RVV(float* C, const float* A, const float* B, size_t eSize, const size_t* parameter,
+                                    const float* postParameters, const float* bias, const float* k, const float* b) {
     const int aStride = static_cast<int>(parameter[0] / sizeof(float));
-    _MNNPackedMatMulRemain_int8(C, A, B, eSize, parameter, postParameters, bias, aStride, k, b);
+    MNNPackedMatMulRemain_int8_RVVImpl(C, A, B, eSize, parameter, postParameters, bias, aStride, k, b);
 }

--- a/source/backend/cpu/riscv/rvv/MNNPackedMatMul_int8.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNPackedMatMul_int8.cpp
@@ -1,0 +1,78 @@
+#include <riscv_vector.h>
+#include <limits>
+#include <cstddef>
+#include <cstdint>
+#include <algorithm>
+
+#define UP_DIV(x, y) (((x) + (y) - 1) / (y))
+
+void _MNNPackedMatMulRemain_int8(float* C, const float* A, const float* fB, size_t eSize, const size_t* parameter,
+                                 const float* postParameters, const float* bias, int aStride, const float* k,
+                                 const float* b) {
+    const int8_t* B = reinterpret_cast<const int8_t*>(fB);
+    size_t h = parameter[2];
+    size_t l = parameter[1];
+    size_t cStride = parameter[3] / sizeof(float);
+    int32_t bExtraStride = static_cast<int32_t>(parameter[5]);
+    size_t bStride = bExtraStride + 4 * l;
+    size_t hC4 = UP_DIV(h, 4);
+
+    float minValue = -std::numeric_limits<float>::max();
+    float maxValue = std::numeric_limits<float>::max();
+    if (postParameters != nullptr) {
+        minValue = postParameters[2];
+        maxValue = postParameters[3];
+    }
+    int blockId = parameter[6];
+    const size_t VL = 4;
+
+    vfloat32m1_t min_v = __riscv_vfmv_v_f_f32m1(minValue, VL);
+    vfloat32m1_t max_v = __riscv_vfmv_v_f_f32m1(maxValue, VL);
+
+    for (size_t x = 0; x < eSize; x++) {
+        float* dst = C + 4 * x;
+        const float* src = A + x;
+
+        for (size_t y = 0; y < hC4; y++) {
+            float* dstY = dst + y * cStride;
+            const int8_t* weight = B + y * bStride;
+            const float* alpha = k + y * 4;
+            const float* qbias = b + y * 4;
+
+            vfloat32m1_t sum_v = __riscv_vfmv_v_f_f32m1(0.0f, VL);
+            if (blockId > 0) {
+                sum_v = __riscv_vle32_v_f32m1(dstY, VL);
+            }
+
+            if (bias != nullptr && postParameters != nullptr) {
+                vfloat32m1_t bias_v = __riscv_vle32_v_f32m1(bias + 4 * y, VL);
+                sum_v = __riscv_vfadd_vv_f32m1(sum_v, bias_v, VL);
+            }
+
+            for (size_t z = 0; z < l; z++) {
+                float a_val = src[z * aStride];
+                vfloat32m1_t a_v = __riscv_vfmv_v_f_f32m1(a_val, VL);
+
+                // 完全和标量逻辑一致，无精度误差
+                float w_buf[4] = {
+                    (float)weight[z * 4 + 0] * alpha[0] + qbias[0], (float)weight[z * 4 + 1] * alpha[1] + qbias[1],
+                    (float)weight[z * 4 + 2] * alpha[2] + qbias[2], (float)weight[z * 4 + 3] * alpha[3] + qbias[3]};
+
+                // 正确加载向量（GCC15.1 标准）
+                vfloat32m1_t w_v = __riscv_vle32_v_f32m1(w_buf, VL);
+
+                // 正确 FMA 指令（带 VL）
+                sum_v = __riscv_vfmadd_vv_f32m1(w_v, a_v, sum_v, VL);
+            }
+
+            sum_v = __riscv_vfmin_vv_f32m1(sum_v, max_v, VL);
+            sum_v = __riscv_vfmax_vv_f32m1(sum_v, min_v, VL);
+            __riscv_vse32_v_f32m1(dstY, sum_v, VL);
+        }
+    }
+}
+
+void MNNPackedMatMul_int8(float* C, const float* A, const float* B, const size_t* parameter,
+                          const float* postParameters, const float* bias, const float* k, const float* b) {
+    _MNNPackedMatMulRemain_int8(C, A, B, 16, parameter, postParameters, bias, 16, k, b);
+}

--- a/source/backend/cpu/riscv/rvv/MNNPackedMatMul_int8.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNPackedMatMul_int8.cpp
@@ -76,3 +76,9 @@ void MNNPackedMatMul_int8(float* C, const float* A, const float* B, const size_t
                           const float* postParameters, const float* bias, const float* k, const float* b) {
     _MNNPackedMatMulRemain_int8(C, A, B, 16, parameter, postParameters, bias, 16, k, b);
 }
+
+void MNNPackedMatMulRemain_int8(float* C, const float* A, const float* B, size_t eSize, const size_t* parameter,
+                                const float* postParameters, const float* bias, const float* k, const float* b) {
+    const int aStride = static_cast<int>(parameter[0] / sizeof(float));
+    _MNNPackedMatMulRemain_int8(C, A, B, eSize, parameter, postParameters, bias, aStride, k, b);
+}

--- a/source/backend/cpu/riscv/rvv/MNNReorderWeightInt4.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNReorderWeightInt4.cpp
@@ -14,7 +14,7 @@ static inline int32_t _rvvReduceAddI32(vint32m4_t value, size_t vl) {
     return __riscv_vmv_x_s_i32m1_i32(sum);
 }
 
-void MNNReorderWeightInt4(uint8_t* dest, const uint8_t* source, int32_t* shape, size_t size, float* kernelsum) {
+void MNNReorderWeightInt4_RVV(uint8_t* dest, const uint8_t* source, int32_t* shape, size_t size, float* kernelsum) {
     MNN_ASSERT(size > 4);
     const int32_t blocknum = shape[0];
     const int32_t hu = shape[1];

--- a/source/backend/cpu/riscv/rvv/MNNReorderWeightInt4.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNReorderWeightInt4.cpp
@@ -52,7 +52,8 @@ void MNNReorderWeightInt4(uint8_t* dest, const uint8_t* source, int32_t* shape, 
     std::vector<uint8_t> buffer(static_cast<size_t>(inside));
 
     for (int32_t i = 0; i < outside; ++i) {
-        std::vector<float> accum(static_cast<size_t>(hp), 0.0f);
+        float* sumBase = kernelsum + i * hp;
+        std::memset(sumBase, 0, static_cast<size_t>(hp) * sizeof(float));
         for (int32_t k = 0; k < lu; ++k) {
             uint8_t* dstBase = dest + (i * lu + k) * inside;
             int32_t j = 0;
@@ -98,8 +99,8 @@ void MNNReorderWeightInt4(uint8_t* dest, const uint8_t* source, int32_t* shape, 
                     const vint32m4_t sum1 = __riscv_vadd_vv_i32m4(__riscv_vwcvt_x_x_v_i32m4(w2_16, vl),
                                                                   __riscv_vwcvt_x_x_v_i32m4(w3_16, vl), vl);
 
-                    accum[static_cast<size_t>(h0)] += static_cast<float>(_rvvReduceAddI32(sum0, vl));
-                    accum[static_cast<size_t>(h1)] += static_cast<float>(_rvvReduceAddI32(sum1, vl));
+                    sumBase[h0] += static_cast<float>(_rvvReduceAddI32(sum0, vl));
+                    sumBase[h1] += static_cast<float>(_rvvReduceAddI32(sum1, vl));
 
                     p += static_cast<int32_t>(vl);
                 }
@@ -107,6 +108,5 @@ void MNNReorderWeightInt4(uint8_t* dest, const uint8_t* source, int32_t* shape, 
             }
             std::memcpy(dstBase, buffer.data(), static_cast<size_t>(inside));
         }
-        std::memcpy(kernelsum + i * hp, accum.data(), static_cast<size_t>(hp) * sizeof(float));
     }
 }

--- a/source/backend/cpu/riscv/rvv/MNNReorderWeightInt4.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNReorderWeightInt4.cpp
@@ -1,0 +1,112 @@
+#include <riscv_vector.h>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#ifndef MNN_ASSERT
+#define MNN_ASSERT(x)
+#endif
+
+static inline int32_t _rvvReduceAddI32(vint32m4_t value, size_t vl) {
+    const size_t vl1 = __riscv_vsetvl_e32m1(1);
+    const vint32m1_t zero = __riscv_vmv_v_x_i32m1(0, vl1);
+    const vint32m1_t sum = __riscv_vredsum_vs_i32m4_i32m1(value, zero, vl);
+    return __riscv_vmv_x_s_i32m1_i32(sum);
+}
+
+void MNNReorderWeightInt4(uint8_t* dest, const uint8_t* source, int32_t* shape, size_t size, float* kernelsum) {
+    MNN_ASSERT(size > 4);
+    const int32_t blocknum = shape[0];
+    const int32_t hu = shape[1];
+    const int32_t lu = shape[2];
+    const int32_t hp = shape[3];
+    const int32_t lp = shape[4];
+    const int32_t ic = blocknum * lu * lp;
+    const int32_t stride0 = blocknum * hp * lu * lp;
+    const int32_t stride1 = lu * hp * lp;
+    const int32_t stride2 = hp * lp;
+
+    // [oc,ic] -> [hu,blocknum,lu,hp,lp]
+    for (int32_t i = 0; i < hu; ++i) {
+        for (int32_t k = 0; k < hp; ++k) {
+            for (int32_t bl = 0; bl < blocknum; ++bl) {
+                for (int32_t j = 0; j < lu; ++j) {
+                    const int32_t srcIndex = (i * hp + k) * ic + bl * (lu * lp) + j * lp;
+                    const int32_t dstIndex = i * stride0 + bl * stride1 + j * stride2 + k * lp;
+                    int32_t x = 0;
+                    while (x < lp) {
+                        const size_t vl = __riscv_vsetvl_e8m1(lp - x);
+                        const vuint8m1_t v = __riscv_vle8_v_u8m1(source + srcIndex + x, vl);
+                        __riscv_vse8_v_u8m1(dest + dstIndex + x, v, vl);
+                        x += static_cast<int32_t>(vl);
+                    }
+                }
+            }
+        }
+    }
+
+    // [hu,blocknum,lu,hp,lp] address [hp,lp] for int4
+    const int32_t inside = lp * hp;
+    const int32_t outside = blocknum * hu;
+    const int32_t half = inside / 2;
+    std::vector<uint8_t> buffer(static_cast<size_t>(inside));
+
+    for (int32_t i = 0; i < outside; ++i) {
+        std::vector<float> accum(static_cast<size_t>(hp), 0.0f);
+        for (int32_t k = 0; k < lu; ++k) {
+            uint8_t* dstBase = dest + (i * lu + k) * inside;
+            int32_t j = 0;
+            while (j < half) {
+                const int32_t h0 = j / lp;
+                const int32_t h1 = (j + half) / lp;
+
+                int32_t chunk = half - j;
+                const int32_t remain0 = lp - (j % lp);
+                const int32_t remain1 = lp - ((j + half) % lp);
+                if (chunk > remain0) {
+                    chunk = remain0;
+                }
+                if (chunk > remain1) {
+                    chunk = remain1;
+                }
+
+                int32_t p = 0;
+                while (p < chunk) {
+                    const int32_t offset = j + p;
+                    const size_t vl = __riscv_vsetvl_e8m1(chunk - p);
+
+                    const vuint8m1_t d0 = __riscv_vle8_v_u8m1(dstBase + offset, vl);
+                    const vuint8m1_t d1 = __riscv_vle8_v_u8m1(dstBase + offset + half, vl);
+
+                    const vuint8m1_t w0 = __riscv_vsrl_vx_u8m1(d0, 4, vl);
+                    const vuint8m1_t w1 = __riscv_vand_vx_u8m1(d0, 0x0f, vl);
+                    const vuint8m1_t w2 = __riscv_vsrl_vx_u8m1(d1, 4, vl);
+                    const vuint8m1_t w3 = __riscv_vand_vx_u8m1(d1, 0x0f, vl);
+
+                    const vuint8m1_t packed0 = __riscv_vor_vv_u8m1(__riscv_vsll_vx_u8m1(w0, 4, vl), w2, vl);
+                    const vuint8m1_t packed1 = __riscv_vor_vv_u8m1(__riscv_vsll_vx_u8m1(w1, 4, vl), w3, vl);
+                    __riscv_vsse8_v_u8m1(buffer.data() + 2 * offset + 0, 2, packed0, vl);
+                    __riscv_vsse8_v_u8m1(buffer.data() + 2 * offset + 1, 2, packed1, vl);
+
+                    const vint16m2_t w0_16 = __riscv_vreinterpret_v_u16m2_i16m2(__riscv_vzext_vf2_u16m2(w0, vl));
+                    const vint16m2_t w1_16 = __riscv_vreinterpret_v_u16m2_i16m2(__riscv_vzext_vf2_u16m2(w1, vl));
+                    const vint16m2_t w2_16 = __riscv_vreinterpret_v_u16m2_i16m2(__riscv_vzext_vf2_u16m2(w2, vl));
+                    const vint16m2_t w3_16 = __riscv_vreinterpret_v_u16m2_i16m2(__riscv_vzext_vf2_u16m2(w3, vl));
+
+                    const vint32m4_t sum0 = __riscv_vadd_vv_i32m4(__riscv_vwcvt_x_x_v_i32m4(w0_16, vl),
+                                                                  __riscv_vwcvt_x_x_v_i32m4(w1_16, vl), vl);
+                    const vint32m4_t sum1 = __riscv_vadd_vv_i32m4(__riscv_vwcvt_x_x_v_i32m4(w2_16, vl),
+                                                                  __riscv_vwcvt_x_x_v_i32m4(w3_16, vl), vl);
+
+                    accum[static_cast<size_t>(h0)] += static_cast<float>(_rvvReduceAddI32(sum0, vl));
+                    accum[static_cast<size_t>(h1)] += static_cast<float>(_rvvReduceAddI32(sum1, vl));
+
+                    p += static_cast<int32_t>(vl);
+                }
+                j += chunk;
+            }
+            std::memcpy(dstBase, buffer.data(), static_cast<size_t>(inside));
+        }
+        std::memcpy(kernelsum + i * hp, accum.data(), static_cast<size_t>(hp) * sizeof(float));
+    }
+}

--- a/source/backend/cpu/riscv/rvv/MNNSumByAxisLForMatmul_A.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNSumByAxisLForMatmul_A.cpp
@@ -1,9 +1,10 @@
-﻿#include <riscv_vector.h>
+#include <riscv_vector.h>
 #include <cstdint>
 #include <algorithm>
+#include "../../compute/CommonOptFunction.h"
 
-void MNNSumByAxisLForMatmul_A(float* dest, int8_t* source, const float* scale, ssize_t realDstCount,
-                              SumByAxisParams sumParams) {
+void MNNSumByAxisLForMatmul_A_RVV(float* dest, int8_t* source, const float* scale, ssize_t realDstCount,
+                                  SumByAxisParams sumParams) {
     int8_t* srcInt8 = source;
     auto scalePtr = scale;
 
@@ -30,7 +31,6 @@ void MNNSumByAxisLForMatmul_A(float* dest, int8_t* source, const float* scale, s
         for (int k = 0; k < blockNum; ++k) {
             const auto src_x = srcInt8 + k * (step * LP * blockSizeQuad * kernelxy);
 
-            // ?? w维展开（2路）
             for (int w = 0; w < step; w += 2) {
                 int w0 = w;
                 int w1 = w + 1;
@@ -53,7 +53,6 @@ void MNNSumByAxisLForMatmul_A(float* dest, int8_t* source, const float* scale, s
                 const auto src_y0 = src_x + w0 * LP;
                 const auto src_y1 = has_w1 ? (src_x + w1 * LP) : nullptr;
 
-                // ?? 正确：vector累加器放在最外层
                 vint32m4_t vacc0 = __riscv_vmv_v_x_i32m4(0, vlmax);
                 vint32m4_t vacc1 = __riscv_vmv_v_x_i32m4(0, vlmax);
 

--- a/source/backend/cpu/riscv/rvv/MNNSumByAxisLForMatmul_A.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNSumByAxisLForMatmul_A.cpp
@@ -1,0 +1,125 @@
+#include <riscv_vector.h>
+#include <cstdint>
+#include <algorithm>
+
+void MNNSumByAxisLForMatmul_A(float* dest, int8_t* source, const float* scale, ssize_t realDstCount,
+                              SumByAxisParams sumParams) {
+    int8_t* srcInt8 = source;
+    auto scalePtr = scale;
+
+    auto blockNum = sumParams.blockNum;
+    auto EP = sumParams.DST_XUNIT;
+    auto LP = sumParams.SRC_UNIT;
+    auto col_buffer_unit_size = sumParams.unitColBufferSize;
+    auto oneScale = sumParams.oneScale;
+    auto LU = sumParams.LU;
+    auto valid = sumParams.valid;
+    auto kernelxy = sumParams.kernelxy;
+
+    auto blockSizeQuad = LU / blockNum;
+    auto inputBlockQuant = sumParams.inputBlock;
+
+    auto lastL = valid ? valid : LP;
+    float singlescale = scale[0];
+
+    do {
+        int step = ALIMIN(EP, realDstCount);
+        int scaleOffset = inputBlockQuant ? (step * blockNum) : step;
+
+        for (int k = 0; k < blockNum; ++k) {
+            const auto src_x = srcInt8 + k * (step * LP * blockSizeQuad * kernelxy);
+
+            // ?? w维展开（2路）
+            for (int w = 0; w < step; w += 2) {
+                int w0 = w;
+                int w1 = w + 1;
+                bool has_w1 = (w1 < step);
+
+                float scale0, scale1;
+
+                if (oneScale) {
+                    scale0 = scale1 = singlescale;
+                } else if (inputBlockQuant) {
+                    scale0 = scalePtr[w0 + k * step];
+                    if (has_w1)
+                        scale1 = scalePtr[w1 + k * step];
+                } else {
+                    scale0 = scalePtr[w0];
+                    if (has_w1)
+                        scale1 = scalePtr[w1];
+                }
+
+                const auto src_y0 = src_x + w0 * LP;
+                const auto src_y1 = has_w1 ? (src_x + w1 * LP) : nullptr;
+
+                // ?? 正确：vector累加器放在最外层
+                vint32m4_t vacc0 = __riscv_vmv_v_x_i32m4(0, 1);
+                vint32m4_t vacc1 = __riscv_vmv_v_x_i32m4(0, 1);
+
+                for (int j = 0; j < kernelxy; ++j) {
+                    for (int i = 0; i < blockSizeQuad; ++i) {
+                        int sumsize = (i == blockSizeQuad - 1) ? lastL : LP;
+
+                        const auto base = j * (blockSizeQuad * step * LP) + i * step * LP;
+
+                        const auto src_z0 = src_y0 + base;
+                        const auto src_z1 = has_w1 ? (src_y1 + base) : nullptr;
+
+                        size_t x = 0;
+
+                        while (x < sumsize) {
+                            size_t vl = __riscv_vsetvl_e8m1(sumsize - x);
+
+                            // w0
+                            vint8m1_t v8_0 = __riscv_vle8_v_i8m1(src_z0 + x, vl);
+
+                            vint16m2_t v16_0 = __riscv_vwcvt_x_x_v_i16m2(v8_0, vl);
+
+                            vint32m4_t v32_0 = __riscv_vwcvt_x_x_v_i32m4(v16_0, vl);
+
+                            vacc0 = __riscv_vadd_vv_i32m4(vacc0, v32_0, vl);
+
+                            // w1
+                            if (has_w1) {
+                                vint8m1_t v8_1 = __riscv_vle8_v_i8m1(src_z1 + x, vl);
+
+                                vint16m2_t v16_1 = __riscv_vwcvt_x_x_v_i16m2(v8_1, vl);
+
+                                vint32m4_t v32_1 = __riscv_vwcvt_x_x_v_i32m4(v16_1, vl);
+
+                                vacc1 = __riscv_vadd_vv_i32m4(vacc1, v32_1, vl);
+                            }
+
+                            x += vl;
+                        }
+                    }
+                }
+
+                // ?? 正确reduce（使用vlmax）
+                size_t vlmax = __riscv_vsetvlmax_e32m4();
+
+                vint32m1_t vzero = __riscv_vmv_s_x_i32m1(0, vlmax);
+
+                vint32m1_t r0 = __riscv_vredsum_vs_i32m4_i32m1(vacc0, vzero, vlmax);
+
+                int32_t sum0 = __riscv_vmv_x_s_i32m1_i32(r0);
+
+                dest[w0 + k * step] = scale0 * (float)sum0;
+
+                if (has_w1) {
+                    vint32m1_t r1 = __riscv_vredsum_vs_i32m4_i32m1(vacc1, vzero, vlmax);
+
+                    int32_t sum1 = __riscv_vmv_x_s_i32m1_i32(r1);
+
+                    dest[w1 + k * step] = scale1 * (float)sum1;
+                }
+            }
+        }
+
+        scalePtr += scaleOffset;
+        dest += (step * blockNum);
+        realDstCount -= step;
+        srcInt8 += col_buffer_unit_size;
+
+    } while (realDstCount > 0);
+}

--- a/source/backend/cpu/riscv/rvv/MNNSumByAxisLForMatmul_A.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNSumByAxisLForMatmul_A.cpp
@@ -1,4 +1,4 @@
-#include <riscv_vector.h>
+ï»¿#include <riscv_vector.h>
 #include <cstdint>
 #include <algorithm>
 
@@ -21,6 +21,7 @@ void MNNSumByAxisLForMatmul_A(float* dest, int8_t* source, const float* scale, s
 
     auto lastL = valid ? valid : LP;
     float singlescale = scale[0];
+    const size_t vlmax = __riscv_vsetvlmax_e32m4();
 
     do {
         int step = ALIMIN(EP, realDstCount);
@@ -29,7 +30,7 @@ void MNNSumByAxisLForMatmul_A(float* dest, int8_t* source, const float* scale, s
         for (int k = 0; k < blockNum; ++k) {
             const auto src_x = srcInt8 + k * (step * LP * blockSizeQuad * kernelxy);
 
-            // ?? wÎ¬Õ¹¿ª£¨2Â·£©
+            // ?? wç»´å±•å¼€ï¼ˆ2è·¯ï¼‰
             for (int w = 0; w < step; w += 2) {
                 int w0 = w;
                 int w1 = w + 1;
@@ -52,9 +53,9 @@ void MNNSumByAxisLForMatmul_A(float* dest, int8_t* source, const float* scale, s
                 const auto src_y0 = src_x + w0 * LP;
                 const auto src_y1 = has_w1 ? (src_x + w1 * LP) : nullptr;
 
-                // ?? ÕýÈ·£ºvectorÀÛ¼ÓÆ÷·ÅÔÚ×îÍâ²ã
-                vint32m4_t vacc0 = __riscv_vmv_v_x_i32m4(0, 1);
-                vint32m4_t vacc1 = __riscv_vmv_v_x_i32m4(0, 1);
+                // ?? æ­£ç¡®ï¼švectorç´¯åŠ å™¨æ”¾åœ¨æœ€å¤–å±‚
+                vint32m4_t vacc0 = __riscv_vmv_v_x_i32m4(0, vlmax);
+                vint32m4_t vacc1 = __riscv_vmv_v_x_i32m4(0, vlmax);
 
                 for (int j = 0; j < kernelxy; ++j) {
                     for (int i = 0; i < blockSizeQuad; ++i) {
@@ -94,9 +95,7 @@ void MNNSumByAxisLForMatmul_A(float* dest, int8_t* source, const float* scale, s
                         }
                     }
                 }
-
-                // ?? ÕýÈ·reduce£¨Ê¹ÓÃvlmax£©
-                size_t vlmax = __riscv_vsetvlmax_e32m4();
+                // Reduce full accumulator width.
 
                 vint32m1_t vzero = __riscv_vmv_s_x_i32m1(0, vlmax);
 

--- a/source/backend/cpu/riscv/rvv/MNNSumWeightInt8.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNSumWeightInt8.cpp
@@ -1,0 +1,32 @@
+#include <riscv_vector.h>
+#include <vector>
+#include <cstring>
+#include <cstdint>
+
+void MNNSumWeightInt8(float* kernelsum, int8_t* source, size_t outside, size_t reduceAxis, size_t hP, size_t lP) {
+    size_t inside = hP * lP;
+    size_t stride0 = inside * reduceAxis;
+    std::vector<float> accum(hP);
+    for (size_t i = 0; i < outside; ++i) {
+        memset(accum.data(), 0, hP * sizeof(float));
+        for (size_t j = 0; j < reduceAxis; ++j) {
+            for (size_t k = 0; k < hP; ++k) {
+                const int8_t* src_ptr = source + i * stride0 + j * inside + k * lP;
+                size_t x = 0;
+                int sum = 0;
+                while (x < lP) {
+                    size_t vl = __riscv_vsetvl_e8m1(lP - x);
+                    vint8m1_t v8 = __riscv_vle8_v_i8m1(src_ptr + x, vl);
+                    vint16m2_t v16 = __riscv_vwcvt_x_x_v_i16m2(v8, vl);
+                    vint32m4_t v32 = __riscv_vwcvt_x_x_v_i32m4(v16, vl);
+                    vint32m1_t vzero = __riscv_vmv_s_x_i32m1(0, vl);
+                    vint32m1_t vres = __riscv_vredsum_vs_i32m4_i32m1(v32, vzero, vl);
+                    sum += __riscv_vmv_x_s_i32m1_i32(vres);
+                    x += vl;
+                }
+                accum[k] += (float)sum;
+            }
+        }
+        memcpy(kernelsum + i * hP, accum.data(), hP * sizeof(float));
+    }
+}

--- a/source/backend/cpu/riscv/rvv/MNNSumWeightInt8.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNSumWeightInt8.cpp
@@ -1,14 +1,13 @@
 #include <riscv_vector.h>
-#include <vector>
 #include <cstring>
 #include <cstdint>
 
 void MNNSumWeightInt8(float* kernelsum, int8_t* source, size_t outside, size_t reduceAxis, size_t hP, size_t lP) {
     size_t inside = hP * lP;
     size_t stride0 = inside * reduceAxis;
-    std::vector<float> accum(hP);
     for (size_t i = 0; i < outside; ++i) {
-        memset(accum.data(), 0, hP * sizeof(float));
+        float* dst = kernelsum + i * hP;
+        memset(dst, 0, hP * sizeof(float));
         for (size_t j = 0; j < reduceAxis; ++j) {
             for (size_t k = 0; k < hP; ++k) {
                 const int8_t* src_ptr = source + i * stride0 + j * inside + k * lP;
@@ -24,9 +23,8 @@ void MNNSumWeightInt8(float* kernelsum, int8_t* source, size_t outside, size_t r
                     sum += __riscv_vmv_x_s_i32m1_i32(vres);
                     x += vl;
                 }
-                accum[k] += (float)sum;
+                dst[k] += (float)sum;
             }
         }
-        memcpy(kernelsum + i * hP, accum.data(), hP * sizeof(float));
     }
 }

--- a/source/backend/cpu/riscv/rvv/MNNSumWeightInt8.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNSumWeightInt8.cpp
@@ -2,7 +2,7 @@
 #include <cstring>
 #include <cstdint>
 
-void MNNSumWeightInt8(float* kernelsum, int8_t* source, size_t outside, size_t reduceAxis, size_t hP, size_t lP) {
+void MNNSumWeightInt8_RVV(float* kernelsum, int8_t* source, size_t outside, size_t reduceAxis, size_t hP, size_t lP) {
     size_t inside = hP * lP;
     size_t stride0 = inside * reduceAxis;
     for (size_t i = 0; i < outside; ++i) {


### PR DESCRIPTION
## Description

Develop the RVV accelerated version of the methods below:
- MNNAbsMaxFP32
- MNNAccumulateSequenceNumber
- MNNAsyQuantFunc
- MNNAsyQuantInfo_FP32
- MNNDynamicQuantFP32
- MNNPackedMatMul_int8
- MNNReorderWeightInt4
- MNNSumByAxisLForMatmul_A
- MNNSumWeightInt8

### Performance Metrics

The performance was evaluated on a remote RISC-V server. Profiling was conducted using `perf` for each individual function. The benchmark compares the baseline scalar C++ implementation against the RVV-optimized implementation.

| Function / Operator | Baseline (Scalar C++) | RVV Optimized | Result |
|---|---:|---:|---:|
| MNNAccumulateSequenceNumber | 11.24 s | 2.08 s | 5.39x speedup |
| MNNSumByAxisLForMatmul_A | 36.03 s | 10.82 s | 3.33x speedup |
| MNNReorderWeightInt4 | 128.78 s | 74.92 s | 1.72x speedup |
| MNNSumWeightInt8 | 29.74 s | 4.18 s | 7.12x speedup |
| MNNPackedMatMul_int8 | 9.06 s | 4.42 s | 2.05x speedup |
| MNNDynamicQuantFP32 | 176.88 s | 116.37 s | 1.52x speedup |
| MNNAsyQuantFunc | 34.64 s | 5.25 s | 6.60x speedup |
| MNNAsyQuantInfo_FP32 | 137.67 s | 99.90 s | 1.38x speedup |
| MNNPackedMatMulRemain_int8 | 1.27 s | 3.77 s | 0.34x (regression) |
| MNNAbsMaxFP32 | 26.57 s | 50.17 s | 0.53x (regression) |

Additional profiling metrics such as CPU cycles, cache misses, instructions, and branch miss rates were also collected using `perf` to further analyze the behavior of the RVV implementations.

(Note: Data represents average execution time collected from repeated benchmark runs on the remote RISC-V platform.)
## Module

CPU/RVV

## Type

- [x] Feature
- [ ] Bugfix
- [x] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [x] Tested on relevant platform(s)
- [x] No unrelated format or style changes included
