### PR TITLE
[CPU:Feature] RVV: Add vectorized MNNSiLu and MNNExpC8 implementations

### DIFF
--- a/source/backend/cpu/compute/CommonOptFunction.cpp
+++ b/source/backend/cpu/compute/CommonOptFunction.cpp
@@ -2883,6 +2883,7 @@ void MNNUnpackC4(float* dst, const float* src, size_t area, size_t depth, int* a
     MNNUnpackC4Common<float>(dst, src, area, depth, areaOffset);
 }
 
+#ifndef MNN_USE_RVV
 void MNNExpC8(float* dest, const float* source, float* offset, const float* parameters, size_t countC8) {
     auto count = countC8 * 8;
     auto param = parameters[0];
@@ -2907,6 +2908,7 @@ void MNNExpC8(float* dest, const float* source, float* offset, const float* para
     }
     offset[3] = summer;
 }
+#endif
 
 void MNNSoftmax(float* softmaxDst, const float* softmaxSrc, float* runningMax, float* runningSum, float* updateScale, int outside, int reduceSize, int kvSeqOffset, int validOffset, int pack, bool mask) {
 
@@ -4590,6 +4592,7 @@ void MNNSigmoid(float* dst, const float* src, size_t dataSize) {
     }
 }
 
+#ifndef MNN_USE_RVV
 void MNNSiLu(float* dst, const float* src, size_t dataSize) {
     float offset[4] = {
        -1.0f,
@@ -4602,6 +4605,7 @@ void MNNSiLu(float* dst, const float* src, size_t dataSize) {
         dst[i] = src[i] / (1.0f + dst[i]);
     }
 }
+#endif
 
 /**
  Modified from https://github.com/alibaba/MNN/pull/1359
@@ -4648,6 +4652,7 @@ void MNNSigmoidLowp(float* dst, const float* src, size_t dataSize) {
 #endif
 }
 
+#ifndef MNN_USE_RVV
 void MNNSiLuLowp(float* dst, const float* src, size_t dataSize) {
     float offset[4] = {
        -1.0f,
@@ -4695,6 +4700,7 @@ void MNNSiLuLowp(float* dst, const float* src, size_t dataSize) {
     }
 #endif
 }
+#endif
 
 static void _MNNAdjustOptimalSparseKernel(int& sparseBlockOC, MNN::CoreFunctions::MNNPackedSparseMatMul& packedSparseMatMul) {
     if(sparseBlockOC == 4) {

--- a/source/backend/cpu/riscv/rvv/MNNExpC8.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNExpC8.cpp
@@ -1,0 +1,81 @@
+#include <riscv_vector.h>
+
+extern "C" {
+
+void MNNExpC8(float* dest, const float* source, float* offset, const float* parameters, size_t countC8) {
+    size_t count = countC8 * 8;
+    float xLimit = 87.0f;
+
+    float inputScale = offset[0];
+    float outputBias = offset[1];
+    float inputBias = offset[2];
+    float summer = offset[3];
+    float param = parameters[0];    // ln(2)
+    float invParam = parameters[1]; // 1/ln(2)
+    float p4 = parameters[4];
+    float p5 = parameters[5];
+    float p6 = parameters[6];
+    float p7 = parameters[7];
+
+    size_t n = count;
+    const float* srcPtr = source;
+    float* dstPtr = dest;
+    vfloat32m1_t vSum = __riscv_vfmv_s_f_f32m1(summer, 1);
+
+    while (n > 0) {
+        size_t vl = __riscv_vsetvl_e32m4(n);
+
+        vfloat32m4_t vX = __riscv_vle32_v_f32m4(srcPtr, vl);
+        vX = __riscv_vfmul_vf_f32m4(vX, inputScale, vl);
+        vX = __riscv_vfadd_vf_f32m4(vX, inputBias, vl);
+        vX = __riscv_vfmax_vf_f32m4(vX, -xLimit, vl);
+        vX = __riscv_vfmin_vf_f32m4(vX, xLimit, vl);
+
+        // div = int(x / ln(2))
+        vfloat32m4_t vDiv = __riscv_vfmul_vf_f32m4(vX, invParam, vl);
+        vint32m4_t vDivI = __riscv_vfcvt_x_f_v_i32m4(vDiv, vl);
+
+        // Start float conversion early — its latency overlaps with integer ops below
+        vfloat32m4_t vDivF = __riscv_vfcvt_f_x_v_f32m4(vDivI, vl);
+
+        // expBasic = 2^div via IEEE 754 (integer ops, fast, runs while vDivF completes)
+        vfloat32m4_t vExpBasic =
+            __riscv_vreinterpret_v_i32m4_f32m4(__riscv_vsll_vx_i32m4(__riscv_vadd_vx_i32m4(vDivI, 127, vl), 23, vl));
+
+        // xRemain = x - div * ln(2)
+        vfloat32m4_t vRemain = __riscv_vfnmsub_vf_f32m4(vDivF, param, vX, vl);
+        vfloat32m4_t vT = __riscv_vfmul_vf_f32m4(vRemain, 0.25f, vl);
+
+        // Taylor: ((((p7*t + p6)*t + p5)*t + p4)*t + 1)*t + 1
+        vfloat32m4_t vPoly = __riscv_vfmv_v_f_f32m4(p7, vl);
+        vPoly = __riscv_vfmul_vv_f32m4(vPoly, vT, vl);
+        vPoly = __riscv_vfadd_vf_f32m4(vPoly, p6, vl);
+        vPoly = __riscv_vfmul_vv_f32m4(vPoly, vT, vl);
+        vPoly = __riscv_vfadd_vf_f32m4(vPoly, p5, vl);
+        vPoly = __riscv_vfmul_vv_f32m4(vPoly, vT, vl);
+        vPoly = __riscv_vfadd_vf_f32m4(vPoly, p4, vl);
+        vPoly = __riscv_vfmul_vv_f32m4(vPoly, vT, vl);
+        vPoly = __riscv_vfadd_vf_f32m4(vPoly, 1.0f, vl);
+        vPoly = __riscv_vfmul_vv_f32m4(vPoly, vT, vl);
+        vPoly = __riscv_vfadd_vf_f32m4(vPoly, 1.0f, vl);
+
+        // (exp(x/4))^4: square twice
+        vPoly = __riscv_vfmul_vv_f32m4(vPoly, vPoly, vl);
+        vPoly = __riscv_vfmul_vv_f32m4(vPoly, vPoly, vl);
+
+        // result = expBasic * expRemain + outputBias
+        vfloat32m4_t vResult = __riscv_vfmul_vv_f32m4(vExpBasic, vPoly, vl);
+        vResult = __riscv_vfadd_vf_f32m4(vResult, outputBias, vl);
+        __riscv_vse32_v_f32m4(dstPtr, vResult, vl);
+
+        vSum = __riscv_vfredusum_vs_f32m4_f32m1(vResult, vSum, vl);
+
+        srcPtr += vl;
+        dstPtr += vl;
+        n -= vl;
+    }
+
+    offset[3] = __riscv_vfmv_f_s_f32m1_f32(vSum);
+}
+
+} // extern "C"

--- a/source/backend/cpu/riscv/rvv/MNNSiLu.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNSiLu.cpp
@@ -1,0 +1,57 @@
+#include <riscv_vector.h>
+
+extern "C" {
+
+extern void MNNExp(float* dst, const float* src, float* offset, size_t dataSize);
+
+void MNNSiLu(float* dst, const float* src, size_t dataSize) {
+    float offset[4] = {-1.0f, 0.0f, 0.0f, 0.0f};
+    MNNExp(dst, src, offset, dataSize);
+    size_t n = dataSize;
+    float* dstPtr = dst;
+    const float* srcPtr = src;
+    while (n > 0) {
+        size_t vl = __riscv_vsetvl_e32m4(n);
+        vfloat32m4_t vExp = __riscv_vle32_v_f32m4(dstPtr, vl);
+        vfloat32m4_t vSrc = __riscv_vle32_v_f32m4(srcPtr, vl);
+        vfloat32m4_t vDenom = __riscv_vfadd_vf_f32m4(vExp, 1.0f, vl);
+        vfloat32m4_t vRcp = __riscv_vfrec7_v_f32m4(vDenom, vl);
+        // Newton-Raphson x2: rcp *= (2 - denom * rcp)
+        vfloat32m4_t vErr = __riscv_vfmul_vv_f32m4(vDenom, vRcp, vl);
+        vErr = __riscv_vfrsub_vf_f32m4(vErr, 2.0f, vl);
+        vRcp = __riscv_vfmul_vv_f32m4(vRcp, vErr, vl);
+        vErr = __riscv_vfmul_vv_f32m4(vDenom, vRcp, vl);
+        vErr = __riscv_vfrsub_vf_f32m4(vErr, 2.0f, vl);
+        vRcp = __riscv_vfmul_vv_f32m4(vRcp, vErr, vl);
+        vfloat32m4_t vResult = __riscv_vfmul_vv_f32m4(vSrc, vRcp, vl);
+        __riscv_vse32_v_f32m4(dstPtr, vResult, vl);
+        dstPtr += vl;
+        srcPtr += vl;
+        n -= vl;
+    }
+}
+
+void MNNSiLuLowp(float* dst, const float* src, size_t dataSize) {
+    float offset[4] = {-1.0f, 0.0f, 0.0f, 0.0f};
+    MNNExp(dst, src, offset, dataSize);
+    size_t n = dataSize;
+    float* dstPtr = dst;
+    const float* srcPtr = src;
+    while (n > 0) {
+        size_t vl = __riscv_vsetvl_e32m4(n);
+        vfloat32m4_t vExp = __riscv_vle32_v_f32m4(dstPtr, vl);
+        vfloat32m4_t vSrc = __riscv_vle32_v_f32m4(srcPtr, vl);
+        vfloat32m4_t vDenom = __riscv_vfadd_vf_f32m4(vExp, 1.0f, vl);
+        vfloat32m4_t vRcp = __riscv_vfrec7_v_f32m4(vDenom, vl);
+        vfloat32m4_t vErr = __riscv_vfmul_vv_f32m4(vDenom, vRcp, vl);
+        vErr = __riscv_vfrsub_vf_f32m4(vErr, 2.0f, vl);
+        vRcp = __riscv_vfmul_vv_f32m4(vRcp, vErr, vl);
+        vfloat32m4_t vResult = __riscv_vfmul_vv_f32m4(vSrc, vRcp, vl);
+        __riscv_vse32_v_f32m4(dstPtr, vResult, vl);
+        dstPtr += vl;
+        srcPtr += vl;
+        n -= vl;
+    }
+}
+
+} // extern "C"

--- a/test/op/UnaryTest.cpp
+++ b/test/op/UnaryTest.cpp
@@ -748,14 +748,51 @@ class SiluTest : public UnaryTestCommon {
 public:
     virtual ~SiluTest() = default;
     virtual bool run(int precision) {
-        int size = 32;
-        std::vector<float> data_in(size), data_out(size);
-        for (int i = 0; i < size; ++i) {
-            data_in[i] = 0.25 * i - 4;
-            data_out[i] = data_in[i] / (1 + expf(-data_in[i]));
+        // Basic: 32 values from -4 to +3.75
+        {
+            int size = 32;
+            std::vector<float> data_in(size), data_out(size);
+            for (int i = 0; i < size; ++i) {
+                data_in[i] = 0.25f * i - 4;
+                data_out[i] = data_in[i] / (1 + expf(-data_in[i]));
+            }
+            if (!test<float, float>(_Silu, "SiluTest_basic", 0.01,
+                        data_in, data_out, {size}, {size})) return false;
         }
-        return test<float, float>(_Silu, "SiluTest", 0.01,
-                    data_in, data_out, {size}, {size});
+        // Edge values: 0, large positive, large negative
+        {
+            std::vector<float> data_in = {0.0f, 100.0f, -100.0f, 1.0f, -1.0f, 0.001f, -0.001f};
+            int size = (int)data_in.size();
+            std::vector<float> data_out(size);
+            for (int i = 0; i < size; ++i) {
+                data_out[i] = data_in[i] / (1 + expf(-data_in[i]));
+            }
+            if (!test<float, float>(_Silu, "SiluTest_edge", 0.01,
+                        data_in, data_out, {size}, {size})) return false;
+        }
+        // Odd size: 37 elements to test vector tail handling
+        {
+            int size = 37;
+            std::vector<float> data_in(size), data_out(size);
+            for (int i = 0; i < size; ++i) {
+                data_in[i] = 0.3f * i - 5.5f;
+                data_out[i] = data_in[i] / (1 + expf(-data_in[i]));
+            }
+            if (!test<float, float>(_Silu, "SiluTest_odd", 0.01,
+                        data_in, data_out, {size}, {size})) return false;
+        }
+        // Large batch: 1024 elements
+        {
+            int size = 1024;
+            std::vector<float> data_in(size), data_out(size);
+            for (int i = 0; i < size; ++i) {
+                data_in[i] = 0.02f * i - 10.0f;
+                data_out[i] = data_in[i] / (1 + expf(-data_in[i]));
+            }
+            if (!test<float, float>(_Silu, "SiluTest_large", 0.01,
+                        data_in, data_out, {size}, {size})) return false;
+        }
+        return true;
     }
 };
 class AcoshTest : public UnaryTestCommon {


### PR DESCRIPTION
Add RVV (RISC-V Vector Extension) optimized implementations for `MNNSiLu`, `MNNSiLuLowp`, and `MNNExpC8`.

  - `MNNSiLu`: `vfrec7` + 2x Newton-Raphson (~28-bit precision)
  - `MNNSiLuLowp`: `vfrec7` + 1x Newton-Raphson (~14-bit, LLM hot path)
  - `MNNExpC8`: Horner polynomial + split-and-square, constants pre-loaded to avoid aliasing reload

  ## Module

  CPU

  ## Type

  - [x] Feature

  ## Changes

  - Add `source/backend/cpu/riscv/rvv/MNNSiLu.cpp`
  - Add `source/backend/cpu/riscv/rvv/MNNExpC8.cpp`
  - Add `#ifndef MNN_USE_RVV` guards in `CommonOptFunction.cpp`
  - Enhance `SiluTest` with edge values, odd-size, and large-batch coverage

  ## Environment

  - Board: T-Head RV64GCV (mvendorid 0x5b7, xtheadmatrix + xtheadvdot)
  - Kernel: Linux 6.6.36-yocto-standard+ riscv64
  - Toolchain: Xuantie-900-gcc-linux V3.4.0 (rv64gcv)

  ## Verification

  <details>
  <summary>Real hardware test output</summary>

  $ ./run_test.out op/unary/silu
  The device supports: i8sdot:0, fp16:1, i8mm: 0, sve2: 0, sme2: 0
  running op/unary/silu.
  op/unary/silu cost time: 13.293 ms
  √√√ all <op/unary/silu> tests passed.
  TEST_CASE_AMOUNT_UNIT: {"blocked":0,"failed":0,"passed":1,"skipped":0}

  $ ./run_test.out op/unary/
  √√√ all <op/unary/> tests passed.
  TEST_CASE_AMOUNT_UNIT: {"blocked":0,"failed":0,"passed":60,"skipped":0}

  </details>