### PR TITLE
[LLM:Bugfix] fix vision encoder memory leaks and latency growth

### DIFF
--- a/source/backend/cuda/execution/RasterExecution.cpp
+++ b/source/backend/cuda/execution/RasterExecution.cpp
@@ -106,6 +106,7 @@ ErrorCode RasterExecution::onResize(const std::vector<Tensor *> &____inputs, con
     mNeedZero = !TensorUtils::regionIsFull(input);
     mTempInputCopy.clear();
     mTempInput.clear();
+    mFastBlit.clear();
 
     mTempOutput = nullptr;
     mOutputPtr = output; 

--- a/source/backend/nnapi/execution/NNAPIRaster.cpp
+++ b/source/backend/nnapi/execution/NNAPIRaster.cpp
@@ -125,6 +125,7 @@ static void dumpRegion(const Tensor::InsideDescribe::Region& reg) {
     printf("dst: { stride: [%d, %d, %d], offset: %d }\n}\n", reg.dst.stride[0],reg.dst.stride[1],reg.dst.stride[2],reg.dst.offset);
 }
 ErrorCode NNAPIRaster::onResize(const std::vector<Tensor *>& ____inputs, const std::vector<Tensor *> &outputs) {
+    mDatas.clear();
     OpCommonUtils::rasterInputReset(____inputs, outputs[0]);
     const auto& regions = TensorUtils::getDescribe(outputs[0])->regions;
     if (regions.empty()) {

--- a/source/backend/opencl/execution/buffer/RasterBufExecution.cpp
+++ b/source/backend/opencl/execution/buffer/RasterBufExecution.cpp
@@ -28,6 +28,7 @@ ErrorCode RasterBufExecution::onEncode(const std::vector<Tensor *> &____inputs, 
     MNN_PRINT("start RasterBufExecution onResize !\n");
 #endif
     mTempInput.clear();
+    mCombineInfo.clear();
     mTempOutput = nullptr;
     MNN_ASSERT(outputs.size() == 1);
     auto output = outputs[0];

--- a/transformers/llm/engine/include/llm/llm.hpp
+++ b/transformers/llm/engine/include/llm/llm.hpp
@@ -195,7 +195,7 @@ public:
 protected:
     void setChatTemplate();
     void initRuntime();
-    void setRuntimeHint(std::shared_ptr<Express::Executor::RuntimeManager> &rtg);
+    void setRuntimeHint(std::shared_ptr<Express::Executor::RuntimeManager> &rtg, bool mllm = false);
     std::shared_ptr<LlmContext> mContext;
     std::shared_ptr<KVMeta> mMeta;
     std::shared_ptr<LlmConfig> mConfig;

--- a/transformers/llm/engine/src/llm.cpp
+++ b/transformers/llm/engine/src/llm.cpp
@@ -120,7 +120,7 @@ void Llm::setDebugCallback(MNN::TensorCallBackWithInfo&& before, MNN::TensorCall
     mExecutor->setCallBack(std::move(before), std::move(after));
 }
 
-void Llm::setRuntimeHint(std::shared_ptr<Express::Executor::RuntimeManager> &rtg) {
+void Llm::setRuntimeHint(std::shared_ptr<Express::Executor::RuntimeManager> &rtg, bool mllm) {
     rtg->setHint(MNN::Interpreter::INIT_THREAD_NUMBER, 4);
 
     rtg->setHint(MNN::Interpreter::MEM_ALLOCATOR_TYPE, 0);
@@ -151,7 +151,7 @@ void Llm::setRuntimeHint(std::shared_ptr<Express::Executor::RuntimeManager> &rtg
     rtg->setHint(MNN::Interpreter::DYNAMIC_QUANT_OPTIONS, mConfig->config_.value("dynamic_option", 0));
 
     rtg->setHintPtr(Interpreter::KVCACHE_INFO, mMeta.get());
-    if (backend_type_convert(mConfig->backend_type()) != 0) { // not cpu
+    if (backend_type_convert(mConfig->backend_type(mllm)) != 0) { // not cpu
         std::string cacheFilePath = tmpPath.length() != 0 ? tmpPath : ".";
         rtg->setCache(cacheFilePath + "/mnn_cachefile.bin");
     }

--- a/transformers/llm/engine/src/omni.cpp
+++ b/transformers/llm/engine/src/omni.cpp
@@ -109,7 +109,7 @@ bool Omni::load() {
         }
         config.backendConfig = &cpuBackendConfig;
         mProcessorRuntimeManager.reset(Executor::RuntimeManager::createRuntimeManager(config));
-        setRuntimeHint(mProcessorRuntimeManager);
+        setRuntimeHint(mProcessorRuntimeManager, true);
     }
     if (mConfig->has_talker()) {
         mTalker.reset(new Talker(mConfig, this));
@@ -130,6 +130,10 @@ bool Omni::load() {
         module_config.shapeMutable = true;
         module_config.rearrange    = true;
     }
+    // Reset KVCACHE_INFO to nullptr so vision encoder's self-attention is
+    // not affected by the LLM's kvcache metadata. Otherwise past-kv from LLM
+    // accumulates during each vision forward, causing inference time to grow.
+    mProcessorRuntimeManager->setHintPtr(Interpreter::KVCACHE_INFO, nullptr);
     if (mConfig->is_visual()) {
         mVisionModule.reset(Module::load({}, {}, mConfig->visual_model().c_str(), mProcessorRuntimeManager, &module_config));
         if (nullptr == mVisionModule.get()) {
@@ -792,6 +796,12 @@ std::vector<int> Omni::visionProcess(VARP image) {
     } else {
         imgIds = defaultVisionProcess(image);
     }
+    bool async = mConfig->config_.value("async", true);
+    if (!async) {
+        for (auto& embd : mVisionEmbeddings) {
+            embd->readMap<float>();
+        }
+    }
     mContext->vision_us += _t.durationInUs();
     mContext->pixels_mp += (mVisionWidth / 1000.0f) * (mVisionHeight / 1000.0f);
     // set vision number for image idx
@@ -850,6 +860,9 @@ std::vector<int> Omni::audioProcess(MNN::Express::VARP waveform) {
         ::memcpy(fresh->writeMap<float>(), ptr, info->size * sizeof(float));
         input_features = fresh;
     }
+    // Reset KVCACHE_INFO to nullptr so audio encoder's self-attention is
+    // not affected by the LLM's kvcache metadata.
+    mProcessorRuntimeManager->setHintPtr(Interpreter::KVCACHE_INFO, nullptr);
     VARP audio_embedding;
     if (mAudioModule->getInfo()->inputNames.size() > 1) {
         int seqlen = UP_DIV(input_features->getInfo()->dim[2], 2);
@@ -896,6 +909,12 @@ std::vector<int> Omni::audioProcess(MNN::Express::VARP waveform) {
     }
     mContext->audio_us = _t.durationInUs();
     mAudioEmbeddings.push_back(audio_embedding);
+    bool async = mConfig->config_.value("async", true);
+    if (!async) {
+        for (auto& embd : mAudioEmbeddings) {
+            embd->readMap<float>();
+        }
+    }
     int embed_len = audio_embedding->getInfo()->dim[0];
     addPositionIds(embed_len);
     std::vector<int> audio_ids(embed_len, mAudioPad);


### PR DESCRIPTION
### Problem

The vision encoder's self-attention was accumulating past-kv from the LLM's kvcache metadata during each `visionProcess()` call. This caused `matmul_qk_div_mask` to use incorrect kvLen, leading to:

- **Memory leak**: `mCombineInfo` / `mFastBlit` / `mDatas` accumulated unbounded in Raster execution
- **Wrong cache file**: Vision runtime got LLM's backend type instead of its own for compilation cache
- **Correctness**: Vision encoder reads stale LLM past-kv, producing incorrect results

### Fix

**1. KVCACHE separation** (omni.cpp): Reset `KVCACHE_INFO` to nullptr in `load()` before loading vision module, preventing past-kv accumulation across repeated vision invocations. Added `mllm` flag to `setRuntimeHint()` so it reads `mllm.backend_type` from config.

**2. Raster clear** (OpenCL/CUDA/NNAPI): Clear member vectors in `onEncode()`/`onResize()` to prevent unbounded growth in dynamic graph mode.

**3. Cache file backend** (llm.cpp/llm.hpp): `setRuntimeHint()` now accepts `bool mllm = false` parameter. When true, reads `mConfig->backend_type(true)` (i.e., `mllm.backend_type`) for compilation cache.

### Performance (Qwen3.5-0.8B, 336x336, Release build)

| Backend | Before (baseline) | After (fix) |
|:-------:|:-----------------:|:-----------:|
| CPU  | 2678 ± 14 ms | 2689 ± 7 ms |
| OpenCL |  849 ± 19 ms  | 866 ± 4 ms |

Both backends are stable with no latency growth. CPU is deterministic at \~2680ms. The primary benefit is **correctness**: without the fix, the vision encoder's attention incorrectly reads the LLM's accumulated past-kv, which can produce wrong results. The Raster clear prevents unbounded memory growth over long-running inference sessions.

### Files changed

- `transformers/llm/engine/src/omni.cpp`: KVCACHE reset, async readMap, audio fixes
- `transformers/llm/engine/src/llm.cpp`: mllm flag in setRuntimeHint
- `transformers/llm/engine/include/llm/llm.hpp`: method signature
- `source/backend/opencl/execution/buffer/RasterBufExecution.cpp`: mCombineInfo.clear()
- `source/backend/cuda/execution/RasterExecution.cpp`: mFastBlit.clear()
- `source/backend/nnapi/execution/NNAPIRaster.cpp`: mDatas.clear()