### PR TITLE
[CPU:Bugfix] supplement missing headfile, and fix a bug in MNNLineDep…

### DIFF
--- a/source/backend/cpu/riscv/rvv/MNNAvgPoolInt8.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNAvgPoolInt8.cpp
@@ -8,6 +8,7 @@
 #include <riscv_vector.h>
 #include <stdint.h>
 #include <limits.h>
+#include "../../compute/Int8FunctionsOpt.h"
 
 void MNNAvgPoolInt8_RVV(int8_t* dst, int8_t* src, size_t outputWidth, size_t inputWidth, size_t kernelx, size_t kernely,
                         size_t stridesx, ssize_t paddingx, ssize_t factor) {

--- a/source/backend/cpu/riscv/rvv/MNNFloat2Int8.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNFloat2Int8.cpp
@@ -7,6 +7,7 @@
 //
 #include <riscv_vector.h>
 #include <stdint.h>
+#include "../../compute/Int8FunctionsOpt.h"
 
 void MNNFloat2Int8_RVV(const float* src, int8_t* dst, size_t sizeQuad, const float* scalep, ssize_t minValue,
                        ssize_t maxValue, const float* zeroPoint, ssize_t quanParamVec) {

--- a/source/backend/cpu/riscv/rvv/MNNInt8ScaleToFloat.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNInt8ScaleToFloat.cpp
@@ -9,6 +9,7 @@
 #include <riscv_vector.h>
 #include <stdint.h>
 #include <string.h>
+#include "../../compute/Int8FunctionsOpt.h"
 
 void MNNInt8ScaleToFloat_RVV(float* dst, const int8_t* src, const float* scale, size_t size, const float* zeroPoint,
                              ssize_t quantParamVec) {

--- a/source/backend/cpu/riscv/rvv/MNNLineDepthWiseInt8AddBiasScaleUnit.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNLineDepthWiseInt8AddBiasScaleUnit.cpp
@@ -20,7 +20,7 @@ void MNNLineDepthWiseInt8AddBiasScaleUnit_RVV(int8_t* dst, const int8_t* src, co
     const int8_t* srcPtr = src;
     const int8_t* weightPtr = weight;
 
-    const float* bias_z = parameters->bias;
+    const int32_t* bias_z = parameters->bias;
     const float* scale_z = parameters->scale;
     const int32_t max_val = parameters->maxValue;
     const int32_t min_val = parameters->minValue;

--- a/source/backend/cpu/riscv/rvv/MNNLineDepthWiseInt8AddBiasScaleUnit.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNLineDepthWiseInt8AddBiasScaleUnit.cpp
@@ -55,7 +55,9 @@ void MNNLineDepthWiseInt8AddBiasScaleUnit_RVV(int8_t* dst, const int8_t* src, co
             }
         }
 
-        vfloat32m4_t vec_bias = __riscv_vle32_v_f32m4(bias_z, vl);
+        // vfloat32m4_t vec_bias = __riscv_vle32_v_f32m4(bias_z, vl);
+        vint32m4_t vec_bias_int = __riscv_vle32_v_i32m4(bias_z, vl);
+        vfloat32m4_t vec_bias = __riscv_vfcvt_f_x_v_f32m4(vec_bias_int, vl);
         vfloat32m4_t f_sum = __riscv_vfcvt_f_x_v_f32m4(vec_sum, vl);
         f_sum = __riscv_vfadd_vv_f32m4(f_sum, vec_bias, vl);
 


### PR DESCRIPTION
## Description

<!-- Brief description of the changes -->
Fix the bugs below:
ssize_t has not been declared:
    source/backend/cpu/riscv/rvv/MNNFloat2Int8.cpp
    source/backend/cpu/riscv/rvv/MNNInt8ScaleToFloat.cpp
    source/backend/cpu/riscv/rvv/MNNAvgPoolInt8.cpp
不能在初始化时将 const int32_t* const 转换为 const float* :
    source/backend/cpu/riscv/rvv/MNNLineDepthWiseInt8AddBiasScaleUnit.cpp
## Module
CPU
<!-- Which module does this PR affect? e.g. LLM, CPU, Metal, CUDA, OpenCL, Core, Infra -->

## Type

- [ ] Feature
- [x] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [x] Tested on relevant platform(s)
- [x] No unrelated format or style changes included
