### PR TITLE
[PyMNN:Bugfix] Make llm submodule import optional

### DIFF
--- a/pymnn/pip_package/MNN/__init__.py
+++ b/pymnn/pip_package/MNN/__init__.py
@@ -10,4 +10,7 @@ from . import optim
 from . import numpy
 from . import cv
 from . import audio
-from . import llm
+try:
+    from . import llm
+except ImportError:
+    llm = None


### PR DESCRIPTION
## 问题描述

当MNN编译时未启用 `-DMNN_BUILD_LLM=ON`，导入PyMNN会崩溃：
```python
from MNN import llm  # ModuleNotFoundError
```

这阻止了仅使用Diffusion/CV功能的用户。

## 解决方案

将llm导入包装在 `try/except ImportError` 中，使其成为可选依赖。

## 变更内容

```python
# pymnn/pip_package/MNN/__init__.py
try:
    from . import llm
except ImportError:
    pass  # llm子模块不可用（MNN_BUILD_LLM=OFF）
```
