### PR TITLE
[Embedding:Bugfix] Fix embedding_demo crash caused by mMeta->add==0

### DIFF
--- a/transformers/llm/engine/src/embedding.cpp
+++ b/transformers/llm/engine/src/embedding.cpp
@@ -9,6 +9,7 @@
 #include "llmconfig.hpp"
 #include "tokenizer/tokenizer.hpp"
 #include "diskembedding.hpp"
+#include "core/KVMeta.hpp"
 
 namespace MNN {
 using namespace Express;
@@ -89,8 +90,14 @@ VARP Embedding::ids_embedding(const std::vector<int>& ids) {
     if(mContext->status == LlmStatus::INTERNAL_ERROR) {
         return nullptr;
     }
-    
+    // Reset KV cache and set add length for independent forward passes
+    setKVCacheInfo(0, getCurrentHistory());
+    reset();
+    mContext->prompt_len = ids.size();
+    mContext->all_seq_len = ids.size();
+
     int prompt_len           = ids.size();
+    mMeta->add = prompt_len;
     auto inputs_ids          = embedding(ids);
     auto attention_mask      = gen_attention_mask(prompt_len);
     auto position_ids        = gen_position_ids(prompt_len);


### PR DESCRIPTION
Fix embedding_demo crash caused by `mMeta->add==0`.