### PR TITLE
[CPU:Perf] add fused MNNFusedGatedDelta kernel for LinearAttention prefill

### DIFF
--- a/source/backend/arm82/Arm82Functions.cpp
+++ b/source/backend/arm82/Arm82Functions.cpp
@@ -80,6 +80,188 @@ void MNNDualMatVecFp16(const float* S, const float* k, const float* q, float* ou
 void MNNDecayRankOneUpdateFp16(float* S, const float* k, const float* delta, float decay, size_t dk, size_t dv);
 }
 
+#if defined(__aarch64__) && defined(MNN_USE_NEON)
+// ──────────────────────────────────────────────────────────────────────────
+// MNNFusedGatedDeltaFp16 — FP16 specialization of the fused gated-delta-rule
+// kernel. See documentation in CommonOptFunction.h for the math.
+//
+// Pointers are typed `float*` for ABI uniformity with the FP32 version (the
+// dispatch table holds a single function pointer signature), but the
+// underlying memory is fp16. d_v is processed in chunks of 32 (= 4 v.8h
+// registers per accumulator) to keep all per-chunk state in registers,
+// which matters at d_v=128 where holding both out_k and out_q for the
+// whole row would otherwise exceed the 32 NEON v register budget.
+// ──────────────────────────────────────────────────────────────────────────
+static void MNNFusedGatedDeltaFp16(float* S_, const float* k_, const float* q_, const float* v_,
+                                   float* out_, float decay, float beta, float kq,
+                                   size_t dk, size_t dv) {
+    auto S   = reinterpret_cast<__fp16*>(S_);
+    auto k   = reinterpret_cast<const __fp16*>(k_);
+    auto q   = reinterpret_cast<const __fp16*>(q_);
+    auto vIn = reinterpret_cast<const __fp16*>(v_);
+    auto out = reinterpret_cast<__fp16*>(out_);
+
+    const __fp16 decayH = static_cast<__fp16>(decay);
+    const __fp16 betaH  = static_cast<__fp16>(beta);
+    const __fp16 kqH    = static_cast<__fp16>(kq);
+    const float16x8_t vDecay = vdupq_n_f16(decayH);
+    const float16x8_t vBeta  = vdupq_n_f16(betaH);
+    const float16x8_t vKq    = vdupq_n_f16(kqH);
+
+    const size_t kChunk = 32;
+    size_t j = 0;
+    for (; j + kChunk <= dv; j += kChunk) {
+        // ── Pass 1: out_k = S^T @ k, out_q = S^T @ q for this column chunk ──
+        float16x8_t ok0 = vdupq_n_f16((__fp16)0), ok1 = vdupq_n_f16((__fp16)0),
+                    ok2 = vdupq_n_f16((__fp16)0), ok3 = vdupq_n_f16((__fp16)0);
+        float16x8_t oq0 = vdupq_n_f16((__fp16)0), oq1 = vdupq_n_f16((__fp16)0),
+                    oq2 = vdupq_n_f16((__fp16)0), oq3 = vdupq_n_f16((__fp16)0);
+        size_t i = 0;
+        // Unroll i by 8: load 8 k & q scalars at once, then use fma-by-lane
+        // to amortize the scalar broadcast across 8 row iterations.
+        for (; i + 8 <= dk; i += 8) {
+            float16x8_t kVec = vld1q_f16(k + i);
+            float16x8_t qVec = vld1q_f16(q + i);
+            #define LANE_STEP(lane)                                              \
+                {                                                                \
+                    const __fp16* row = S + (i + (lane)) * dv + j;               \
+                    float16x8_t s0 = vld1q_f16(row);                             \
+                    float16x8_t s1 = vld1q_f16(row + 8);                         \
+                    float16x8_t s2 = vld1q_f16(row + 16);                        \
+                    float16x8_t s3 = vld1q_f16(row + 24);                        \
+                    ok0 = vfmaq_laneq_f16(ok0, s0, kVec, (lane));                \
+                    ok1 = vfmaq_laneq_f16(ok1, s1, kVec, (lane));                \
+                    ok2 = vfmaq_laneq_f16(ok2, s2, kVec, (lane));                \
+                    ok3 = vfmaq_laneq_f16(ok3, s3, kVec, (lane));                \
+                    oq0 = vfmaq_laneq_f16(oq0, s0, qVec, (lane));                \
+                    oq1 = vfmaq_laneq_f16(oq1, s1, qVec, (lane));                \
+                    oq2 = vfmaq_laneq_f16(oq2, s2, qVec, (lane));                \
+                    oq3 = vfmaq_laneq_f16(oq3, s3, qVec, (lane));                \
+                }
+            LANE_STEP(0); LANE_STEP(1); LANE_STEP(2); LANE_STEP(3);
+            LANE_STEP(4); LANE_STEP(5); LANE_STEP(6); LANE_STEP(7);
+            #undef LANE_STEP
+        }
+        // Tail rows (dk % 8) — fall back to the broadcast form.
+        for (; i < dk; ++i) {
+            const __fp16* row = S + i * dv + j;
+            float16x8_t s0 = vld1q_f16(row);
+            float16x8_t s1 = vld1q_f16(row + 8);
+            float16x8_t s2 = vld1q_f16(row + 16);
+            float16x8_t s3 = vld1q_f16(row + 24);
+            __fp16 ki = k[i];
+            __fp16 qi = q[i];
+            ok0 = vfmaq_n_f16(ok0, s0, ki);
+            ok1 = vfmaq_n_f16(ok1, s1, ki);
+            ok2 = vfmaq_n_f16(ok2, s2, ki);
+            ok3 = vfmaq_n_f16(ok3, s3, ki);
+            oq0 = vfmaq_n_f16(oq0, s0, qi);
+            oq1 = vfmaq_n_f16(oq1, s1, qi);
+            oq2 = vfmaq_n_f16(oq2, s2, qi);
+            oq3 = vfmaq_n_f16(oq3, s3, qi);
+        }
+
+        // ── Inline analytic correction (regs only) ──
+        float16x8_t v0 = vld1q_f16(vIn + j);
+        float16x8_t v1 = vld1q_f16(vIn + j + 8);
+        float16x8_t v2 = vld1q_f16(vIn + j + 16);
+        float16x8_t v3 = vld1q_f16(vIn + j + 24);
+        // delta = beta * (v - decay * out_k)
+        float16x8_t d0 = vmulq_f16(vBeta, vsubq_f16(v0, vmulq_f16(vDecay, ok0)));
+        float16x8_t d1 = vmulq_f16(vBeta, vsubq_f16(v1, vmulq_f16(vDecay, ok1)));
+        float16x8_t d2 = vmulq_f16(vBeta, vsubq_f16(v2, vmulq_f16(vDecay, ok2)));
+        float16x8_t d3 = vmulq_f16(vBeta, vsubq_f16(v3, vmulq_f16(vDecay, ok3)));
+        // out = decay * out_q + kq * delta
+        float16x8_t o0 = vfmaq_f16(vmulq_f16(vDecay, oq0), vKq, d0);
+        float16x8_t o1 = vfmaq_f16(vmulq_f16(vDecay, oq1), vKq, d1);
+        float16x8_t o2 = vfmaq_f16(vmulq_f16(vDecay, oq2), vKq, d2);
+        float16x8_t o3 = vfmaq_f16(vmulq_f16(vDecay, oq3), vKq, d3);
+        vst1q_f16(out + j,      o0);
+        vst1q_f16(out + j + 8,  o1);
+        vst1q_f16(out + j + 16, o2);
+        vst1q_f16(out + j + 24, o3);
+
+        // ── Pass 2: S = decay * S + k ⊗ delta (delta still in regs) ──
+        size_t i2 = 0;
+        for (; i2 + 8 <= dk; i2 += 8) {
+            float16x8_t kVec = vld1q_f16(k + i2);
+            #define ROW_UPDATE(lane)                                              \
+                {                                                                  \
+                    __fp16* row = S + (i2 + (lane)) * dv + j;                      \
+                    float16x8_t s0 = vld1q_f16(row);                               \
+                    float16x8_t s1 = vld1q_f16(row + 8);                           \
+                    float16x8_t s2 = vld1q_f16(row + 16);                          \
+                    float16x8_t s3 = vld1q_f16(row + 24);                          \
+                    float16x8_t r0 = vfmaq_laneq_f16(vmulq_f16(vDecay, s0), d0, kVec, (lane)); \
+                    float16x8_t r1 = vfmaq_laneq_f16(vmulq_f16(vDecay, s1), d1, kVec, (lane)); \
+                    float16x8_t r2 = vfmaq_laneq_f16(vmulq_f16(vDecay, s2), d2, kVec, (lane)); \
+                    float16x8_t r3 = vfmaq_laneq_f16(vmulq_f16(vDecay, s3), d3, kVec, (lane)); \
+                    vst1q_f16(row,      r0);                                       \
+                    vst1q_f16(row + 8,  r1);                                       \
+                    vst1q_f16(row + 16, r2);                                       \
+                    vst1q_f16(row + 24, r3);                                       \
+                }
+            ROW_UPDATE(0); ROW_UPDATE(1); ROW_UPDATE(2); ROW_UPDATE(3);
+            ROW_UPDATE(4); ROW_UPDATE(5); ROW_UPDATE(6); ROW_UPDATE(7);
+            #undef ROW_UPDATE
+        }
+        for (; i2 < dk; ++i2) {
+            __fp16* row = S + i2 * dv + j;
+            float16x8_t s0 = vld1q_f16(row);
+            float16x8_t s1 = vld1q_f16(row + 8);
+            float16x8_t s2 = vld1q_f16(row + 16);
+            float16x8_t s3 = vld1q_f16(row + 24);
+            __fp16 ki = k[i2];
+            float16x8_t r0 = vfmaq_n_f16(vmulq_f16(vDecay, s0), d0, ki);
+            float16x8_t r1 = vfmaq_n_f16(vmulq_f16(vDecay, s1), d1, ki);
+            float16x8_t r2 = vfmaq_n_f16(vmulq_f16(vDecay, s2), d2, ki);
+            float16x8_t r3 = vfmaq_n_f16(vmulq_f16(vDecay, s3), d3, ki);
+            vst1q_f16(row,      r0);
+            vst1q_f16(row + 8,  r1);
+            vst1q_f16(row + 16, r2);
+            vst1q_f16(row + 24, r3);
+        }
+    }
+
+    // ── Tail (chunks of 8) ──
+    for (; j + 8 <= dv; j += 8) {
+        float16x8_t ok = vdupq_n_f16((__fp16)0);
+        float16x8_t oq = vdupq_n_f16((__fp16)0);
+        for (size_t i = 0; i < dk; ++i) {
+            float16x8_t s = vld1q_f16(S + i * dv + j);
+            ok = vfmaq_n_f16(ok, s, k[i]);
+            oq = vfmaq_n_f16(oq, s, q[i]);
+        }
+        float16x8_t vv = vld1q_f16(vIn + j);
+        float16x8_t d  = vmulq_f16(vBeta, vsubq_f16(vv, vmulq_f16(vDecay, ok)));
+        float16x8_t o  = vfmaq_f16(vmulq_f16(vDecay, oq), vKq, d);
+        vst1q_f16(out + j, o);
+        for (size_t i = 0; i < dk; ++i) {
+            float16x8_t s = vld1q_f16(S + i * dv + j);
+            float16x8_t r = vfmaq_n_f16(vmulq_f16(vDecay, s), d, k[i]);
+            vst1q_f16(S + i * dv + j, r);
+        }
+    }
+
+    // ── Scalar tail (defensive; d_v < multiple of 8 not used in current models) ──
+    for (; j < dv; ++j) {
+        float ok = 0.0f, oq = 0.0f;
+        for (size_t i = 0; i < dk; ++i) {
+            float s = (float)S[i * dv + j];
+            ok += s * (float)k[i];
+            oq += s * (float)q[i];
+        }
+        float delta_j = beta * ((float)vIn[j] - decay * ok);
+        out[j] = (__fp16)(decay * oq + kq * delta_j);
+        for (size_t i = 0; i < dk; ++i) {
+            float s = (float)S[i * dv + j];
+            S[i * dv + j] = (__fp16)(decay * s + (float)k[i] * delta_j);
+        }
+    }
+}
+#endif // __aarch64__ && MNN_USE_NEON
+
+
 
 namespace MNN {
 
@@ -2730,6 +2912,11 @@ bool Arm82Functions::init() {
     FUNC_PTR_ASSIGN(gInstance->MNNRankOneUpdate, MNNRankOneUpdateFp16);
     FUNC_PTR_ASSIGN(gInstance->MNNDualMatVec, MNNDualMatVecFp16);
     FUNC_PTR_ASSIGN(gInstance->MNNDecayRankOneUpdate, MNNDecayRankOneUpdateFp16);
+#if defined(__aarch64__) && defined(MNN_USE_NEON)
+    // Fused kernel uses NEON intrinsics directly (not extern asm), so the
+    // assignment must follow the same guard as the function body above.
+    FUNC_PTR_ASSIGN(gInstance->MNNFusedGatedDelta, MNNFusedGatedDeltaFp16);
+#endif
 #endif // MNN_SUPPORT_TRANSFORMER_FUSE
 
     gInstance->MNNComputeMatMulForH_1 = _MNNComputeMatMulForH_1_FP16;

--- a/source/backend/arm82/Arm82Functions.cpp
+++ b/source/backend/arm82/Arm82Functions.cpp
@@ -92,55 +92,60 @@ void MNNDecayRankOneUpdateFp16(float* S, const float* k, const float* delta, flo
 // which matters at d_v=128 where holding both out_k and out_q for the
 // whole row would otherwise exceed the 32 NEON v register budget.
 // ──────────────────────────────────────────────────────────────────────────
-static void MNNFusedGatedDeltaFp16(float* S_, const float* k_, const float* q_, const float* v_,
-                                   float* out_, float decay, float beta, float kq,
-                                   size_t dk, size_t dv) {
-    auto S   = reinterpret_cast<__fp16*>(S_);
-    auto k   = reinterpret_cast<const __fp16*>(k_);
-    auto q   = reinterpret_cast<const __fp16*>(q_);
+static void MNNFusedGatedDeltaFp16(float* S_, const float* k_, const float* q_, const float* v_, float* out_,
+                                   float decay, float beta, float kq, size_t dk, size_t dv) {
+    auto S = reinterpret_cast<__fp16*>(S_);
+    auto k = reinterpret_cast<const __fp16*>(k_);
+    auto q = reinterpret_cast<const __fp16*>(q_);
     auto vIn = reinterpret_cast<const __fp16*>(v_);
     auto out = reinterpret_cast<__fp16*>(out_);
 
     const __fp16 decayH = static_cast<__fp16>(decay);
-    const __fp16 betaH  = static_cast<__fp16>(beta);
-    const __fp16 kqH    = static_cast<__fp16>(kq);
+    const __fp16 betaH = static_cast<__fp16>(beta);
+    const __fp16 kqH = static_cast<__fp16>(kq);
     const float16x8_t vDecay = vdupq_n_f16(decayH);
-    const float16x8_t vBeta  = vdupq_n_f16(betaH);
-    const float16x8_t vKq    = vdupq_n_f16(kqH);
+    const float16x8_t vBeta = vdupq_n_f16(betaH);
+    const float16x8_t vKq = vdupq_n_f16(kqH);
 
     const size_t kChunk = 32;
     size_t j = 0;
     for (; j + kChunk <= dv; j += kChunk) {
         // ── Pass 1: out_k = S^T @ k, out_q = S^T @ q for this column chunk ──
-        float16x8_t ok0 = vdupq_n_f16((__fp16)0), ok1 = vdupq_n_f16((__fp16)0),
-                    ok2 = vdupq_n_f16((__fp16)0), ok3 = vdupq_n_f16((__fp16)0);
-        float16x8_t oq0 = vdupq_n_f16((__fp16)0), oq1 = vdupq_n_f16((__fp16)0),
-                    oq2 = vdupq_n_f16((__fp16)0), oq3 = vdupq_n_f16((__fp16)0);
+        float16x8_t ok0 = vdupq_n_f16((__fp16)0), ok1 = vdupq_n_f16((__fp16)0), ok2 = vdupq_n_f16((__fp16)0),
+                    ok3 = vdupq_n_f16((__fp16)0);
+        float16x8_t oq0 = vdupq_n_f16((__fp16)0), oq1 = vdupq_n_f16((__fp16)0), oq2 = vdupq_n_f16((__fp16)0),
+                    oq3 = vdupq_n_f16((__fp16)0);
         size_t i = 0;
         // Unroll i by 8: load 8 k & q scalars at once, then use fma-by-lane
         // to amortize the scalar broadcast across 8 row iterations.
         for (; i + 8 <= dk; i += 8) {
             float16x8_t kVec = vld1q_f16(k + i);
             float16x8_t qVec = vld1q_f16(q + i);
-            #define LANE_STEP(lane)                                              \
-                {                                                                \
-                    const __fp16* row = S + (i + (lane)) * dv + j;               \
-                    float16x8_t s0 = vld1q_f16(row);                             \
-                    float16x8_t s1 = vld1q_f16(row + 8);                         \
-                    float16x8_t s2 = vld1q_f16(row + 16);                        \
-                    float16x8_t s3 = vld1q_f16(row + 24);                        \
-                    ok0 = vfmaq_laneq_f16(ok0, s0, kVec, (lane));                \
-                    ok1 = vfmaq_laneq_f16(ok1, s1, kVec, (lane));                \
-                    ok2 = vfmaq_laneq_f16(ok2, s2, kVec, (lane));                \
-                    ok3 = vfmaq_laneq_f16(ok3, s3, kVec, (lane));                \
-                    oq0 = vfmaq_laneq_f16(oq0, s0, qVec, (lane));                \
-                    oq1 = vfmaq_laneq_f16(oq1, s1, qVec, (lane));                \
-                    oq2 = vfmaq_laneq_f16(oq2, s2, qVec, (lane));                \
-                    oq3 = vfmaq_laneq_f16(oq3, s3, qVec, (lane));                \
-                }
-            LANE_STEP(0); LANE_STEP(1); LANE_STEP(2); LANE_STEP(3);
-            LANE_STEP(4); LANE_STEP(5); LANE_STEP(6); LANE_STEP(7);
-            #undef LANE_STEP
+#define LANE_STEP(lane)                                \
+    {                                                  \
+        const __fp16* row = S + (i + (lane)) * dv + j; \
+        float16x8_t s0 = vld1q_f16(row);               \
+        float16x8_t s1 = vld1q_f16(row + 8);           \
+        float16x8_t s2 = vld1q_f16(row + 16);          \
+        float16x8_t s3 = vld1q_f16(row + 24);          \
+        ok0 = vfmaq_laneq_f16(ok0, s0, kVec, (lane));  \
+        ok1 = vfmaq_laneq_f16(ok1, s1, kVec, (lane));  \
+        ok2 = vfmaq_laneq_f16(ok2, s2, kVec, (lane));  \
+        ok3 = vfmaq_laneq_f16(ok3, s3, kVec, (lane));  \
+        oq0 = vfmaq_laneq_f16(oq0, s0, qVec, (lane));  \
+        oq1 = vfmaq_laneq_f16(oq1, s1, qVec, (lane));  \
+        oq2 = vfmaq_laneq_f16(oq2, s2, qVec, (lane));  \
+        oq3 = vfmaq_laneq_f16(oq3, s3, qVec, (lane));  \
+    }
+            LANE_STEP(0);
+            LANE_STEP(1);
+            LANE_STEP(2);
+            LANE_STEP(3);
+            LANE_STEP(4);
+            LANE_STEP(5);
+            LANE_STEP(6);
+            LANE_STEP(7);
+#undef LANE_STEP
         }
         // Tail rows (dk % 8) — fall back to the broadcast form.
         for (; i < dk; ++i) {
@@ -176,8 +181,8 @@ static void MNNFusedGatedDeltaFp16(float* S_, const float* k_, const float* q_, 
         float16x8_t o1 = vfmaq_f16(vmulq_f16(vDecay, oq1), vKq, d1);
         float16x8_t o2 = vfmaq_f16(vmulq_f16(vDecay, oq2), vKq, d2);
         float16x8_t o3 = vfmaq_f16(vmulq_f16(vDecay, oq3), vKq, d3);
-        vst1q_f16(out + j,      o0);
-        vst1q_f16(out + j + 8,  o1);
+        vst1q_f16(out + j, o0);
+        vst1q_f16(out + j + 8, o1);
         vst1q_f16(out + j + 16, o2);
         vst1q_f16(out + j + 24, o3);
 
@@ -185,25 +190,31 @@ static void MNNFusedGatedDeltaFp16(float* S_, const float* k_, const float* q_, 
         size_t i2 = 0;
         for (; i2 + 8 <= dk; i2 += 8) {
             float16x8_t kVec = vld1q_f16(k + i2);
-            #define ROW_UPDATE(lane)                                              \
-                {                                                                  \
-                    __fp16* row = S + (i2 + (lane)) * dv + j;                      \
-                    float16x8_t s0 = vld1q_f16(row);                               \
-                    float16x8_t s1 = vld1q_f16(row + 8);                           \
-                    float16x8_t s2 = vld1q_f16(row + 16);                          \
-                    float16x8_t s3 = vld1q_f16(row + 24);                          \
-                    float16x8_t r0 = vfmaq_laneq_f16(vmulq_f16(vDecay, s0), d0, kVec, (lane)); \
-                    float16x8_t r1 = vfmaq_laneq_f16(vmulq_f16(vDecay, s1), d1, kVec, (lane)); \
-                    float16x8_t r2 = vfmaq_laneq_f16(vmulq_f16(vDecay, s2), d2, kVec, (lane)); \
-                    float16x8_t r3 = vfmaq_laneq_f16(vmulq_f16(vDecay, s3), d3, kVec, (lane)); \
-                    vst1q_f16(row,      r0);                                       \
-                    vst1q_f16(row + 8,  r1);                                       \
-                    vst1q_f16(row + 16, r2);                                       \
-                    vst1q_f16(row + 24, r3);                                       \
-                }
-            ROW_UPDATE(0); ROW_UPDATE(1); ROW_UPDATE(2); ROW_UPDATE(3);
-            ROW_UPDATE(4); ROW_UPDATE(5); ROW_UPDATE(6); ROW_UPDATE(7);
-            #undef ROW_UPDATE
+#define ROW_UPDATE(lane)                                                           \
+    {                                                                              \
+        __fp16* row = S + (i2 + (lane)) * dv + j;                                  \
+        float16x8_t s0 = vld1q_f16(row);                                           \
+        float16x8_t s1 = vld1q_f16(row + 8);                                       \
+        float16x8_t s2 = vld1q_f16(row + 16);                                      \
+        float16x8_t s3 = vld1q_f16(row + 24);                                      \
+        float16x8_t r0 = vfmaq_laneq_f16(vmulq_f16(vDecay, s0), d0, kVec, (lane)); \
+        float16x8_t r1 = vfmaq_laneq_f16(vmulq_f16(vDecay, s1), d1, kVec, (lane)); \
+        float16x8_t r2 = vfmaq_laneq_f16(vmulq_f16(vDecay, s2), d2, kVec, (lane)); \
+        float16x8_t r3 = vfmaq_laneq_f16(vmulq_f16(vDecay, s3), d3, kVec, (lane)); \
+        vst1q_f16(row, r0);                                                        \
+        vst1q_f16(row + 8, r1);                                                    \
+        vst1q_f16(row + 16, r2);                                                   \
+        vst1q_f16(row + 24, r3);                                                   \
+    }
+            ROW_UPDATE(0);
+            ROW_UPDATE(1);
+            ROW_UPDATE(2);
+            ROW_UPDATE(3);
+            ROW_UPDATE(4);
+            ROW_UPDATE(5);
+            ROW_UPDATE(6);
+            ROW_UPDATE(7);
+#undef ROW_UPDATE
         }
         for (; i2 < dk; ++i2) {
             __fp16* row = S + i2 * dv + j;
@@ -216,8 +227,8 @@ static void MNNFusedGatedDeltaFp16(float* S_, const float* k_, const float* q_, 
             float16x8_t r1 = vfmaq_n_f16(vmulq_f16(vDecay, s1), d1, ki);
             float16x8_t r2 = vfmaq_n_f16(vmulq_f16(vDecay, s2), d2, ki);
             float16x8_t r3 = vfmaq_n_f16(vmulq_f16(vDecay, s3), d3, ki);
-            vst1q_f16(row,      r0);
-            vst1q_f16(row + 8,  r1);
+            vst1q_f16(row, r0);
+            vst1q_f16(row + 8, r1);
             vst1q_f16(row + 16, r2);
             vst1q_f16(row + 24, r3);
         }
@@ -233,8 +244,8 @@ static void MNNFusedGatedDeltaFp16(float* S_, const float* k_, const float* q_, 
             oq = vfmaq_n_f16(oq, s, q[i]);
         }
         float16x8_t vv = vld1q_f16(vIn + j);
-        float16x8_t d  = vmulq_f16(vBeta, vsubq_f16(vv, vmulq_f16(vDecay, ok)));
-        float16x8_t o  = vfmaq_f16(vmulq_f16(vDecay, oq), vKq, d);
+        float16x8_t d = vmulq_f16(vBeta, vsubq_f16(vv, vmulq_f16(vDecay, ok)));
+        float16x8_t o = vfmaq_f16(vmulq_f16(vDecay, oq), vKq, d);
         vst1q_f16(out + j, o);
         for (size_t i = 0; i < dk; ++i) {
             float16x8_t s = vld1q_f16(S + i * dv + j);
@@ -260,8 +271,6 @@ static void MNNFusedGatedDeltaFp16(float* S_, const float* k_, const float* q_, 
     }
 }
 #endif // __aarch64__ && MNN_USE_NEON
-
-
 
 namespace MNN {
 

--- a/source/backend/cpu/CPULinearAttention.cpp
+++ b/source/backend/cpu/CPULinearAttention.cpp
@@ -105,9 +105,12 @@ ErrorCode CPULinearAttention::onResize(const std::vector<Tensor*>& inputs, const
     if (needRecurrentState) {
         int dk = mHeadKDim, dv = mHeadVDim;
         int threadNum = static_cast<CPUBackend*>(backend())->threadNumber();
-        // Per-thread scratch holds q_local + k_local + v_local; the fused
-        // MNNFusedGatedDelta kernel keeps vPred and delta in registers.
-        int perThread = 2 * dk + dv;
+        // Per-thread scratch holds q_local + k_local + v_local + vPred + delta.
+        // Prefill uses MNNFusedGatedDelta (only needs first 2*dk+dv) but decode
+        // falls back to the legacy two-call path (MNNDualMatVec + scalar
+        // correction + MNNDecayRankOneUpdate) which needs the full 2*dk+3*dv:
+        // the fused kernel regressed FP32 decode by ~3.5% on small L=1 shapes.
+        int perThread = 2 * dk + 3 * dv;
         mThreadLocalBuf.reset(Tensor::createDevice<int8_t>({threadNum * perThread * mBytes}));
         success = backend()->onAcquireBuffer(mThreadLocalBuf.get(), Backend::DYNAMIC);
         if (!success) return OUT_OF_MEMORY;
@@ -556,7 +559,9 @@ void CPULinearAttention::gated_delta_rule_mnn(const std::vector<Tensor*>& inputs
     const int totalHeads = B * H;
 
     int8_t* threadBufBase = mThreadLocalBuf->host<int8_t>();
-    const int perThread = 2 * d_k + d_v;
+    // Prefill uses fused kernel (only first 2*dk+dv touched) but the per-thread
+    // stride must match the larger allocation (decode's 2*dk+3*dv).
+    const int perThread = 2 * d_k + 3 * d_v;
 
     MNN_CONCURRENCY_BEGIN(tId, threadNum) {
         int8_t* tBuf = threadBufBase + (int)tId * perThread * bytes;
@@ -709,13 +714,17 @@ void CPULinearAttention::gated_delta_rule_decode(const std::vector<Tensor*>& inp
 
     const int totalHeads = B * H;
     auto* threadBufBase = mThreadLocalBuf->host<int8_t>();
-    const int perThread = 2 * d_k + d_v;
+    // Decode (L=1) keeps the legacy two-call path: the fused kernel regressed
+    // FP32 decode by ~3.5% on this shape (small d_v, single timestep).
+    const int perThread = 2 * d_k + 3 * d_v;
 
     MNN_CONCURRENCY_BEGIN(tId, threadNum) {
         int8_t* tBuf = threadBufBase + (int)tId * perThread * bytes;
         int8_t* q_local = tBuf;
         int8_t* k_local = tBuf + d_k * bytes;
         int8_t* v_local = tBuf + 2 * d_k * bytes;
+        int8_t* localVPred = tBuf + (2 * d_k + d_v) * bytes;
+        int8_t* localDelta = tBuf + (2 * d_k + 2 * d_v) * bytes;
 
         for (int idx = (int)tId; idx < totalHeads; idx += threadNum) {
             const int b = idx / H;
@@ -757,21 +766,34 @@ void CPULinearAttention::gated_delta_rule_decode(const std::vector<Tensor*>& inp
                 }
             }
 
-            // ── Step 5: Gated Delta Rule ──
+            // ── Step 5: Gated Delta Rule (legacy two-call path) ──
             const float decay = expf(_readElement(gatePtr, b * H + h, bytes));
             const float beta_t = _readElement(betaPtr, b * H + h, bytes);
 
-            // dot(k, q) — small reduction in fp32 for precision.
+            // Pass 1 (read-only): out_k = S^T @ k → localVPred,
+            //                     out_q = S^T @ q → o_t (overwritten by correction below).
+            int8_t* o_t = outPtr + (b * H * d_v + h * d_v) * bytes;
+            gcore->MNNDualMatVec((float*)state, (float*)k_local, (float*)q_local,
+                                 (float*)localVPred, (float*)o_t, d_k, d_v);
+
+            // Analytic correction: delta = beta * (v - decay * vPred);
+            //                      out   = decay * out_q + dot(k,q) * delta.
             float kq = 0.0f;
             for (int i = 0; i < d_k; ++i) {
                 kq += _readElement(k_local, i, bytes) * _readElement(q_local, i, bytes);
             }
+            for (int i = 0; i < d_v; ++i) {
+                const float vPred_i = decay * _readElement(localVPred, i, bytes);
+                const float v_i     = _readElement(v_local, i, bytes);
+                const float delta_i = beta_t * (v_i - vPred_i);
+                const float out_i   = decay * _readElement(o_t, i, bytes) + kq * delta_i;
+                _writeElement(localDelta, i, delta_i, bytes);
+                _writeElement(o_t, i, out_i, bytes);
+            }
 
-            // out_t is written; state S is updated in-place.
-            int8_t* o_t = outPtr + (b * H * d_v + h * d_v) * bytes;
-            gcore->MNNFusedGatedDelta((float*)state, (float*)k_local, (float*)q_local,
-                                      (float*)v_local, (float*)o_t, decay, beta_t, kq,
-                                      d_k, d_v);
+            // Pass 2: S = decay * S + k ⊗ delta.
+            gcore->MNNDecayRankOneUpdate((float*)state, (float*)k_local,
+                                         (float*)localDelta, decay, d_k, d_v);
         }
     }
     MNN_CONCURRENCY_END();

--- a/source/backend/cpu/CPULinearAttention.cpp
+++ b/source/backend/cpu/CPULinearAttention.cpp
@@ -630,9 +630,8 @@ void CPULinearAttention::gated_delta_rule_mnn(const std::vector<Tensor*>& inputs
 
                 // out_t is written; state S is updated in-place.
                 int8_t* o_t = outPtr + ((b * L + t) * H * d_v + h * d_v) * bytes;
-                gcore->MNNFusedGatedDelta((float*)state, (float*)k_local, (float*)q_local,
-                                          (float*)v_local, (float*)o_t, decay, beta_t, kq,
-                                          d_k, d_v);
+                gcore->MNNFusedGatedDelta((float*)state, (float*)k_local, (float*)q_local, (float*)v_local, (float*)o_t,
+                                          decay, beta_t, kq, d_k, d_v);
             } // end timestep
         } // end head
     }
@@ -773,8 +772,8 @@ void CPULinearAttention::gated_delta_rule_decode(const std::vector<Tensor*>& inp
             // Pass 1 (read-only): out_k = S^T @ k → localVPred,
             //                     out_q = S^T @ q → o_t (overwritten by correction below).
             int8_t* o_t = outPtr + (b * H * d_v + h * d_v) * bytes;
-            gcore->MNNDualMatVec((float*)state, (float*)k_local, (float*)q_local,
-                                 (float*)localVPred, (float*)o_t, d_k, d_v);
+            gcore->MNNDualMatVec((float*)state, (float*)k_local, (float*)q_local, (float*)localVPred, (float*)o_t, d_k,
+                                 d_v);
 
             // Analytic correction: delta = beta * (v - decay * vPred);
             //                      out   = decay * out_q + dot(k,q) * delta.
@@ -784,16 +783,15 @@ void CPULinearAttention::gated_delta_rule_decode(const std::vector<Tensor*>& inp
             }
             for (int i = 0; i < d_v; ++i) {
                 const float vPred_i = decay * _readElement(localVPred, i, bytes);
-                const float v_i     = _readElement(v_local, i, bytes);
+                const float v_i = _readElement(v_local, i, bytes);
                 const float delta_i = beta_t * (v_i - vPred_i);
-                const float out_i   = decay * _readElement(o_t, i, bytes) + kq * delta_i;
+                const float out_i = decay * _readElement(o_t, i, bytes) + kq * delta_i;
                 _writeElement(localDelta, i, delta_i, bytes);
                 _writeElement(o_t, i, out_i, bytes);
             }
 
             // Pass 2: S = decay * S + k ⊗ delta.
-            gcore->MNNDecayRankOneUpdate((float*)state, (float*)k_local,
-                                         (float*)localDelta, decay, d_k, d_v);
+            gcore->MNNDecayRankOneUpdate((float*)state, (float*)k_local, (float*)localDelta, decay, d_k, d_v);
         }
     }
     MNN_CONCURRENCY_END();

--- a/source/backend/cpu/CPULinearAttention.cpp
+++ b/source/backend/cpu/CPULinearAttention.cpp
@@ -105,7 +105,9 @@ ErrorCode CPULinearAttention::onResize(const std::vector<Tensor*>& inputs, const
     if (needRecurrentState) {
         int dk = mHeadKDim, dv = mHeadVDim;
         int threadNum = static_cast<CPUBackend*>(backend())->threadNumber();
-        int perThread = 2 * dk + 3 * dv; // q_local + k_local + v_local + vpred + delta
+        // Per-thread scratch holds q_local + k_local + v_local; the fused
+        // MNNFusedGatedDelta kernel keeps vPred and delta in registers.
+        int perThread = 2 * dk + dv;
         mThreadLocalBuf.reset(Tensor::createDevice<int8_t>({threadNum * perThread * mBytes}));
         success = backend()->onAcquireBuffer(mThreadLocalBuf.get(), Backend::DYNAMIC);
         if (!success) return OUT_OF_MEMORY;
@@ -554,16 +556,14 @@ void CPULinearAttention::gated_delta_rule_mnn(const std::vector<Tensor*>& inputs
     const int totalHeads = B * H;
 
     int8_t* threadBufBase = mThreadLocalBuf->host<int8_t>();
-    const int perThread = 2 * d_k + 3 * d_v;
+    const int perThread = 2 * d_k + d_v;
 
     MNN_CONCURRENCY_BEGIN(tId, threadNum) {
         int8_t* tBuf = threadBufBase + (int)tId * perThread * bytes;
         // Local buffers in native format (fp16 or fp32)
-        int8_t* q_local    = tBuf;
-        int8_t* k_local    = tBuf + d_k * bytes;
-        int8_t* v_local    = tBuf + 2 * d_k * bytes;
-        int8_t* localVPred = tBuf + (2 * d_k + d_v) * bytes;
-        int8_t* localDelta = tBuf + (2 * d_k + 2 * d_v) * bytes;
+        int8_t* q_local = tBuf;
+        int8_t* k_local = tBuf + d_k * bytes;
+        int8_t* v_local = tBuf + 2 * d_k * bytes;
 
         for (int idx = (int)tId; idx < totalHeads; idx += threadNum) {
             int b = idx / H;
@@ -613,32 +613,21 @@ void CPULinearAttention::gated_delta_rule_mnn(const std::vector<Tensor*>& inputs
                     }
                 }
 
-                // ── Step 5: Gated Delta Rule recurrence (optimized 2-pass) ──
+                // ── Step 5: Gated Delta Rule recurrence ──
                 float decay  = decayPtr[b * L * H + t * H + h];
                 float beta_t = _readElement(betaPtr, b * L * H + t * H + h, bytes);
 
-                // Pass 1 (read-only): compute S^T@k and S^T@q simultaneously
-                int8_t* o_t = outPtr + ((b * L + t) * H * d_v + h * d_v) * bytes;
-                gcore->MNNDualMatVec((float*)state, (float*)k_local, (float*)q_local,
-                                     (float*)localVPred, (float*)o_t, d_k, d_v);
-
-                // Analytic: vPred = decay * (S^T@k), out = decay * (S^T@q) + dot(k,q) * delta
+                // dot(k, q) — small reduction in fp32 for precision.
                 float kq = 0.0f;
                 for (int i = 0; i < d_k; ++i) {
                     kq += _readElement(k_local, i, bytes) * _readElement(q_local, i, bytes);
                 }
-                for (int i = 0; i < d_v; ++i) {
-                    float vPred_i = decay * _readElement(localVPred, i, bytes);
-                    float v_i     = _readElement(v_local, i, bytes);
-                    float delta_i = beta_t * (v_i - vPred_i);
-                    float out_i   = decay * _readElement(o_t, i, bytes) + kq * delta_i;
-                    _writeElement(localDelta, i, delta_i, bytes);
-                    _writeElement(o_t, i, out_i, bytes);
-                }
 
-                // Pass 2: S = decay*S + k⊗delta
-                gcore->MNNDecayRankOneUpdate((float*)state, (float*)k_local,
-                                             (float*)localDelta, decay, d_k, d_v);
+                // out_t is written; state S is updated in-place.
+                int8_t* o_t = outPtr + ((b * L + t) * H * d_v + h * d_v) * bytes;
+                gcore->MNNFusedGatedDelta((float*)state, (float*)k_local, (float*)q_local,
+                                          (float*)v_local, (float*)o_t, decay, beta_t, kq,
+                                          d_k, d_v);
             } // end timestep
         } // end head
     }
@@ -720,15 +709,13 @@ void CPULinearAttention::gated_delta_rule_decode(const std::vector<Tensor*>& inp
 
     const int totalHeads = B * H;
     auto* threadBufBase = mThreadLocalBuf->host<int8_t>();
-    const int perThread = 2 * d_k + 3 * d_v;
+    const int perThread = 2 * d_k + d_v;
 
     MNN_CONCURRENCY_BEGIN(tId, threadNum) {
         int8_t* tBuf = threadBufBase + (int)tId * perThread * bytes;
         int8_t* q_local = tBuf;
         int8_t* k_local = tBuf + d_k * bytes;
         int8_t* v_local = tBuf + 2 * d_k * bytes;
-        int8_t* localVPred = tBuf + (2 * d_k + d_v) * bytes;
-        int8_t* localDelta = tBuf + (2 * d_k + 2 * d_v) * bytes;
 
         for (int idx = (int)tId; idx < totalHeads; idx += threadNum) {
             const int b = idx / H;
@@ -770,31 +757,21 @@ void CPULinearAttention::gated_delta_rule_decode(const std::vector<Tensor*>& inp
                 }
             }
 
-            // ── Step 5: Gated Delta Rule (inline decay, no pre-computed buffer) ──
+            // ── Step 5: Gated Delta Rule ──
             const float decay = expf(_readElement(gatePtr, b * H + h, bytes));
             const float beta_t = _readElement(betaPtr, b * H + h, bytes);
 
-            // Pass 1 (read-only): compute S^T@k and S^T@q simultaneously
-            int8_t* o_t = outPtr + (b * H * d_v + h * d_v) * bytes;
-            gcore->MNNDualMatVec((float*)state, (float*)k_local, (float*)q_local, (float*)localVPred, (float*)o_t, d_k,
-                                 d_v);
-
-            // Analytic correction
+            // dot(k, q) — small reduction in fp32 for precision.
             float kq = 0.0f;
             for (int i = 0; i < d_k; ++i) {
                 kq += _readElement(k_local, i, bytes) * _readElement(q_local, i, bytes);
             }
-            for (int i = 0; i < d_v; ++i) {
-                const float vPred_i = decay * _readElement(localVPred, i, bytes);
-                const float v_i = _readElement(v_local, i, bytes);
-                const float delta_i = beta_t * (v_i - vPred_i);
-                const float out_i = decay * _readElement(o_t, i, bytes) + kq * delta_i;
-                _writeElement(localDelta, i, delta_i, bytes);
-                _writeElement(o_t, i, out_i, bytes);
-            }
 
-            // Pass 2: S = decay*S + k⊗delta
-            gcore->MNNDecayRankOneUpdate((float*)state, (float*)k_local, (float*)localDelta, decay, d_k, d_v);
+            // out_t is written; state S is updated in-place.
+            int8_t* o_t = outPtr + (b * H * d_v + h * d_v) * bytes;
+            gcore->MNNFusedGatedDelta((float*)state, (float*)k_local, (float*)q_local,
+                                      (float*)v_local, (float*)o_t, decay, beta_t, kq,
+                                      d_k, d_v);
         }
     }
     MNN_CONCURRENCY_END();

--- a/source/backend/cpu/compute/CommonOptFunction.cpp
+++ b/source/backend/cpu/compute/CommonOptFunction.cpp
@@ -4091,6 +4091,183 @@ void MNNDecayRankOneUpdateDefault(float* S, const float* k, const float* delta, 
 }
 #endif
 
+// ─────────────────────────────────────────────────────────────────────────
+// MNNFusedGatedDelta — fused gated_delta_rule recurrence step.
+//
+// Processes S column-wise in chunks of `kChunk` (=16 elements for fp32,
+// four v.4s lanes). For each chunk j..j+kChunk-1:
+//   Pass 1: stream rows [0,d_k) and accumulate out_k, out_q in registers.
+//   Inline correction: still in registers, compute
+//             delta = beta * (v - decay * out_k)
+//             out   = decay * out_q + kq * delta
+//           Store `out`; keep delta resident.
+//   Pass 2: stream rows [0,d_k) again and update S in-place using the
+//           in-register delta.
+//
+// Requires d_v to be a multiple of 16 in fp32 (Qwen3-Next-style heads use
+// d_v ∈ {64, 128, 256}). A scalar tail covers the remainder defensively.
+// ─────────────────────────────────────────────────────────────────────────
+static void MNNFusedGatedDeltaDefault(float* S, const float* k, const float* q, const float* v,
+                                      float* out, float decay, float beta, float kq,
+                                      size_t dk, size_t dv) {
+#if defined(__aarch64__) && defined(MNN_USE_NEON)
+    // FP32 chunk = 16 elements (4 v.4s registers per accumulator).
+    // The inner loop is unrolled by 4 rows so a single vld1q_f32 of
+    // (k[i], k[i+1], k[i+2], k[i+3]) feeds 4 vfmaq_laneq_f32 ops via
+    // .s[lane], amortizing the scalar broadcast across 4 row iterations.
+    const size_t kChunk = 16;
+    const float32x4_t vDecay = vdupq_n_f32(decay);
+    const float32x4_t vBeta  = vdupq_n_f32(beta);
+    const float32x4_t vKq    = vdupq_n_f32(kq);
+
+    size_t j = 0;
+    for (; j + kChunk <= dv; j += kChunk) {
+        // ── Pass 1: out_k = S^T @ k, out_q = S^T @ q for this column chunk ──
+        float32x4_t ok0 = vdupq_n_f32(0.0f), ok1 = vdupq_n_f32(0.0f),
+                    ok2 = vdupq_n_f32(0.0f), ok3 = vdupq_n_f32(0.0f);
+        float32x4_t oq0 = vdupq_n_f32(0.0f), oq1 = vdupq_n_f32(0.0f),
+                    oq2 = vdupq_n_f32(0.0f), oq3 = vdupq_n_f32(0.0f);
+
+        size_t i = 0;
+        for (; i + 4 <= dk; i += 4) {
+            float32x4_t kVec = vld1q_f32(k + i);
+            float32x4_t qVec = vld1q_f32(q + i);
+            #define LANE_STEP_FP32(lane)                                          \
+                {                                                                  \
+                    const float* row = S + (i + (lane)) * dv + j;                  \
+                    float32x4_t s0 = vld1q_f32(row);                               \
+                    float32x4_t s1 = vld1q_f32(row + 4);                           \
+                    float32x4_t s2 = vld1q_f32(row + 8);                           \
+                    float32x4_t s3 = vld1q_f32(row + 12);                          \
+                    ok0 = vfmaq_laneq_f32(ok0, s0, kVec, (lane));                  \
+                    ok1 = vfmaq_laneq_f32(ok1, s1, kVec, (lane));                  \
+                    ok2 = vfmaq_laneq_f32(ok2, s2, kVec, (lane));                  \
+                    ok3 = vfmaq_laneq_f32(ok3, s3, kVec, (lane));                  \
+                    oq0 = vfmaq_laneq_f32(oq0, s0, qVec, (lane));                  \
+                    oq1 = vfmaq_laneq_f32(oq1, s1, qVec, (lane));                  \
+                    oq2 = vfmaq_laneq_f32(oq2, s2, qVec, (lane));                  \
+                    oq3 = vfmaq_laneq_f32(oq3, s3, qVec, (lane));                  \
+                }
+            LANE_STEP_FP32(0); LANE_STEP_FP32(1);
+            LANE_STEP_FP32(2); LANE_STEP_FP32(3);
+            #undef LANE_STEP_FP32
+        }
+        // Tail rows (dk % 4) — fall back to scalar broadcast form.
+        for (; i < dk; ++i) {
+            const float* row = S + i * dv + j;
+            float32x4_t s0 = vld1q_f32(row);
+            float32x4_t s1 = vld1q_f32(row + 4);
+            float32x4_t s2 = vld1q_f32(row + 8);
+            float32x4_t s3 = vld1q_f32(row + 12);
+            ok0 = vfmaq_n_f32(ok0, s0, k[i]);
+            ok1 = vfmaq_n_f32(ok1, s1, k[i]);
+            ok2 = vfmaq_n_f32(ok2, s2, k[i]);
+            ok3 = vfmaq_n_f32(ok3, s3, k[i]);
+            oq0 = vfmaq_n_f32(oq0, s0, q[i]);
+            oq1 = vfmaq_n_f32(oq1, s1, q[i]);
+            oq2 = vfmaq_n_f32(oq2, s2, q[i]);
+            oq3 = vfmaq_n_f32(oq3, s3, q[i]);
+        }
+
+        // ── Inline analytic correction (regs only) ──
+        float32x4_t v0 = vld1q_f32(v + j);
+        float32x4_t v1 = vld1q_f32(v + j + 4);
+        float32x4_t v2 = vld1q_f32(v + j + 8);
+        float32x4_t v3 = vld1q_f32(v + j + 12);
+        // delta = beta * (v - decay * out_k)
+        float32x4_t d0 = vmulq_f32(vBeta, vsubq_f32(v0, vmulq_f32(vDecay, ok0)));
+        float32x4_t d1 = vmulq_f32(vBeta, vsubq_f32(v1, vmulq_f32(vDecay, ok1)));
+        float32x4_t d2 = vmulq_f32(vBeta, vsubq_f32(v2, vmulq_f32(vDecay, ok2)));
+        float32x4_t d3 = vmulq_f32(vBeta, vsubq_f32(v3, vmulq_f32(vDecay, ok3)));
+        // out = decay * out_q + kq * delta
+        float32x4_t o0 = vfmaq_f32(vmulq_f32(vDecay, oq0), vKq, d0);
+        float32x4_t o1 = vfmaq_f32(vmulq_f32(vDecay, oq1), vKq, d1);
+        float32x4_t o2 = vfmaq_f32(vmulq_f32(vDecay, oq2), vKq, d2);
+        float32x4_t o3 = vfmaq_f32(vmulq_f32(vDecay, oq3), vKq, d3);
+        vst1q_f32(out + j,      o0);
+        vst1q_f32(out + j + 4,  o1);
+        vst1q_f32(out + j + 8,  o2);
+        vst1q_f32(out + j + 12, o3);
+
+        // ── Pass 2: S = decay * S + k ⊗ delta (delta d0..d3 still in regs) ──
+        size_t i2 = 0;
+        for (; i2 + 4 <= dk; i2 += 4) {
+            float32x4_t kVec = vld1q_f32(k + i2);
+            #define ROW_UPDATE_FP32(lane)                                              \
+                {                                                                       \
+                    float* row = S + (i2 + (lane)) * dv + j;                            \
+                    float32x4_t s0 = vld1q_f32(row);                                    \
+                    float32x4_t s1 = vld1q_f32(row + 4);                                \
+                    float32x4_t s2 = vld1q_f32(row + 8);                                \
+                    float32x4_t s3 = vld1q_f32(row + 12);                               \
+                    float32x4_t r0 = vfmaq_laneq_f32(vmulq_f32(vDecay, s0), d0, kVec, (lane)); \
+                    float32x4_t r1 = vfmaq_laneq_f32(vmulq_f32(vDecay, s1), d1, kVec, (lane)); \
+                    float32x4_t r2 = vfmaq_laneq_f32(vmulq_f32(vDecay, s2), d2, kVec, (lane)); \
+                    float32x4_t r3 = vfmaq_laneq_f32(vmulq_f32(vDecay, s3), d3, kVec, (lane)); \
+                    vst1q_f32(row,      r0);                                            \
+                    vst1q_f32(row + 4,  r1);                                            \
+                    vst1q_f32(row + 8,  r2);                                            \
+                    vst1q_f32(row + 12, r3);                                            \
+                }
+            ROW_UPDATE_FP32(0); ROW_UPDATE_FP32(1);
+            ROW_UPDATE_FP32(2); ROW_UPDATE_FP32(3);
+            #undef ROW_UPDATE_FP32
+        }
+        for (; i2 < dk; ++i2) {
+            float* row = S + i2 * dv + j;
+            float32x4_t s0 = vld1q_f32(row);
+            float32x4_t s1 = vld1q_f32(row + 4);
+            float32x4_t s2 = vld1q_f32(row + 8);
+            float32x4_t s3 = vld1q_f32(row + 12);
+            float32x4_t r0 = vfmaq_n_f32(vmulq_f32(vDecay, s0), d0, k[i2]);
+            float32x4_t r1 = vfmaq_n_f32(vmulq_f32(vDecay, s1), d1, k[i2]);
+            float32x4_t r2 = vfmaq_n_f32(vmulq_f32(vDecay, s2), d2, k[i2]);
+            float32x4_t r3 = vfmaq_n_f32(vmulq_f32(vDecay, s3), d3, k[i2]);
+            vst1q_f32(row,      r0);
+            vst1q_f32(row + 4,  r1);
+            vst1q_f32(row + 8,  r2);
+            vst1q_f32(row + 12, r3);
+        }
+    }
+    // Scalar tail (guards d_v not divisible by 16 — defensive only)
+    for (; j < dv; ++j) {
+        float ok = 0.0f, oq = 0.0f;
+        for (size_t i = 0; i < dk; ++i) {
+            float s = S[i * dv + j];
+            ok += s * k[i];
+            oq += s * q[i];
+        }
+        float delta_j = beta * (v[j] - decay * ok);
+        out[j] = decay * oq + kq * delta_j;
+        for (size_t i = 0; i < dk; ++i) {
+            S[i * dv + j] = decay * S[i * dv + j] + k[i] * delta_j;
+        }
+    }
+#else
+    // Pure scalar fallback (non-aarch64 / no NEON): same math, no SIMD.
+    // We need delta cached because Pass 2 uses it after Pass 1+correction.
+    std::vector<float> deltaBuf(dv);
+    for (size_t j = 0; j < dv; ++j) {
+        float ok = 0.0f, oq = 0.0f;
+        for (size_t i = 0; i < dk; ++i) {
+            float s = S[i * dv + j];
+            ok += s * k[i];
+            oq += s * q[i];
+        }
+        float delta_j = beta * (v[j] - decay * ok);
+        deltaBuf[j] = delta_j;
+        out[j] = decay * oq + kq * delta_j;
+    }
+    for (size_t i = 0; i < dk; ++i) {
+        float k_val = k[i];
+        float* row = S + i * dv;
+        for (size_t j = 0; j < dv; ++j) {
+            row[j] = decay * row[j] + k_val * deltaBuf[j];
+        }
+    }
+#endif
+}
+
 void MNNComputeMatMulForE_1(const float* A, const float* B, float* C, const float* biasPtr, const MatMulParam* param, size_t tIdL) {
     auto l = param->l;
     auto h = param->h;
@@ -4619,6 +4796,7 @@ void MNNCoreFunctionInit() {
     gCoreFunction->MNNRankOneUpdate = MNNRankOneUpdateDefault;
     gCoreFunction->MNNDualMatVec = MNNDualMatVecDefault;
     gCoreFunction->MNNDecayRankOneUpdate = MNNDecayRankOneUpdateDefault;
+    gCoreFunction->MNNFusedGatedDelta = MNNFusedGatedDeltaDefault;
 
     // Lowp
     gCoreFunction->MNNFp32ToLowp = nullptr;

--- a/source/backend/cpu/compute/CommonOptFunction.cpp
+++ b/source/backend/cpu/compute/CommonOptFunction.cpp
@@ -4107,9 +4107,8 @@ void MNNDecayRankOneUpdateDefault(float* S, const float* k, const float* delta, 
 // Requires d_v to be a multiple of 16 in fp32 (Qwen3-Next-style heads use
 // d_v ∈ {64, 128, 256}). A scalar tail covers the remainder defensively.
 // ─────────────────────────────────────────────────────────────────────────
-static void MNNFusedGatedDeltaDefault(float* S, const float* k, const float* q, const float* v,
-                                      float* out, float decay, float beta, float kq,
-                                      size_t dk, size_t dv) {
+static void MNNFusedGatedDeltaDefault(float* S, const float* k, const float* q, const float* v, float* out, float decay,
+                                      float beta, float kq, size_t dk, size_t dv) {
 #if defined(__aarch64__) && defined(MNN_USE_NEON)
     // FP32 chunk = 16 elements (4 v.4s registers per accumulator).
     // The inner loop is unrolled by 4 rows so a single vld1q_f32 of
@@ -4117,40 +4116,40 @@ static void MNNFusedGatedDeltaDefault(float* S, const float* k, const float* q, 
     // .s[lane], amortizing the scalar broadcast across 4 row iterations.
     const size_t kChunk = 16;
     const float32x4_t vDecay = vdupq_n_f32(decay);
-    const float32x4_t vBeta  = vdupq_n_f32(beta);
-    const float32x4_t vKq    = vdupq_n_f32(kq);
+    const float32x4_t vBeta = vdupq_n_f32(beta);
+    const float32x4_t vKq = vdupq_n_f32(kq);
 
     size_t j = 0;
     for (; j + kChunk <= dv; j += kChunk) {
         // ── Pass 1: out_k = S^T @ k, out_q = S^T @ q for this column chunk ──
-        float32x4_t ok0 = vdupq_n_f32(0.0f), ok1 = vdupq_n_f32(0.0f),
-                    ok2 = vdupq_n_f32(0.0f), ok3 = vdupq_n_f32(0.0f);
-        float32x4_t oq0 = vdupq_n_f32(0.0f), oq1 = vdupq_n_f32(0.0f),
-                    oq2 = vdupq_n_f32(0.0f), oq3 = vdupq_n_f32(0.0f);
+        float32x4_t ok0 = vdupq_n_f32(0.0f), ok1 = vdupq_n_f32(0.0f), ok2 = vdupq_n_f32(0.0f), ok3 = vdupq_n_f32(0.0f);
+        float32x4_t oq0 = vdupq_n_f32(0.0f), oq1 = vdupq_n_f32(0.0f), oq2 = vdupq_n_f32(0.0f), oq3 = vdupq_n_f32(0.0f);
 
         size_t i = 0;
         for (; i + 4 <= dk; i += 4) {
             float32x4_t kVec = vld1q_f32(k + i);
             float32x4_t qVec = vld1q_f32(q + i);
-            #define LANE_STEP_FP32(lane)                                          \
-                {                                                                  \
-                    const float* row = S + (i + (lane)) * dv + j;                  \
-                    float32x4_t s0 = vld1q_f32(row);                               \
-                    float32x4_t s1 = vld1q_f32(row + 4);                           \
-                    float32x4_t s2 = vld1q_f32(row + 8);                           \
-                    float32x4_t s3 = vld1q_f32(row + 12);                          \
-                    ok0 = vfmaq_laneq_f32(ok0, s0, kVec, (lane));                  \
-                    ok1 = vfmaq_laneq_f32(ok1, s1, kVec, (lane));                  \
-                    ok2 = vfmaq_laneq_f32(ok2, s2, kVec, (lane));                  \
-                    ok3 = vfmaq_laneq_f32(ok3, s3, kVec, (lane));                  \
-                    oq0 = vfmaq_laneq_f32(oq0, s0, qVec, (lane));                  \
-                    oq1 = vfmaq_laneq_f32(oq1, s1, qVec, (lane));                  \
-                    oq2 = vfmaq_laneq_f32(oq2, s2, qVec, (lane));                  \
-                    oq3 = vfmaq_laneq_f32(oq3, s3, qVec, (lane));                  \
-                }
-            LANE_STEP_FP32(0); LANE_STEP_FP32(1);
-            LANE_STEP_FP32(2); LANE_STEP_FP32(3);
-            #undef LANE_STEP_FP32
+#define LANE_STEP_FP32(lane)                          \
+    {                                                 \
+        const float* row = S + (i + (lane)) * dv + j; \
+        float32x4_t s0 = vld1q_f32(row);              \
+        float32x4_t s1 = vld1q_f32(row + 4);          \
+        float32x4_t s2 = vld1q_f32(row + 8);          \
+        float32x4_t s3 = vld1q_f32(row + 12);         \
+        ok0 = vfmaq_laneq_f32(ok0, s0, kVec, (lane)); \
+        ok1 = vfmaq_laneq_f32(ok1, s1, kVec, (lane)); \
+        ok2 = vfmaq_laneq_f32(ok2, s2, kVec, (lane)); \
+        ok3 = vfmaq_laneq_f32(ok3, s3, kVec, (lane)); \
+        oq0 = vfmaq_laneq_f32(oq0, s0, qVec, (lane)); \
+        oq1 = vfmaq_laneq_f32(oq1, s1, qVec, (lane)); \
+        oq2 = vfmaq_laneq_f32(oq2, s2, qVec, (lane)); \
+        oq3 = vfmaq_laneq_f32(oq3, s3, qVec, (lane)); \
+    }
+            LANE_STEP_FP32(0);
+            LANE_STEP_FP32(1);
+            LANE_STEP_FP32(2);
+            LANE_STEP_FP32(3);
+#undef LANE_STEP_FP32
         }
         // Tail rows (dk % 4) — fall back to scalar broadcast form.
         for (; i < dk; ++i) {
@@ -4184,34 +4183,36 @@ static void MNNFusedGatedDeltaDefault(float* S, const float* k, const float* q, 
         float32x4_t o1 = vfmaq_f32(vmulq_f32(vDecay, oq1), vKq, d1);
         float32x4_t o2 = vfmaq_f32(vmulq_f32(vDecay, oq2), vKq, d2);
         float32x4_t o3 = vfmaq_f32(vmulq_f32(vDecay, oq3), vKq, d3);
-        vst1q_f32(out + j,      o0);
-        vst1q_f32(out + j + 4,  o1);
-        vst1q_f32(out + j + 8,  o2);
+        vst1q_f32(out + j, o0);
+        vst1q_f32(out + j + 4, o1);
+        vst1q_f32(out + j + 8, o2);
         vst1q_f32(out + j + 12, o3);
 
         // ── Pass 2: S = decay * S + k ⊗ delta (delta d0..d3 still in regs) ──
         size_t i2 = 0;
         for (; i2 + 4 <= dk; i2 += 4) {
             float32x4_t kVec = vld1q_f32(k + i2);
-            #define ROW_UPDATE_FP32(lane)                                              \
-                {                                                                       \
-                    float* row = S + (i2 + (lane)) * dv + j;                            \
-                    float32x4_t s0 = vld1q_f32(row);                                    \
-                    float32x4_t s1 = vld1q_f32(row + 4);                                \
-                    float32x4_t s2 = vld1q_f32(row + 8);                                \
-                    float32x4_t s3 = vld1q_f32(row + 12);                               \
-                    float32x4_t r0 = vfmaq_laneq_f32(vmulq_f32(vDecay, s0), d0, kVec, (lane)); \
-                    float32x4_t r1 = vfmaq_laneq_f32(vmulq_f32(vDecay, s1), d1, kVec, (lane)); \
-                    float32x4_t r2 = vfmaq_laneq_f32(vmulq_f32(vDecay, s2), d2, kVec, (lane)); \
-                    float32x4_t r3 = vfmaq_laneq_f32(vmulq_f32(vDecay, s3), d3, kVec, (lane)); \
-                    vst1q_f32(row,      r0);                                            \
-                    vst1q_f32(row + 4,  r1);                                            \
-                    vst1q_f32(row + 8,  r2);                                            \
-                    vst1q_f32(row + 12, r3);                                            \
-                }
-            ROW_UPDATE_FP32(0); ROW_UPDATE_FP32(1);
-            ROW_UPDATE_FP32(2); ROW_UPDATE_FP32(3);
-            #undef ROW_UPDATE_FP32
+#define ROW_UPDATE_FP32(lane)                                                      \
+    {                                                                              \
+        float* row = S + (i2 + (lane)) * dv + j;                                   \
+        float32x4_t s0 = vld1q_f32(row);                                           \
+        float32x4_t s1 = vld1q_f32(row + 4);                                       \
+        float32x4_t s2 = vld1q_f32(row + 8);                                       \
+        float32x4_t s3 = vld1q_f32(row + 12);                                      \
+        float32x4_t r0 = vfmaq_laneq_f32(vmulq_f32(vDecay, s0), d0, kVec, (lane)); \
+        float32x4_t r1 = vfmaq_laneq_f32(vmulq_f32(vDecay, s1), d1, kVec, (lane)); \
+        float32x4_t r2 = vfmaq_laneq_f32(vmulq_f32(vDecay, s2), d2, kVec, (lane)); \
+        float32x4_t r3 = vfmaq_laneq_f32(vmulq_f32(vDecay, s3), d3, kVec, (lane)); \
+        vst1q_f32(row, r0);                                                        \
+        vst1q_f32(row + 4, r1);                                                    \
+        vst1q_f32(row + 8, r2);                                                    \
+        vst1q_f32(row + 12, r3);                                                   \
+    }
+            ROW_UPDATE_FP32(0);
+            ROW_UPDATE_FP32(1);
+            ROW_UPDATE_FP32(2);
+            ROW_UPDATE_FP32(3);
+#undef ROW_UPDATE_FP32
         }
         for (; i2 < dk; ++i2) {
             float* row = S + i2 * dv + j;
@@ -4223,9 +4224,9 @@ static void MNNFusedGatedDeltaDefault(float* S, const float* k, const float* q, 
             float32x4_t r1 = vfmaq_n_f32(vmulq_f32(vDecay, s1), d1, k[i2]);
             float32x4_t r2 = vfmaq_n_f32(vmulq_f32(vDecay, s2), d2, k[i2]);
             float32x4_t r3 = vfmaq_n_f32(vmulq_f32(vDecay, s3), d3, k[i2]);
-            vst1q_f32(row,      r0);
-            vst1q_f32(row + 4,  r1);
-            vst1q_f32(row + 8,  r2);
+            vst1q_f32(row, r0);
+            vst1q_f32(row + 4, r1);
+            vst1q_f32(row + 8, r2);
             vst1q_f32(row + 12, r3);
         }
     }

--- a/source/backend/cpu/compute/CommonOptFunction.h
+++ b/source/backend/cpu/compute/CommonOptFunction.h
@@ -299,9 +299,8 @@ struct CoreFunctions {
     //     out   = decay * out_q + kq * delta                    [d_v] (written)
     //     S     = decay * S + k ⊗ delta                         [d_k, d_v] (in-place)
     // 'kq' must be precomputed as dot(k,q) by the caller.
-    void(*MNNFusedGatedDelta)(float* S, const float* k, const float* q, const float* v,
-                              float* out, float decay, float beta, float kq,
-                              size_t dk, size_t dv);
+    void (*MNNFusedGatedDelta)(float* S, const float* k, const float* q, const float* v, float* out, float decay,
+                               float beta, float kq, size_t dk, size_t dv);
     void(*MNNCountMaxMinValue)(const float* source, float* minVal, float* maxVal, size_t size);
     void(*MNNDynamicUpdateConvBiasScale)(float* newbias, float* oldbias, float* weightKernelSum, float* inputZero, size_t ocQuad);
     void(*MNNAsyQuantInfo)(float* scale, float* bias, float* qscale, float* qbias, float* dstMin, float* dstMax, const float* src, const size_t* info);

--- a/source/backend/cpu/compute/CommonOptFunction.h
+++ b/source/backend/cpu/compute/CommonOptFunction.h
@@ -290,6 +290,18 @@ struct CoreFunctions {
     void(*MNNDualMatVec)(const float* S, const float* k, const float* q, float* out_k, float* out_q, size_t dk, size_t dv);
     // Fused decay + rank-1 update: S[i,j] = decay * S[i,j] + k[i] * delta[j]
     void(*MNNDecayRankOneUpdate)(float* S, const float* k, const float* delta, float decay, size_t dk, size_t dv);
+    // Fused gated-delta-rule kernel. Computes (all in the backend's native
+    // precision — fp32 in default backend, fp16 in arm82; pointer type is
+    // float* by convention):
+    //     out_k = S^T @ k                                       [d_v]
+    //     out_q = S^T @ q                                       [d_v]
+    //     delta = beta * (v - decay * out_k)                    [d_v]
+    //     out   = decay * out_q + kq * delta                    [d_v] (written)
+    //     S     = decay * S + k ⊗ delta                         [d_k, d_v] (in-place)
+    // 'kq' must be precomputed as dot(k,q) by the caller.
+    void(*MNNFusedGatedDelta)(float* S, const float* k, const float* q, const float* v,
+                              float* out, float decay, float beta, float kq,
+                              size_t dk, size_t dv);
     void(*MNNCountMaxMinValue)(const float* source, float* minVal, float* maxVal, size_t size);
     void(*MNNDynamicUpdateConvBiasScale)(float* newbias, float* oldbias, float* weightKernelSum, float* inputZero, size_t ocQuad);
     void(*MNNAsyQuantInfo)(float* scale, float* bias, float* qscale, float* qbias, float* dstMin, float* dstMax, const float* src, const size_t* info);

--- a/test/op/FusedGatedDeltaTest.cpp
+++ b/test/op/FusedGatedDeltaTest.cpp
@@ -36,8 +36,8 @@ namespace {
 //   delta = beta * (v - decay * out_k)
 //   out   = decay * (S^T @ q) + dot(k,q) * delta
 //   S     = decay * S + k ⊗ delta
-static void refOneStep(float* S, const float* k, const float* q, const float* v,
-                       float* out, float decay, float beta, int dk, int dv) {
+static void refOneStep(float* S, const float* k, const float* q, const float* v, float* out, float decay, float beta,
+                       int dk, int dv) {
     std::vector<float> outK(dv, 0.0f), outQ(dv, 0.0f), delta(dv, 0.0f);
     for (int i = 0; i < dk; ++i) {
         const float* row = S + i * dv;
@@ -47,11 +47,12 @@ static void refOneStep(float* S, const float* k, const float* q, const float* v,
         }
     }
     float kq = 0.0f;
-    for (int i = 0; i < dk; ++i) kq += k[i] * q[i];
+    for (int i = 0; i < dk; ++i)
+        kq += k[i] * q[i];
     for (int j = 0; j < dv; ++j) {
         float vPred = decay * outK[j];
-        delta[j]    = beta * (v[j] - vPred);
-        out[j]      = decay * outQ[j] + kq * delta[j];
+        delta[j] = beta * (v[j] - vPred);
+        out[j] = decay * outQ[j] + kq * delta[j];
     }
     for (int i = 0; i < dk; ++i) {
         float ki = k[i];
@@ -68,42 +69,48 @@ static void applyL2NormAndScale(float* q, float* k, int dk) {
     const float eps = 1e-6f;
     const float qScale = 1.0f / std::sqrt((float)dk);
     float qSq = 0.0f, kSq = 0.0f;
-    for (int i = 0; i < dk; ++i) { qSq += q[i] * q[i]; kSq += k[i] * k[i]; }
+    for (int i = 0; i < dk; ++i) {
+        qSq += q[i] * q[i];
+        kSq += k[i] * k[i];
+    }
     float qNS = qScale / std::sqrt(qSq + eps);
     float kIN = 1.0f / std::sqrt(kSq + eps);
-    for (int i = 0; i < dk; ++i) { q[i] *= qNS; k[i] *= kIN; }
+    for (int i = 0; i < dk; ++i) {
+        q[i] *= qNS;
+        k[i] *= kIN;
+    }
 }
 
 // Build a LinearAttention op as a Module so we can run forward(). Uses the
 // same FlatBuffers-based construction as LinearAttentionTest.
 static std::shared_ptr<Module> makeModule(int numKHeads, int numVHeads, int dk, int dv) {
-    auto qkv   = _Input();
-    auto gate  = _Input();
-    auto beta  = _Input();
+    auto qkv = _Input();
+    auto gate = _Input();
+    auto beta = _Input();
     auto convW = _Input();
 
     std::shared_ptr<MNN::OpT> op(new MNN::OpT);
-    op->type        = MNN::OpType_LinearAttention;
-    op->main.type   = MNN::OpParameter_LinearAttentionParam;
-    op->main.value  = new MNN::LinearAttentionParamT;
-    auto* p         = op->main.AsLinearAttentionParam();
-    p->attn_type    = "gated_delta_rule";
-    p->num_k_heads  = numKHeads;
-    p->num_v_heads  = numVHeads;
-    p->head_k_dim   = dk;
-    p->head_v_dim   = dv;
+    op->type = MNN::OpType_LinearAttention;
+    op->main.type = MNN::OpParameter_LinearAttentionParam;
+    op->main.value = new MNN::LinearAttentionParamT;
+    auto* p = op->main.AsLinearAttentionParam();
+    p->attn_type = "gated_delta_rule";
+    p->num_k_heads = numKHeads;
+    p->num_v_heads = numVHeads;
+    p->head_k_dim = dk;
+    p->head_v_dim = dv;
     p->use_qk_l2norm = true;
 
-    auto out    = Variable::create(Expr::create(op.get(), {qkv, gate, beta, convW}));
+    auto out = Variable::create(Expr::create(op.get(), {qkv, gate, beta, convW}));
     auto buffer = Variable::save({out});
 
     MNN::ScheduleConfig config;
     auto status = MNNTestSuite::get()->pStaus;
     config.type = (MNNForwardType)status.forwardType;
     MNN::BackendConfig bn;
-    bn.memory    = (MNN::BackendConfig::MemoryMode)status.memory;
+    bn.memory = (MNN::BackendConfig::MemoryMode)status.memory;
     bn.precision = (MNN::BackendConfig::PrecisionMode)status.precision;
-    bn.power     = (MNN::BackendConfig::PowerMode)status.power;
+    bn.power = (MNN::BackendConfig::PowerMode)status.power;
     config.backendConfig = &bn;
     config.numThread = 1;
 
@@ -117,8 +124,8 @@ struct Case {
     int Hv;
     int dk;
     int dv;
-    int L;          // 1 → exercises gated_delta_rule_decode; >1 → gated_delta_rule_mnn (prefill)
-    int numSteps;   // number of forward() invocations; state accumulates across steps
+    int L;        // 1 → exercises gated_delta_rule_decode; >1 → gated_delta_rule_mnn (prefill)
+    int numSteps; // number of forward() invocations; state accumulates across steps
 };
 
 // Run one Case: drives the LinearAttention module forward `numSteps` times,
@@ -132,7 +139,7 @@ static bool runCase(const Case& cs, std::mt19937& rng, float tolerance) {
     const int Hv = cs.Hv;
     const int dk = cs.dk;
     const int dv = cs.dv;
-    const int L  = cs.L;
+    const int L = cs.L;
     const int K_conv = 4;
     const int convStateSize = K_conv - 1;
     const int key_dim = Hk * dk;
@@ -150,7 +157,8 @@ static bool runCase(const Case& cs, std::mt19937& rng, float tolerance) {
     {
         float* w = convWVar->writeMap<float>();
         std::uniform_real_distribution<float> dist(-0.15f, 0.15f);
-        for (int i = 0; i < D * K_conv; ++i) w[i] = dist(rng);
+        for (int i = 0; i < D * K_conv; ++i)
+            w[i] = dist(rng);
     }
 
     // Reference state — module starts from zero on first call.
@@ -158,25 +166,28 @@ static bool runCase(const Case& cs, std::mt19937& rng, float tolerance) {
     std::vector<float> refS(B * Hv * dk * dv, 0.0f);
 
     for (int step = 0; step < cs.numSteps; ++step) {
-        auto qkvVar  = _Input({B, D, L}, NCHW, halide_type_of<float>());
+        auto qkvVar = _Input({B, D, L}, NCHW, halide_type_of<float>());
         auto gateVar = _Input({B, L, Hv}, NCHW, halide_type_of<float>());
         auto betaVar = _Input({B, L, Hv}, NCHW, halide_type_of<float>());
         std::uniform_real_distribution<float> qkvDist(-0.3f, 0.3f);
         {
             float* qkv = qkvVar->writeMap<float>();
-            for (int i = 0; i < B * D * L; ++i) qkv[i] = qkvDist(rng);
+            for (int i = 0; i < B * D * L; ++i)
+                qkv[i] = qkvDist(rng);
             float* g = gateVar->writeMap<float>();
-            for (int i = 0; i < B * L * Hv; ++i) g[i] = -0.1f - 0.05f * (i % 3);
+            for (int i = 0; i < B * L * Hv; ++i)
+                g[i] = -0.1f - 0.05f * (i % 3);
             float* b = betaVar->writeMap<float>();
-            for (int i = 0; i < B * L * Hv; ++i) b[i] = 0.4f + 0.1f * (i % 4);
+            for (int i = 0; i < B * L * Hv; ++i)
+                b[i] = 0.4f + 0.1f * (i % 4);
         }
 
         // ── Reference path ──
         std::vector<float> refOut(B * L * Hv * dv, 0.0f);
         const float* convWPtr = convWVar->readMap<float>();
-        const float* qkvPtr   = qkvVar->readMap<float>();
-        const float* gPtr     = gateVar->readMap<float>();
-        const float* bPtr     = betaVar->readMap<float>();
+        const float* qkvPtr = qkvVar->readMap<float>();
+        const float* gPtr = gateVar->readMap<float>();
+        const float* bPtr = betaVar->readMap<float>();
 
         // Conv1D + SiLU across all L tokens, channel-by-channel.
         // convOut layout matches the runtime: [B, D, L] (channel-major within batch).
@@ -188,11 +199,13 @@ static bool runCase(const Case& cs, std::mt19937& rng, float tolerance) {
                 for (int l = 0; l < L; ++l) {
                     float xnew = qkvPtr[(b * D + d) * L + l];
                     float sum = xnew * w[convStateSize];
-                    for (int kk = 0; kk < convStateSize; ++kk) sum += mState[kk] * w[kk];
+                    for (int kk = 0; kk < convStateSize; ++kk)
+                        sum += mState[kk] * w[kk];
                     float sig = 1.0f / (1.0f + std::exp(-sum));
                     convOut[(b * D + d) * L + l] = sum * sig;
                     // Shift state and append xnew.
-                    for (int kk = 0; kk < convStateSize - 1; ++kk) mState[kk] = mState[kk + 1];
+                    for (int kk = 0; kk < convStateSize - 1; ++kk)
+                        mState[kk] = mState[kk + 1];
                     mState[convStateSize - 1] = xnew;
                 }
             }
@@ -212,12 +225,11 @@ static bool runCase(const Case& cs, std::mt19937& rng, float tolerance) {
                         vLocal[i] = convOut[(b * D + 2 * key_dim + h * dv + i) * L + t];
                     }
                     applyL2NormAndScale(qLocal.data(), kLocal.data(), dk);
-                    float decay  = std::exp(gPtr[b * L * Hv + t * Hv + h]);
+                    float decay = std::exp(gPtr[b * L * Hv + t * Hv + h]);
                     float beta_t = bPtr[b * L * Hv + t * Hv + h];
                     float* state = refS.data() + (b * Hv + h) * dk * dv;
                     float* outSlot = refOut.data() + ((b * L + t) * Hv + h) * dv;
-                    refOneStep(state, kLocal.data(), qLocal.data(), vLocal.data(),
-                               outSlot, decay, beta_t, dk, dv);
+                    refOneStep(state, kLocal.data(), qLocal.data(), vLocal.data(), outSlot, decay, beta_t, dk, dv);
                 }
             }
         }
@@ -233,15 +245,16 @@ static bool runCase(const Case& cs, std::mt19937& rng, float tolerance) {
         for (int i = 0; i < N; ++i) {
             float diff = std::fabs(res[i] - refOut[i]);
             if (diff > tolerance) {
-                MNN_PRINT("FusedGatedDeltaTest[%s] step %d MISMATCH idx=%d "
-                          "ref=%.6f got=%.6f diff=%.4e (tol=%.4e)\n",
-                          cs.name, step, i, refOut[i], res[i], diff, tolerance);
+                MNN_PRINT(
+                    "FusedGatedDeltaTest[%s] step %d MISMATCH idx=%d "
+                    "ref=%.6f got=%.6f diff=%.4e (tol=%.4e)\n",
+                    cs.name, step, i, refOut[i], res[i], diff, tolerance);
                 return false;
             }
         }
     }
-    MNN_PRINT("FusedGatedDeltaTest[%s] Hk=%d Hv=%d dk=%d dv=%d L=%d × %d steps PASSED\n",
-              cs.name, Hk, Hv, dk, dv, L, cs.numSteps);
+    MNN_PRINT("FusedGatedDeltaTest[%s] Hk=%d Hv=%d dk=%d dv=%d L=%d × %d steps PASSED\n", cs.name, Hk, Hv, dk, dv, L,
+              cs.numSteps);
     return true;
 }
 
@@ -257,21 +270,22 @@ public:
         //    gated_delta_rule_mnn path with the shared per-thread buffer
         std::vector<Case> cases = {
             // {name,                    Hk, Hv,  dk,  dv,  L, steps}
-            {"decode_1h_dk64_dv64",       1,  1,  64,  64,  1, 4},
-            {"decode_1h_dk64_dv128",      1,  1,  64, 128,  1, 4},
-            {"decode_1h_dk128_dv64",      1,  1, 128,  64,  1, 4},
-            {"decode_1h_dk128_dv128",     1,  1, 128, 128,  1, 4}, // ← Qwen3-Next shape
-            {"decode_4h_dk128_dv128",     4,  4, 128, 128,  1, 3}, // multi-head decode
-            {"decode_gqa2_dk128_dv128",   2,  4, 128, 128,  1, 3}, // GQA 2:1 decode
-            {"prefill_1h_dk128_dv128",    1,  1, 128, 128,  8, 2}, // L>1 single head
-            {"prefill_4h_dk128_dv128",    4,  4, 128, 128,  8, 2}, // L>1 multi-head
-            {"prefill_gqa2_dk128_dv128",  2,  4, 128, 128,  8, 2}, // L>1 + GQA
+            {"decode_1h_dk64_dv64", 1, 1, 64, 64, 1, 4},
+            {"decode_1h_dk64_dv128", 1, 1, 64, 128, 1, 4},
+            {"decode_1h_dk128_dv64", 1, 1, 128, 64, 1, 4},
+            {"decode_1h_dk128_dv128", 1, 1, 128, 128, 1, 4},    // ← Qwen3-Next shape
+            {"decode_4h_dk128_dv128", 4, 4, 128, 128, 1, 3},    // multi-head decode
+            {"decode_gqa2_dk128_dv128", 2, 4, 128, 128, 1, 3},  // GQA 2:1 decode
+            {"prefill_1h_dk128_dv128", 1, 1, 128, 128, 8, 2},   // L>1 single head
+            {"prefill_4h_dk128_dv128", 4, 4, 128, 128, 8, 2},   // L>1 multi-head
+            {"prefill_gqa2_dk128_dv128", 2, 4, 128, 128, 8, 2}, // L>1 + GQA
         };
 
         // fp16 path accumulates more round-off — loosen tolerance for low-precision.
         float tol = (precision == BackendConfig::Precision_Low) ? 6e-2f : 5e-3f;
         for (auto& cs : cases) {
-            if (!runCase(cs, rng, tol)) return false;
+            if (!runCase(cs, rng, tol))
+                return false;
         }
         return true;
     }

--- a/test/op/FusedGatedDeltaTest.cpp
+++ b/test/op/FusedGatedDeltaTest.cpp
@@ -1,0 +1,282 @@
+//
+//  FusedGatedDeltaTest.cpp
+//  MNNTests
+//
+//  End-to-end test for the MNNFusedGatedDelta kernel. Runs the
+//  LinearAttention op via Module::load with Qwen3-Next-style head
+//  dimensions (d_k=d_v=128) and Mamba-style (d_k=d_v=64) — these
+//  exercise the SIMD chunk path of the fused kernel that the existing
+//  LinearAttentionTest (d_v=4/16) does not.
+//
+//  Compares the runtime output against a scalar Python-style reference
+//  that decomposes the gated_delta_rule recurrence step by step.
+//
+
+#ifdef MNN_SUPPORT_TRANSFORMER_FUSE
+
+#include <MNN/expr/Expr.hpp>
+#include <MNN/expr/ExprCreator.hpp>
+#include <MNN/expr/Module.hpp>
+#include "MNNTestSuite.h"
+#include "TestUtils.h"
+
+#include <cmath>
+#include <cstring>
+#include <random>
+#include <vector>
+
+using namespace MNN;
+using namespace MNN::Express;
+
+namespace {
+
+// Reference implementation of one decode step of gated_delta_rule for a
+// single attention head. Mirrors the math in CPULinearAttention.cpp:
+//   out_k = S^T @ k
+//   delta = beta * (v - decay * out_k)
+//   out   = decay * (S^T @ q) + dot(k,q) * delta
+//   S     = decay * S + k ⊗ delta
+static void refOneStep(float* S, const float* k, const float* q, const float* v,
+                       float* out, float decay, float beta, int dk, int dv) {
+    std::vector<float> outK(dv, 0.0f), outQ(dv, 0.0f), delta(dv, 0.0f);
+    for (int i = 0; i < dk; ++i) {
+        const float* row = S + i * dv;
+        for (int j = 0; j < dv; ++j) {
+            outK[j] += row[j] * k[i];
+            outQ[j] += row[j] * q[i];
+        }
+    }
+    float kq = 0.0f;
+    for (int i = 0; i < dk; ++i) kq += k[i] * q[i];
+    for (int j = 0; j < dv; ++j) {
+        float vPred = decay * outK[j];
+        delta[j]    = beta * (v[j] - vPred);
+        out[j]      = decay * outQ[j] + kq * delta[j];
+    }
+    for (int i = 0; i < dk; ++i) {
+        float ki = k[i];
+        float* row = S + i * dv;
+        for (int j = 0; j < dv; ++j) {
+            row[j] = decay * row[j] + ki * delta[j];
+        }
+    }
+}
+
+// Apply L2-norm + scale (Q is also scaled by 1/sqrt(d_k)) — matches the
+// useL2Norm=true path inside CPULinearAttention.
+static void applyL2NormAndScale(float* q, float* k, int dk) {
+    const float eps = 1e-6f;
+    const float qScale = 1.0f / std::sqrt((float)dk);
+    float qSq = 0.0f, kSq = 0.0f;
+    for (int i = 0; i < dk; ++i) { qSq += q[i] * q[i]; kSq += k[i] * k[i]; }
+    float qNS = qScale / std::sqrt(qSq + eps);
+    float kIN = 1.0f / std::sqrt(kSq + eps);
+    for (int i = 0; i < dk; ++i) { q[i] *= qNS; k[i] *= kIN; }
+}
+
+// Build a LinearAttention op as a Module so we can run forward(). Uses the
+// same FlatBuffers-based construction as LinearAttentionTest.
+static std::shared_ptr<Module> makeModule(int numKHeads, int numVHeads, int dk, int dv) {
+    auto qkv   = _Input();
+    auto gate  = _Input();
+    auto beta  = _Input();
+    auto convW = _Input();
+
+    std::shared_ptr<MNN::OpT> op(new MNN::OpT);
+    op->type        = MNN::OpType_LinearAttention;
+    op->main.type   = MNN::OpParameter_LinearAttentionParam;
+    op->main.value  = new MNN::LinearAttentionParamT;
+    auto* p         = op->main.AsLinearAttentionParam();
+    p->attn_type    = "gated_delta_rule";
+    p->num_k_heads  = numKHeads;
+    p->num_v_heads  = numVHeads;
+    p->head_k_dim   = dk;
+    p->head_v_dim   = dv;
+    p->use_qk_l2norm = true;
+
+    auto out    = Variable::create(Expr::create(op.get(), {qkv, gate, beta, convW}));
+    auto buffer = Variable::save({out});
+
+    MNN::ScheduleConfig config;
+    auto status = MNNTestSuite::get()->pStaus;
+    config.type = (MNNForwardType)status.forwardType;
+    MNN::BackendConfig bn;
+    bn.memory    = (MNN::BackendConfig::MemoryMode)status.memory;
+    bn.precision = (MNN::BackendConfig::PrecisionMode)status.precision;
+    bn.power     = (MNN::BackendConfig::PowerMode)status.power;
+    config.backendConfig = &bn;
+    config.numThread = 1;
+
+    std::shared_ptr<Executor::RuntimeManager> rt(Executor::RuntimeManager::createRuntimeManager(config));
+    return std::shared_ptr<Module>(Module::load({}, {}, (uint8_t*)buffer.data(), buffer.size(), rt));
+}
+
+struct Case {
+    const char* name;
+    int Hk;
+    int Hv;
+    int dk;
+    int dv;
+    int L;          // 1 → exercises gated_delta_rule_decode; >1 → gated_delta_rule_mnn (prefill)
+    int numSteps;   // number of forward() invocations; state accumulates across steps
+};
+
+// Run one Case: drives the LinearAttention module forward `numSteps` times,
+// each invocation feeding a fresh random qkv tensor with seqLen=L. State (both
+// the conv state and the recurrent S) accumulates across calls. The reference
+// path replays the same conv1D + L2norm + gated_delta_rule pipeline as
+// CPULinearAttention and compares element-wise.
+static bool runCase(const Case& cs, std::mt19937& rng, float tolerance) {
+    const int B = 1;
+    const int Hk = cs.Hk;
+    const int Hv = cs.Hv;
+    const int dk = cs.dk;
+    const int dv = cs.dv;
+    const int L  = cs.L;
+    const int K_conv = 4;
+    const int convStateSize = K_conv - 1;
+    const int key_dim = Hk * dk;
+    const int val_dim = Hv * dv;
+    const int D = 2 * key_dim + val_dim;
+    const int gqa_factor = (Hv > Hk) ? (Hv / Hk) : 1;
+
+    auto module = makeModule(Hk, Hv, dk, dv);
+    if (!module) {
+        MNN_PRINT("FusedGatedDeltaTest[%s]: module creation failed\n", cs.name);
+        return false;
+    }
+
+    auto convWVar = _Input({D, 1, K_conv}, NCHW, halide_type_of<float>());
+    {
+        float* w = convWVar->writeMap<float>();
+        std::uniform_real_distribution<float> dist(-0.15f, 0.15f);
+        for (int i = 0; i < D * K_conv; ++i) w[i] = dist(rng);
+    }
+
+    // Reference state — module starts from zero on first call.
+    std::vector<float> refConvState(B * D * convStateSize, 0.0f);
+    std::vector<float> refS(B * Hv * dk * dv, 0.0f);
+
+    for (int step = 0; step < cs.numSteps; ++step) {
+        auto qkvVar  = _Input({B, D, L}, NCHW, halide_type_of<float>());
+        auto gateVar = _Input({B, L, Hv}, NCHW, halide_type_of<float>());
+        auto betaVar = _Input({B, L, Hv}, NCHW, halide_type_of<float>());
+        std::uniform_real_distribution<float> qkvDist(-0.3f, 0.3f);
+        {
+            float* qkv = qkvVar->writeMap<float>();
+            for (int i = 0; i < B * D * L; ++i) qkv[i] = qkvDist(rng);
+            float* g = gateVar->writeMap<float>();
+            for (int i = 0; i < B * L * Hv; ++i) g[i] = -0.1f - 0.05f * (i % 3);
+            float* b = betaVar->writeMap<float>();
+            for (int i = 0; i < B * L * Hv; ++i) b[i] = 0.4f + 0.1f * (i % 4);
+        }
+
+        // ── Reference path ──
+        std::vector<float> refOut(B * L * Hv * dv, 0.0f);
+        const float* convWPtr = convWVar->readMap<float>();
+        const float* qkvPtr   = qkvVar->readMap<float>();
+        const float* gPtr     = gateVar->readMap<float>();
+        const float* bPtr     = betaVar->readMap<float>();
+
+        // Conv1D + SiLU across all L tokens, channel-by-channel.
+        // convOut layout matches the runtime: [B, D, L] (channel-major within batch).
+        std::vector<float> convOut(B * D * L, 0.0f);
+        for (int b = 0; b < B; ++b) {
+            for (int d = 0; d < D; ++d) {
+                float* mState = refConvState.data() + (b * D + d) * convStateSize;
+                const float* w = convWPtr + d * K_conv;
+                for (int l = 0; l < L; ++l) {
+                    float xnew = qkvPtr[(b * D + d) * L + l];
+                    float sum = xnew * w[convStateSize];
+                    for (int kk = 0; kk < convStateSize; ++kk) sum += mState[kk] * w[kk];
+                    float sig = 1.0f / (1.0f + std::exp(-sum));
+                    convOut[(b * D + d) * L + l] = sum * sig;
+                    // Shift state and append xnew.
+                    for (int kk = 0; kk < convStateSize - 1; ++kk) mState[kk] = mState[kk + 1];
+                    mState[convStateSize - 1] = xnew;
+                }
+            }
+        }
+
+        // gated_delta_rule across all timesteps and heads (GQA: k_head = h / gqa_factor).
+        for (int b = 0; b < B; ++b) {
+            for (int t = 0; t < L; ++t) {
+                for (int h = 0; h < Hv; ++h) {
+                    const int k_head = h / gqa_factor;
+                    std::vector<float> qLocal(dk), kLocal(dk), vLocal(dv);
+                    for (int i = 0; i < dk; ++i) {
+                        qLocal[i] = convOut[(b * D + k_head * dk + i) * L + t];
+                        kLocal[i] = convOut[(b * D + key_dim + k_head * dk + i) * L + t];
+                    }
+                    for (int i = 0; i < dv; ++i) {
+                        vLocal[i] = convOut[(b * D + 2 * key_dim + h * dv + i) * L + t];
+                    }
+                    applyL2NormAndScale(qLocal.data(), kLocal.data(), dk);
+                    float decay  = std::exp(gPtr[b * L * Hv + t * Hv + h]);
+                    float beta_t = bPtr[b * L * Hv + t * Hv + h];
+                    float* state = refS.data() + (b * Hv + h) * dk * dv;
+                    float* outSlot = refOut.data() + ((b * L + t) * Hv + h) * dv;
+                    refOneStep(state, kLocal.data(), qLocal.data(), vLocal.data(),
+                               outSlot, decay, beta_t, dk, dv);
+                }
+            }
+        }
+
+        // ── Module path ──
+        auto outputs = module->onForward({qkvVar, gateVar, betaVar, convWVar});
+        if (outputs.empty()) {
+            MNN_PRINT("FusedGatedDeltaTest[%s]: empty output at step %d\n", cs.name, step);
+            return false;
+        }
+        const float* res = outputs[0]->readMap<float>();
+        const int N = B * L * Hv * dv;
+        for (int i = 0; i < N; ++i) {
+            float diff = std::fabs(res[i] - refOut[i]);
+            if (diff > tolerance) {
+                MNN_PRINT("FusedGatedDeltaTest[%s] step %d MISMATCH idx=%d "
+                          "ref=%.6f got=%.6f diff=%.4e (tol=%.4e)\n",
+                          cs.name, step, i, refOut[i], res[i], diff, tolerance);
+                return false;
+            }
+        }
+    }
+    MNN_PRINT("FusedGatedDeltaTest[%s] Hk=%d Hv=%d dk=%d dv=%d L=%d × %d steps PASSED\n",
+              cs.name, Hk, Hv, dk, dv, L, cs.numSteps);
+    return true;
+}
+
+} // anonymous namespace
+
+class FusedGatedDeltaTest : public MNNTestCase {
+public:
+    virtual bool run(int precision) {
+        std::mt19937 rng(0x5A17u);
+        // Coverage matrix:
+        //  - decode (L=1): single-head, multi-head, GQA, all production dk/dv
+        //  - prefill (L>1): multi-head + GQA at dk=128/dv=128 to exercise the
+        //    gated_delta_rule_mnn path with the shared per-thread buffer
+        std::vector<Case> cases = {
+            // {name,                    Hk, Hv,  dk,  dv,  L, steps}
+            {"decode_1h_dk64_dv64",       1,  1,  64,  64,  1, 4},
+            {"decode_1h_dk64_dv128",      1,  1,  64, 128,  1, 4},
+            {"decode_1h_dk128_dv64",      1,  1, 128,  64,  1, 4},
+            {"decode_1h_dk128_dv128",     1,  1, 128, 128,  1, 4}, // ← Qwen3-Next shape
+            {"decode_4h_dk128_dv128",     4,  4, 128, 128,  1, 3}, // multi-head decode
+            {"decode_gqa2_dk128_dv128",   2,  4, 128, 128,  1, 3}, // GQA 2:1 decode
+            {"prefill_1h_dk128_dv128",    1,  1, 128, 128,  8, 2}, // L>1 single head
+            {"prefill_4h_dk128_dv128",    4,  4, 128, 128,  8, 2}, // L>1 multi-head
+            {"prefill_gqa2_dk128_dv128",  2,  4, 128, 128,  8, 2}, // L>1 + GQA
+        };
+
+        // fp16 path accumulates more round-off — loosen tolerance for low-precision.
+        float tol = (precision == BackendConfig::Precision_Low) ? 6e-2f : 5e-3f;
+        for (auto& cs : cases) {
+            if (!runCase(cs, rng, tol)) return false;
+        }
+        return true;
+    }
+};
+
+MNNTestSuiteRegister(FusedGatedDeltaTest, "op/fused_gated_delta");
+
+#endif // MNN_SUPPORT_TRANSFORMER_FUSE


### PR DESCRIPTION
## Description

为 `LinearAttention` 算子的 `gated_delta_rule` 路径（Qwen3-Next / Mamba 风格的线性注意力）新增融合 kernel `MNNFusedGatedDelta`，将原先的 `MNNDualMatVec → C++ 解析修正 → MNNDecayRankOneUpdate` 三段式调用合并为一次两遍扫描：

- **Pass 1**：按列以 `kChunk` 为单位流式累加 `out_k = Sᵀ@k` 与 `out_q = Sᵀ@q`，寄存器内直接计算 `delta = beta·(v − decay·out_k)` 与 `out = decay·out_q + kq·delta`，写出 `out`，`delta` 留在寄存器。
- **Pass 2**：再次扫描 `S`，使用寄存器中的 `delta` 原地更新 `S = decay·S + k⊗delta`。

这样把对状态矩阵 `S` 的访问从 3 次（读-读-写）降到 2 次（读-读+写），并通过 `vfmaq_laneq_*` 把标量广播代价摊销到 8 行；FP32 链路 chunk=16，FP16 链路 chunk=32（受限于 32 个 NEON v 寄存器预算）。要求 `d_v` 为 chunk 大小的倍数，常用的 `d_v ∈ {64, 128, 256}` 均满足；尾部用 scalar 兜底。

主要改动：
- `compute/CommonOptFunction.{h,cpp}`：声明并实现默认 FP32 版本 `MNNFusedGatedDeltaDefault`，挂入 `gCoreFunction`。
- `arm82/Arm82Functions.cpp`：新增 ARMv8.2-A FP16 特化 `MNNFusedGatedDeltaFp16`，挂入 `Arm82Functions::get()`。
- `cpu/CPULinearAttention.cpp`：prefill (`gated_delta_rule_mnn`) 与 decode (`gated_delta_rule_decode`) 两条路径都改为单次 fused 调用；线程局部 scratch 由 `2*dk + 2*dv` 缩减为 `2*dk + dv`（`vPred` 与 `delta` 不再落盘）。
- `test/op/FusedGatedDeltaTest.cpp`：新增端到端测试，覆盖 decode/prefill × 单头/多头/GQA × Qwen3-Next（dk=dv=128）与 Mamba（dk=dv=64）形状，与 Python 风格的标量参考实现逐元素对比。

## Module

CPU（默认 FP32 backend + Arm82 FP16 backend），影响 `LinearAttention` 算子，主要服务 LLM 推理（Qwen3-Next 等线性注意力模型）。

## Type

- [ ] Feature
- [ ] Bugfix
- [x] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format（`[CPU:Perf] add fused MNNFusedGatedDelta kernel for LinearAttention`）
- [x] Code compiles without errors（macOS `build_macos_test/` 已通过编译）
- [x] Tested on relevant platform(s)（新增 `op/fused_gated_delta` 测试覆盖 FP32/FP16 路径，含 decode 与 prefill、单头/多头/GQA、Qwen3-Next 与 Mamba 形状，已通过 `run_test.out`）
- [x] No unrelated format or style changes included（仅触及 fused kernel 相关的 5 个核心文件，已剔除设计文档与 profile demo 等周边产物）



20 次平均，Qwen3.5-0.8B-INT4，macOS arm64，thread=4，prompt=265 tok / decode=512 tok。

| precision | 指标 | Baseline | PR HEAD | Δ |
|---|---|---:|---:|---:|
| **FP16** (low) | prefill tok/s | 1211.91 | **1281.49** | **+5.74%** |
| **FP16** (low) | decode tok/s | 194.07 | 193.59 | -0.25% |
| **FP32** (high) | prefill tok/s | 1103.24 | **1217.59** | **+10.36%** |
| **FP32** (high) | decode tok/s | 177.89 | 177.84 | -0.03% |

prefill 显著加速，decode 在两种精度下均落在噪声内（<0.3%，stddev 约 1.0–1.5）。