### PR TITLE
RVV: Optimize conv opt and common opt functions

### DIFF
--- a/source/backend/cpu/compute/ConvOpt.cpp
+++ b/source/backend/cpu/compute/ConvOpt.cpp
@@ -12,7 +12,7 @@
 #include "core/Macro.h"
 #include "math/Vec.hpp"
 using Vec4 = MNN::Math::Vec<float, 4>;
-#ifndef MNN_USE_NEON
+#if !defined(MNN_USE_NEON) && !defined(MNN_USE_RVV)
 
 void MNNMatrixSub(float* C, const float* A, const float* B, size_t widthC4, size_t cStride, size_t aStride,
                   size_t bStride, size_t height) {

--- a/source/backend/cpu/riscv/rvv/MNNAbsMaxFP32.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNAbsMaxFP32.cpp
@@ -1,22 +1,29 @@
 #include <riscv_vector.h>
+#include <cstddef>
+
 void MNNAbsMaxFP32_RVV(const float* source, float* absmax, size_t src_depth_quad, size_t realSize, int pack) {
-    size_t stride = pack * realSize;
-    const size_t vlmax = __riscv_vsetvlmax_e32m1();
-    for (size_t i = 0; i < realSize; ++i) {
-        vfloat32m1_t max_v = __riscv_vfmv_v_f_f32m1(0.f, vlmax);
-        for (size_t c = 0; c < src_depth_quad; ++c) {
-            const float* src = source + c * stride + i * pack;
-            size_t n = pack;
-            size_t vl;
-            for (; n > 0; n -= vl, src += vl) {
-                vl = __riscv_vsetvl_e32m1(n);
-                vfloat32m1_t v = __riscv_vle32_v_f32m1(src, vl);
-                vfloat32m1_t v_abs = __riscv_vfabs_v_f32m1(v, vl);
-                max_v = __riscv_vfmax_vv_f32m1(max_v, v_abs, vl);
+    const size_t planeStride = static_cast<size_t>(pack) * realSize;
+    const ptrdiff_t srcStrideBytes = static_cast<ptrdiff_t>(pack) * sizeof(float);
+
+    for (size_t i = 0; i < realSize;) {
+        const size_t vl = __riscv_vsetvl_e32m8(realSize - i);
+        const vfloat32m8_t zero = __riscv_vfmv_v_f_f32m8(0.0f, vl);
+        __riscv_vse32_v_f32m8(absmax + i, zero, vl);
+        i += vl;
+    }
+
+    for (size_t c = 0; c < src_depth_quad; ++c) {
+        const float* srcC = source + c * planeStride;
+        for (size_t i = 0; i < realSize;) {
+            const size_t vl = __riscv_vsetvl_e32m8(realSize - i);
+            const float* src = srcC + i * pack;
+            vfloat32m8_t maxValue = __riscv_vle32_v_f32m8(absmax + i, vl);
+            for (int k = 0; k < pack; ++k) {
+                const vfloat32m8_t value = __riscv_vlse32_v_f32m8(src + k, srcStrideBytes, vl);
+                maxValue = __riscv_vfmax_vv_f32m8(maxValue, __riscv_vfabs_v_f32m8(value, vl), vl);
             }
+            __riscv_vse32_v_f32m8(absmax + i, maxValue, vl);
+            i += vl;
         }
-        vfloat32m1_t res = __riscv_vfredmax_vs_f32m1_f32m1(max_v, __riscv_vfmv_s_f_f32m1(0.0f, vlmax), vlmax);
-        float absmaxVal = __riscv_vfmv_f_s_f32m1_f32(res);
-        absmax[i] = absmaxVal;
     }
 }

--- a/source/backend/cpu/riscv/rvv/MNNAccumulateSequenceNumber.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNAccumulateSequenceNumber.cpp
@@ -1,17 +1,30 @@
 #include <riscv_vector.h>
+#include <cstddef>
+
 void MNNAccumulateSequenceNumber_RVV(float* dst, const float* src, int size) {
-    size_t vl = __riscv_vsetvlmax_e32m1();
-    vfloat32m1_t v_sum = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-    int n = size;
-    for (; n > 0;) {
-        vl = __riscv_vsetvl_e32m1(n);
-        vfloat32m1_t v_src = __riscv_vle32_v_f32m1(src, vl);
-        v_sum = __riscv_vfadd_vv_f32m1(v_sum, v_src, vl);
-        n -= vl;
-        src += vl;
+    if (size <= 0) {
+        *dst = 0.0f;
+        return;
     }
-    vl = __riscv_vsetvlmax_e32m1();
-    vfloat32m1_t v_total = __riscv_vfredusum_vs_f32m1_f32m1(v_sum, __riscv_vfmv_s_f_f32m1(0.0f, vl), vl);
-    float sum = __riscv_vfmv_f_s_f32m1_f32(v_total);
+
+    const size_t vlmax = __riscv_vsetvlmax_e32m8();
+    vfloat32m8_t sumVector = __riscv_vfmv_v_f_f32m8(0.0f, vlmax);
+    size_t remaining = static_cast<size_t>(size);
+    while (remaining >= vlmax) {
+        const vfloat32m8_t value = __riscv_vle32_v_f32m8(src, vlmax);
+        sumVector = __riscv_vfadd_vv_f32m8(sumVector, value, vlmax);
+        src += vlmax;
+        remaining -= vlmax;
+    }
+
+    vfloat32m1_t sumScalar = __riscv_vfredusum_vs_f32m8_f32m1(sumVector, __riscv_vfmv_s_f_f32m1(0.0f, 1), vlmax);
+    float sum = __riscv_vfmv_f_s_f32m1_f32(sumScalar);
+
+    if (remaining > 0) {
+        const size_t vl = __riscv_vsetvl_e32m8(remaining);
+        const vfloat32m8_t value = __riscv_vle32_v_f32m8(src, vl);
+        sumScalar = __riscv_vfredusum_vs_f32m8_f32m1(value, __riscv_vfmv_s_f_f32m1(sum, 1), vl);
+        sum = __riscv_vfmv_f_s_f32m1_f32(sumScalar);
+    }
     *dst = sum;
 }

--- a/source/backend/cpu/riscv/rvv/MNNConvRunForLineDepthwise.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNConvRunForLineDepthwise.cpp
@@ -1,47 +1,39 @@
 #include <riscv_vector.h>
+#include <cstddef>
 
-void MNNConvRunForLineDepthwise(
-    float* dst, const float* src, const float* weight, 
-    size_t width, size_t src_w_setup,
-    size_t fw, size_t fh, size_t dilateX_step, size_t dilateY_step, 
-    size_t height, size_t srcHStep, size_t dstHStep, 
-    const float* bias, const float* parameters) {
-    float minV = parameters[0];
-    float maxV = parameters[1];
-        ptrdiff_t srcByteStride = src_w_setup * sizeof(float);
-    ptrdiff_t dstByteStride = 4 * sizeof(float);
-    
+void MNNConvRunForLineDepthwise(float* dst, const float* src, const float* weight, size_t width, size_t src_w_setup,
+                                size_t fw, size_t fh, size_t dilateX_step, size_t dilateY_step, size_t height,
+                                size_t srcHStep, size_t dstHStep, const float* bias, const float* parameters) {
+    const float minV = parameters[0];
+    const float maxV = parameters[1];
+    const ptrdiff_t srcByteStride = static_cast<ptrdiff_t>(src_w_setup) * sizeof(float);
+    const ptrdiff_t dstByteStride = 4 * sizeof(float);
+
     for (size_t y = 0; y < height; ++y) {
         const float* srcY = src + y * srcHStep;
         float* dstY = dst + y * dstHStep;
-        size_t dx = 0;
-        
-        while (dx < width) {
-            size_t vl = __riscv_vsetvl_e32m8(width - dx);
-            
+        for (size_t dx = 0; dx < width;) {
+            const size_t vl = __riscv_vsetvl_e32m8(width - dx);
+
             for (int c = 0; c < 4; ++c) {
                 vfloat32m8_t acc = __riscv_vfmv_v_f_f32m8(bias[c], vl);
                 const float* srcBase = srcY + dx * src_w_setup + c;
                 const float* weightPtr = weight + c;
-                
+
                 for (size_t fy = 0; fy < fh; ++fy) {
                     const float* srcFy = srcBase + fy * dilateY_step;
-                    
                     for (size_t fx = 0; fx < fw; ++fx) {
-                        float w = *weightPtr;
+                        const vfloat32m8_t srcValue =
+                            __riscv_vlse32_v_f32m8(srcFy + fx * dilateX_step, srcByteStride, vl);
+                        acc = __riscv_vfmacc_vf_f32m8(acc, *weightPtr, srcValue, vl);
                         weightPtr += 4;
-                        const float* srcFx = srcFy + fx * dilateX_step;
-                        vfloat32m8_t s = __riscv_vlse32_v_f32m8(srcFx, srcByteStride, vl);
-                        acc = __riscv_vfmacc_vf_f32m8(acc, w, s, vl);
                     }
                 }
-                
+
                 acc = __riscv_vfmax_vf_f32m8(acc, minV, vl);
                 acc = __riscv_vfmin_vf_f32m8(acc, maxV, vl);
-                float* dstAddr = dstY + dx * 4 + c;
-                __riscv_vsse32_v_f32m8(dstAddr, dstByteStride, acc, vl);
+                __riscv_vsse32_v_f32m8(dstY + dx * 4 + c, dstByteStride, acc, vl);
             }
-            
             dx += vl;
         }
     }

--- a/source/backend/cpu/riscv/rvv/MNNConvRunForLineint8_t.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNConvRunForLineint8_t.cpp
@@ -1,0 +1,52 @@
+#include <riscv_vector.h>
+#include <cstddef>
+#include <cstdint>
+
+void MNNConvRunForLineint8_t(float* dst, const int8_t* src, const int8_t* weight, size_t width, size_t src_w_setup,
+                             size_t src_depth_quad, size_t src_depth_step, size_t fw, size_t fh, size_t dilateX_step,
+                             size_t dilateY_step, float* alpha) {
+    const ptrdiff_t srcWidthStrideBytes = static_cast<ptrdiff_t>(src_w_setup);
+    const ptrdiff_t dstWidthStrideBytes = 4 * sizeof(float);
+
+    for (size_t dx = 0; dx < width;) {
+        const size_t vl = __riscv_vsetvl_e32m4(width - dx);
+        vfloat32m4_t acc0 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+        vfloat32m4_t acc1 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+        vfloat32m4_t acc2 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+        vfloat32m4_t acc3 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+        const int8_t* srcDx = src + src_w_setup * dx;
+
+        for (size_t sz = 0; sz < src_depth_quad; ++sz) {
+            const int8_t* srcZ = srcDx + sz * src_depth_step;
+            const int8_t* weightZ = weight + sz * fh * fw * 16;
+            for (size_t fy = 0; fy < fh; ++fy) {
+                const int8_t* srcY = srcZ + fy * dilateY_step;
+                const int8_t* weightY = weightZ + fy * fw * 16;
+                for (size_t fx = 0; fx < fw; ++fx) {
+                    const int8_t* srcX = srcY + fx * dilateX_step;
+                    const int8_t* weightX = weightY + 16 * fx;
+                    for (int i = 0; i < 4; ++i) {
+                        const vint8m1_t src8 = __riscv_vlse8_v_i8m1(srcX + i, srcWidthStrideBytes, vl);
+                        const vint32m4_t src32 = __riscv_vsext_vf4_i32m4(src8, vl);
+                        const vfloat32m4_t srcF = __riscv_vfcvt_f_x_v_f32m4(src32, vl);
+                        acc0 = __riscv_vfmacc_vf_f32m4(acc0, static_cast<float>(weightX[4 * i + 0]), srcF, vl);
+                        acc1 = __riscv_vfmacc_vf_f32m4(acc1, static_cast<float>(weightX[4 * i + 1]), srcF, vl);
+                        acc2 = __riscv_vfmacc_vf_f32m4(acc2, static_cast<float>(weightX[4 * i + 2]), srcF, vl);
+                        acc3 = __riscv_vfmacc_vf_f32m4(acc3, static_cast<float>(weightX[4 * i + 3]), srcF, vl);
+                    }
+                }
+            }
+        }
+
+        float* dstDx = dst + dx * 4;
+        acc0 = __riscv_vfmul_vf_f32m4(acc0, alpha[0], vl);
+        acc1 = __riscv_vfmul_vf_f32m4(acc1, alpha[1], vl);
+        acc2 = __riscv_vfmul_vf_f32m4(acc2, alpha[2], vl);
+        acc3 = __riscv_vfmul_vf_f32m4(acc3, alpha[3], vl);
+        __riscv_vsse32_v_f32m4(dstDx + 0, dstWidthStrideBytes, acc0, vl);
+        __riscv_vsse32_v_f32m4(dstDx + 1, dstWidthStrideBytes, acc1, vl);
+        __riscv_vsse32_v_f32m4(dstDx + 2, dstWidthStrideBytes, acc2, vl);
+        __riscv_vsse32_v_f32m4(dstDx + 3, dstWidthStrideBytes, acc3, vl);
+        dx += vl;
+    }
+}

--- a/source/backend/cpu/riscv/rvv/MNNConvRunForUnitint8_t.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNConvRunForUnitint8_t.cpp
@@ -1,0 +1,32 @@
+#include <riscv_vector.h>
+#include <cstddef>
+#include <cstdint>
+
+void MNNConvRunForUnitint8_t(float* dst, const int8_t* src, const int8_t* weight, size_t src_depth_quad,
+                             size_t src_depth_step, size_t fw, size_t fh, size_t weight_y_step, size_t weight_z_step,
+                             size_t dilateX_step, size_t dilateY_step, float* alpha) {
+    const size_t vl = __riscv_vsetvl_e32m4(4);
+    vfloat32m4_t acc = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+
+    for (size_t sz = 0; sz < src_depth_quad; ++sz) {
+        const int8_t* srcZ = src + sz * src_depth_step;
+        const int8_t* weightZ = weight + sz * weight_z_step;
+        for (size_t fy = 0; fy < fh; ++fy) {
+            const int8_t* srcY = srcZ + fy * dilateY_step;
+            const int8_t* weightY = weightZ + fy * weight_y_step;
+            for (size_t fx = 0; fx < fw; ++fx) {
+                const int8_t* srcX = srcY + fx * dilateX_step;
+                const int8_t* weightX = weightY + 16 * fx;
+                for (int i = 0; i < 4; ++i) {
+                    const vint8m1_t weight8 = __riscv_vle8_v_i8m1(weightX + 4 * i, vl);
+                    const vint32m4_t weight32 = __riscv_vsext_vf4_i32m4(weight8, vl);
+                    const vfloat32m4_t weightF = __riscv_vfcvt_f_x_v_f32m4(weight32, vl);
+                    acc = __riscv_vfmacc_vf_f32m4(acc, static_cast<float>(srcX[i]), weightF, vl);
+                }
+            }
+        }
+    }
+
+    const vfloat32m4_t alphaV = __riscv_vle32_v_f32m4(alpha, vl);
+    __riscv_vse32_v_f32m4(dst, __riscv_vfmul_vv_f32m4(acc, alphaV, vl), vl);
+}

--- a/source/backend/cpu/riscv/rvv/MNNDeconvRunForUnitDepthWise.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNDeconvRunForUnitDepthWise.cpp
@@ -1,41 +1,23 @@
 #include <riscv_vector.h>
+#include <cstddef>
 
-void MNNDeconvRunForUnitDepthWise(
-    const float* dst, float* src, const float* weight, 
-    size_t fw, size_t fh,
-    size_t weightY_step, size_t dilateX_step, size_t dilateY_step) {    
-    const ptrdiff_t wStride = 4 * sizeof(float);
-    const ptrdiff_t sStride = dilateX_step * sizeof(float);
-    float d0 = dst[0], d1 = dst[1], d2 = dst[2], d3 = dst[3];
-    
+void MNNDeconvRunForUnitDepthWise(const float* dst, float* src, const float* weight, size_t fw, size_t fh,
+                                  size_t weight_y_step, size_t dilateX_step, size_t dilateY_step) {
+    const ptrdiff_t weightStrideBytes = 4 * sizeof(float);
+    const ptrdiff_t srcStrideBytes = static_cast<ptrdiff_t>(dilateX_step) * sizeof(float);
+
     for (size_t fy = 0; fy < fh; ++fy) {
         float* srcY = src + fy * dilateY_step;
-        const float* weightY = weight + fy * weightY_step;
-        
-        size_t fx = 0;
-        while (fx < fw) {
-            size_t vl = __riscv_vsetvl_e32m8(fw - fx);
-            
-            vfloat32m8_t w = __riscv_vlse32_v_f32m8(weightY + 0 + fx * 4, wStride, vl);
-            vfloat32m8_t s = __riscv_vlse32_v_f32m8(srcY + 0 + fx * dilateX_step, sStride, vl);
-            s = __riscv_vfmacc_vf_f32m8(s, d0, w, vl);
-            __riscv_vsse32_v_f32m8(srcY + 0 + fx * dilateX_step, sStride, s, vl);
-            
-            w = __riscv_vlse32_v_f32m8(weightY + 1 + fx * 4, wStride, vl);
-            s = __riscv_vlse32_v_f32m8(srcY + 1 + fx * dilateX_step, sStride, vl);
-            s = __riscv_vfmacc_vf_f32m8(s, d1, w, vl);
-            __riscv_vsse32_v_f32m8(srcY + 1 + fx * dilateX_step, sStride, s, vl);
-            
-            w = __riscv_vlse32_v_f32m8(weightY + 2 + fx * 4, wStride, vl);
-            s = __riscv_vlse32_v_f32m8(srcY + 2 + fx * dilateX_step, sStride, vl);
-            s = __riscv_vfmacc_vf_f32m8(s, d2, w, vl);
-            __riscv_vsse32_v_f32m8(srcY + 2 + fx * dilateX_step, sStride, s, vl);
-            
-            w = __riscv_vlse32_v_f32m8(weightY + 3 + fx * 4, wStride, vl);
-            s = __riscv_vlse32_v_f32m8(srcY + 3 + fx * dilateX_step, sStride, vl);
-            s = __riscv_vfmacc_vf_f32m8(s, d3, w, vl);
-            __riscv_vsse32_v_f32m8(srcY + 3 + fx * dilateX_step, sStride, s, vl);
-            
+        const float* weightY = weight + fy * weight_y_step;
+        for (size_t fx = 0; fx < fw;) {
+            const size_t vl = __riscv_vsetvl_e32m8(fw - fx);
+
+            for (int c = 0; c < 4; ++c) {
+                vfloat32m8_t srcValue = __riscv_vlse32_v_f32m8(srcY + fx * dilateX_step + c, srcStrideBytes, vl);
+                const vfloat32m8_t weightValue = __riscv_vlse32_v_f32m8(weightY + fx * 4 + c, weightStrideBytes, vl);
+                srcValue = __riscv_vfmacc_vf_f32m8(srcValue, dst[c], weightValue, vl);
+                __riscv_vsse32_v_f32m8(srcY + fx * dilateX_step + c, srcStrideBytes, srcValue, vl);
+            }
             fx += vl;
         }
     }

--- a/source/backend/cpu/riscv/rvv/MNNMatrixAdd.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNMatrixAdd.cpp
@@ -1,26 +1,20 @@
 #include <riscv_vector.h>
+#include <cstddef>
 
-void MNNMatrixAdd(float *C, const float *A, const float *B,
-                     size_t widthC4, size_t cStride, size_t aStride,
-                     size_t bStride, size_t height) {
-    size_t total = widthC4 * 4;
+void MNNMatrixAdd(float* C, const float* A, const float* B, size_t widthC4, size_t cStride, size_t aStride,
+                  size_t bStride, size_t height) {
+    const size_t total = widthC4 * 4;
     for (size_t y = 0; y < height; ++y) {
-        auto a = A + aStride * y;
-        auto b = B + bStride * y;
-        auto c = C + cStride * y;
+        const float* a = A + aStride * y;
+        const float* b = B + bStride * y;
+        float* c = C + cStride * y;
 
-        size_t n = total;
-        while (n > 0) {
-            size_t vl = __riscv_vsetvl_e32m8(n);
-            vfloat32m8_t va = __riscv_vle32_v_f32m8(a, vl);
-            vfloat32m8_t vb = __riscv_vle32_v_f32m8(b, vl);
-            vfloat32m8_t vc = __riscv_vfadd_vv_f32m8(va, vb, vl);
-            __riscv_vse32_v_f32m8(c, vc, vl);
-
-            a += vl;
-            b += vl;
-            c += vl;
-            n -= vl;
+        for (size_t x = 0; x < total;) {
+            const size_t vl = __riscv_vsetvl_e32m8(total - x);
+            const vfloat32m8_t va = __riscv_vle32_v_f32m8(a + x, vl);
+            const vfloat32m8_t vb = __riscv_vle32_v_f32m8(b + x, vl);
+            __riscv_vse32_v_f32m8(c + x, __riscv_vfadd_vv_f32m8(va, vb, vl), vl);
+            x += vl;
         }
     }
 }

--- a/source/backend/cpu/riscv/rvv/MNNMatrixProd.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNMatrixProd.cpp
@@ -1,27 +1,20 @@
 #include <riscv_vector.h>
+#include <cstddef>
 
-void MNNMatrixProd(float* C, const float* A, const float* B,
-                       size_t widthC4, size_t cStride, size_t aStride,
-                       size_t bStride, size_t height) {
-    size_t total = widthC4 * 4;
-
-    for (int y = 0; y < height; ++y) {
+void MNNMatrixProd(float* C, const float* A, const float* B, size_t widthC4, size_t cStride, size_t aStride,
+                   size_t bStride, size_t height) {
+    const size_t total = widthC4 * 4;
+    for (size_t y = 0; y < height; ++y) {
         const float* a = A + aStride * y;
         const float* b = B + bStride * y;
         float* c = C + cStride * y;
-        size_t n = total;
 
-        while (n > 0) {
-            size_t vl = __riscv_vsetvl_e32m8(n);
-            vfloat32m8_t va = __riscv_vle32_v_f32m8(a, vl);
-            vfloat32m8_t vb = __riscv_vle32_v_f32m8(b, vl);
-            vfloat32m8_t vc = __riscv_vfmul_vv_f32m8(va, vb, vl);
-            __riscv_vse32_v_f32m8(c, vc, vl);
-
-            a += vl;
-            b += vl;
-            c += vl;
-            n -= vl;
+        for (size_t x = 0; x < total;) {
+            const size_t vl = __riscv_vsetvl_e32m8(total - x);
+            const vfloat32m8_t va = __riscv_vle32_v_f32m8(a + x, vl);
+            const vfloat32m8_t vb = __riscv_vle32_v_f32m8(b + x, vl);
+            __riscv_vse32_v_f32m8(c + x, __riscv_vfmul_vv_f32m8(va, vb, vl), vl);
+            x += vl;
         }
     }
 }

--- a/source/backend/cpu/riscv/rvv/MNNMatrixSub.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNMatrixSub.cpp
@@ -1,26 +1,20 @@
 #include <riscv_vector.h>
+#include <cstddef>
 
-void MNNMatrixSub(float *C, const float *A, const float *B,
-                     size_t widthC4, size_t cStride, size_t aStride,
-                     size_t bStride, size_t height) {
-    size_t total = widthC4 * 4;
-    for (int y = 0; y < height; ++y) {
-        auto a = A + aStride * y;
-        auto b = B + bStride * y;
-        auto c = C + cStride * y;
+void MNNMatrixSub(float* C, const float* A, const float* B, size_t widthC4, size_t cStride, size_t aStride,
+                  size_t bStride, size_t height) {
+    const size_t total = widthC4 * 4;
+    for (size_t y = 0; y < height; ++y) {
+        const float* a = A + aStride * y;
+        const float* b = B + bStride * y;
+        float* c = C + cStride * y;
 
-        size_t n = total;
-        while (n > 0) {
-            size_t vl = __riscv_vsetvl_e32m8(n);
-            vfloat32m8_t va = __riscv_vle32_v_f32m8(a, vl);
-            vfloat32m8_t vb = __riscv_vle32_v_f32m8(b, vl);
-            vfloat32m8_t vc = __riscv_vfsub_vv_f32m8(va, vb, vl);
-            __riscv_vse32_v_f32m8(c, vc, vl);
-
-            a += vl;
-            b += vl;
-            c += vl;
-            n -= vl;
+        for (size_t x = 0; x < total;) {
+            const size_t vl = __riscv_vsetvl_e32m8(total - x);
+            const vfloat32m8_t va = __riscv_vle32_v_f32m8(a + x, vl);
+            const vfloat32m8_t vb = __riscv_vle32_v_f32m8(b + x, vl);
+            __riscv_vse32_v_f32m8(c + x, __riscv_vfsub_vv_f32m8(va, vb, vl), vl);
+            x += vl;
         }
     }
 }

--- a/source/backend/cpu/riscv/rvv/MNNPackedMatMul_int8.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNPackedMatMul_int8.cpp
@@ -2,7 +2,6 @@
 #include <limits>
 #include <cstddef>
 #include <cstdint>
-#include <algorithm>
 
 #define UP_DIV(x, y) (((x) + (y) - 1) / (y))
 
@@ -10,12 +9,11 @@ static void MNNPackedMatMulRemain_int8_RVVImpl(float* C, const float* A, const f
                                                const size_t* parameter, const float* postParameters, const float* bias,
                                                int aStride, const float* k, const float* b) {
     const int8_t* B = reinterpret_cast<const int8_t*>(fB);
-    size_t h = parameter[2];
-    size_t l = parameter[1];
-    size_t cStride = parameter[3] / sizeof(float);
-    int32_t bExtraStride = static_cast<int32_t>(parameter[5]);
-    size_t bStride = bExtraStride + 4 * l;
-    size_t hC4 = UP_DIV(h, 4);
+    const size_t h = parameter[2];
+    const size_t l = parameter[1];
+    const size_t cStride = parameter[3] / sizeof(float);
+    const size_t bStride = parameter[5] + 4 * l;
+    const size_t hC4 = UP_DIV(h, 4);
 
     float minValue = -std::numeric_limits<float>::max();
     float maxValue = std::numeric_limits<float>::max();
@@ -23,48 +21,62 @@ static void MNNPackedMatMulRemain_int8_RVVImpl(float* C, const float* A, const f
         minValue = postParameters[2];
         maxValue = postParameters[3];
     }
-    int blockId = parameter[6];
-    const size_t VL = 4;
+    const int blockId = static_cast<int>(parameter[6]);
+    const ptrdiff_t cXStrideBytes = 4 * sizeof(float);
 
-    vfloat32m1_t min_v = __riscv_vfmv_v_f_f32m1(minValue, VL);
-    vfloat32m1_t max_v = __riscv_vfmv_v_f_f32m1(maxValue, VL);
-
-    for (size_t x = 0; x < eSize; x++) {
-        float* dst = C + 4 * x;
-        const float* src = A + x;
-
-        for (size_t y = 0; y < hC4; y++) {
-            float* dstY = dst + y * cStride;
-            const int8_t* weight = B + y * bStride;
-            const float* alpha = k + y * 4;
-            const float* qbias = b + y * 4;
-
-            vfloat32m1_t sum_v = __riscv_vfmv_v_f_f32m1(0.0f, VL);
+    for (size_t y = 0; y < hC4; ++y) {
+        const int8_t* weight = B + y * bStride;
+        const float* alpha = k + y * 4;
+        const float* qbias = b + y * 4;
+        for (size_t x = 0; x < eSize;) {
+            const size_t vl = __riscv_vsetvl_e32m4(eSize - x);
+            float* dst = C + y * cStride + 4 * x;
+            vfloat32m4_t sum0;
+            vfloat32m4_t sum1;
+            vfloat32m4_t sum2;
+            vfloat32m4_t sum3;
             if (blockId > 0) {
-                sum_v = __riscv_vle32_v_f32m1(dstY, VL);
+                sum0 = __riscv_vlse32_v_f32m4(dst + 0, cXStrideBytes, vl);
+                sum1 = __riscv_vlse32_v_f32m4(dst + 1, cXStrideBytes, vl);
+                sum2 = __riscv_vlse32_v_f32m4(dst + 2, cXStrideBytes, vl);
+                sum3 = __riscv_vlse32_v_f32m4(dst + 3, cXStrideBytes, vl);
+            } else {
+                sum0 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+                sum1 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+                sum2 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+                sum3 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
             }
 
             if (bias != nullptr && postParameters != nullptr) {
-                vfloat32m1_t bias_v = __riscv_vle32_v_f32m1(bias + 4 * y, VL);
-                sum_v = __riscv_vfadd_vv_f32m1(sum_v, bias_v, VL);
+                const float* biasY = bias + y * 4;
+                sum0 = __riscv_vfadd_vf_f32m4(sum0, biasY[0], vl);
+                sum1 = __riscv_vfadd_vf_f32m4(sum1, biasY[1], vl);
+                sum2 = __riscv_vfadd_vf_f32m4(sum2, biasY[2], vl);
+                sum3 = __riscv_vfadd_vf_f32m4(sum3, biasY[3], vl);
             }
 
-            for (size_t z = 0; z < l; z++) {
-                float a_val = src[z * aStride];
-                vfloat32m1_t a_v = __riscv_vfmv_v_f_f32m1(a_val, VL);
-
-                float w_buf[4] = {
-                    (float)weight[z * 4 + 0] * alpha[0] + qbias[0], (float)weight[z * 4 + 1] * alpha[1] + qbias[1],
-                    (float)weight[z * 4 + 2] * alpha[2] + qbias[2], (float)weight[z * 4 + 3] * alpha[3] + qbias[3]};
-
-                vfloat32m1_t w_v = __riscv_vle32_v_f32m1(w_buf, VL);
-
-                sum_v = __riscv_vfmadd_vv_f32m1(w_v, a_v, sum_v, VL);
+            for (size_t z = 0; z < l; ++z) {
+                const int8_t* weightZ = weight + 4 * z;
+                const vfloat32m4_t a = __riscv_vle32_v_f32m4(A + z * aStride + x, vl);
+                const float w0 = static_cast<float>(weightZ[0]) * alpha[0] + qbias[0];
+                const float w1 = static_cast<float>(weightZ[1]) * alpha[1] + qbias[1];
+                const float w2 = static_cast<float>(weightZ[2]) * alpha[2] + qbias[2];
+                const float w3 = static_cast<float>(weightZ[3]) * alpha[3] + qbias[3];
+                sum0 = __riscv_vfmacc_vf_f32m4(sum0, w0, a, vl);
+                sum1 = __riscv_vfmacc_vf_f32m4(sum1, w1, a, vl);
+                sum2 = __riscv_vfmacc_vf_f32m4(sum2, w2, a, vl);
+                sum3 = __riscv_vfmacc_vf_f32m4(sum3, w3, a, vl);
             }
 
-            sum_v = __riscv_vfmin_vv_f32m1(sum_v, max_v, VL);
-            sum_v = __riscv_vfmax_vv_f32m1(sum_v, min_v, VL);
-            __riscv_vse32_v_f32m1(dstY, sum_v, VL);
+            sum0 = __riscv_vfmax_vf_f32m4(__riscv_vfmin_vf_f32m4(sum0, maxValue, vl), minValue, vl);
+            sum1 = __riscv_vfmax_vf_f32m4(__riscv_vfmin_vf_f32m4(sum1, maxValue, vl), minValue, vl);
+            sum2 = __riscv_vfmax_vf_f32m4(__riscv_vfmin_vf_f32m4(sum2, maxValue, vl), minValue, vl);
+            sum3 = __riscv_vfmax_vf_f32m4(__riscv_vfmin_vf_f32m4(sum3, maxValue, vl), minValue, vl);
+            __riscv_vsse32_v_f32m4(dst + 0, cXStrideBytes, sum0, vl);
+            __riscv_vsse32_v_f32m4(dst + 1, cXStrideBytes, sum1, vl);
+            __riscv_vsse32_v_f32m4(dst + 2, cXStrideBytes, sum2, vl);
+            __riscv_vsse32_v_f32m4(dst + 3, cXStrideBytes, sum3, vl);
+            x += vl;
         }
     }
 }


### PR DESCRIPTION
Add and refine RVV implementations for ConvOpt depthwise, int8, deconv, matrix, and related low-memory helper kernels.

## Description
#Develop the RVV accelerated version of the methods below:

- MNNConvRunForLineDepthwise
- MNNConvRunForUnitint8_t
- MNNConvRunForLineint8_t
- MNNDeconvRunForUnitDepthWise
- MNNMatrixAdd
- MNNMatrixSub
- MNNMatrixProd

#Fix RVV performance regression introduced in #4433

- MNNPackedMatMulRemain_int8
- MNNAbsMaxFP32

##Performance Metrics

The performance metrics will be updated in the near future.

##Module

CPU/RVV

## Type

- [x] Feature
- [ ] Bugfix
- [x] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [x] Tested on relevant platform(s)
- [x] No unrelated format or style changes included
