### PR TITLE
[Converter:Bugfix] Fix Einsum 4D fast-path for non-aligned batch dims

### DIFF
--- a/tools/converter/source/optimizer/onnxextra/OnnxEinsum.cpp
+++ b/tools/converter/source/optimizer/onnxextra/OnnxEinsum.cpp
@@ -169,9 +169,9 @@ public:
             // bhwc,bhkc -> bhwk  batch = `bh`, reduce_dim = `c`
 
             // find reduce dim
-            char reduce_dim;
+            char reduce_dim = 0;
             int reduce_dim_pos = -1;
-            for (int i = 0; i < input0.size(); ++i) {
+            for (int i = 0; i < (int)input0.size(); ++i) {
                 auto c = input0[i];
                 if (right.find(c) == std::string::npos) {
                     reduce_dim = c;
@@ -179,15 +179,32 @@ public:
                     break;
                 }
             }
-            bool needTransposeA = false;
-            if (reduce_dim_pos >= 0 && input0.size() >= 2 && reduce_dim_pos == input0.size() - 2) {
-                needTransposeA = true;
+            // Verify the fast path produces correct output order:
+            // MatMul output dims = input0 dims (minus reduce) + input1's unique dim appended.
+            // Only valid when this matches `right` without needing permutation.
+            std::string expectedOutput;
+            for (int i = 0; i < (int)input0.size(); ++i) {
+                if (i != reduce_dim_pos) {
+                    expectedOutput += input0[i];
+                }
             }
-            auto need_transpose = input1.find(reduce_dim) == (input1.size() - 1);
-            // matmul: matmul auto broadcast such: `bhwc @ hkc` -> `bhwc @ bhkc`
-            auto output = _MatMul(var0, var1, needTransposeA, need_transpose);
-            output->setName(expr->name());
-            return output->expr().first;
+            for (int i = 0; i < (int)input1.size(); ++i) {
+                char c = input1[i];
+                if (c != reduce_dim && expectedOutput.find(c) == std::string::npos) {
+                    expectedOutput += c;
+                }
+            }
+            if (reduce_dim_pos >= 0 && right == expectedOutput) {
+                bool needTransposeA = false;
+                if (input0.size() >= 2 && reduce_dim_pos == (int)input0.size() - 2) {
+                    needTransposeA = true;
+                }
+                auto need_transpose = input1.find(reduce_dim) == (input1.size() - 1);
+                auto output = _MatMul(var0, var1, needTransposeA, need_transpose);
+                output->setName(expr->name());
+                return output->expr().first;
+            }
+            // Fall through to general path when output order doesn't match
         }
 
         if (right.size() == 3) {


### PR DESCRIPTION
## 问题描述

Einsum转换器的4D快速路径假设矩阵乘法输出顺序与方程右侧匹配，但未验证此假设。

对于批次维度与非批次维度交错的方程（如 `binc,bjnc->bnij`，常见于Wan/T5注意力机制），快速路径生成的普通MatMul产生 `[b,i,n,n]` 而非 `[b,n,i,j]`，导致：
- 注意力分数损坏
- 运行时 Compute Shape Error
- 段错误

## 解决方案

添加输出顺序检查：仅当 `input0的非reduce维度 + input1的唯一维度 == right` 时才使用快速路径，否则回退到通用的 permute+reshape+matmul 路径。

## 变更内容

- 初始化 `reduce_dim` 变量（修复未初始化警告）
- 修复有符号/无符号比较警告
- 添加输出顺序验证逻辑（14行新增）
- 条件化快速路径执行
