### PR TITLE
Fix ScheduleConfig.numThread ignored due to union copy bug in GCC 4.9

### DIFF
--- a/source/core/Interpreter.cpp
+++ b/source/core/Interpreter.cpp
@@ -351,11 +351,15 @@ Session* Interpreter::createMultiPathSession(const std::vector<ScheduleConfig>& 
 }
 
 Session* Interpreter::createSession(const ScheduleConfig& config) {
-    return createMultiPathSession({config});
+    std::vector<ScheduleConfig> configs(1, config);
+    configs[0].numThread = config.numThread;
+    return createMultiPathSession(configs);
 }
 
 Session* Interpreter::createSession(const ScheduleConfig& config, const RuntimeInfo& runtime) {
-    return createMultiPathSession({config}, runtime);
+    std::vector<ScheduleConfig> configs(1, config);
+    configs[0].numThread = config.numThread;
+    return createMultiPathSession(configs, runtime);
 }
 
 bool Interpreter::releaseSession(Session* session) {


### PR DESCRIPTION
## Summary
- `ScheduleConfig.numThread` setting is silently ignored when using `createSession()` with GCC 4.9 (NDK r14b), causing unexpected multi-threaded inference even when `numThread=1`

## Root Cause
`numThread` is defined in an anonymous union with a default member initializer (`= 4`). When `createSession()` calls `createMultiPathSession({config})`, the `{config}` initializer_list triggers copy construction where GCC 4.9 incorrectly resets the union member to its default value (4), discarding the user-set value.

## Fix
Replace `{config}` initializer_list construction with explicit vector construction followed by reassignment of `numThread` from the original config reference.

## Reproduction
1. Set `config.numThread = 1` and call `net->createSession(config)`
2. On a 2-core ARM Android device (NDK r14b / GCC 4.9), observe:
   - CPU usage ~95% (both cores saturated) instead of expected ~50%
   - `strace -f -e trace=clone` shows a worker thread created via `clone(CLONE_THREAD)`
   - `/proc/<pid>/task/` shows 2 threads, both in R state with `sched_yield` spin-wait from ThreadPool
3. Debug prints confirm: `config.numThread=1` before `createSession`, but `config.numThread=4` inside `createMultiPathSession` after the vector copy

## Test Plan
- Verified on ARM Android device (2-core, NDK r14b / GCC 4.9):
  - Before fix: 2 threads, CPU 93-98%, ThreadPool active
  - After fix: 1 thread, CPU 50%, no clone syscall, no ThreadPool initialized