### PR TITLE
[LLM] Support Hy-MT2-1.8B export and inference

### DIFF
--- a/transformers/llm/export/utils/config.py
+++ b/transformers/llm/export/utils/config.py
@@ -25,6 +25,7 @@ class LlmConfig(PretrainedConfig):
         self.tie_word_embeddings = kwargs.pop("tie_word_embeddings", False)
         self.conv_L_cache = kwargs.pop("conv_L_cache", 0)
         self.rope_parameters = kwargs.pop("rope_parameters", None)
+        self.qk_norm_after_rope = kwargs.pop("qk_norm_after_rope", False)
         self.model_map = kwargs.pop("model_map", {})
         super().__init__(**kwargs)
 

--- a/transformers/llm/export/utils/model.py
+++ b/transformers/llm/export/utils/model.py
@@ -114,7 +114,9 @@ class LlmModel(PreTrainedModel):
         # print(f"Loading model type: {model_type}\n{original_model}")
 
         # LoRA
-        if args.lora_path is not None and not args.lora_split:
+        if (args is not None
+                and hasattr(args, 'lora_path') and args.lora_path is not None
+                and (not hasattr(args, 'lora_split') or not args.lora_split)):
             from peft import PeftModel
             adapter = PeftModel.from_pretrained(original_model, model_id=args.lora_path)
             original_model = adapter.merge_and_unload(progressbar=True)

--- a/transformers/llm/export/utils/transformers.py
+++ b/transformers/llm/export/utils/transformers.py
@@ -73,6 +73,11 @@ class Attention(torch.nn.Module):
             self.num_key_value_heads = config.num_key_value_heads
         self.num_key_value_groups = self.num_heads // self.num_key_value_heads
         ModelMapper.do_map(self, attn, mapper['attention'])
+        self.qk_norm_after_rope = getattr(config, 'qk_norm_after_rope', False)
+        if not self.qk_norm_after_rope:
+            self.qk_norm_after_rope = (
+                hasattr(attn, 'query_layernorm') and hasattr(attn, 'key_layernorm')
+            )
 
         # Read attention scaling from the original HF attention module
         if hasattr(attn, 'scaling'):
@@ -173,9 +178,10 @@ class Attention(torch.nn.Module):
         else:
             gate = None
 
+        qk_norm_after_rope = getattr(self, 'qk_norm_after_rope', getattr(self.config, 'qk_norm_after_rope', False))
         query_states = query_states.view(bsz, q_len, self.num_heads, self.head_dim)
-        # q_norm (openelm, gemma3/4, qwen3, etc.)
-        if hasattr(self, 'q_norm') and self.q_norm is not None:
+        # Most models apply q_norm before rotary, but HunYuan applies it after rotary.
+        if not qk_norm_after_rope and hasattr(self, 'q_norm') and self.q_norm is not None:
             query_states = self.q_norm(query_states)
 
         # KV sharing: for shared layers, reuse KV from source layer (test mode only)
@@ -194,7 +200,7 @@ class Attention(torch.nn.Module):
                 value_states = self.v_proj(hidden_states)
             key_states = key_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim)
             value_states = value_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim)
-            if hasattr(self, 'k_norm') and self.k_norm is not None:
+            if not qk_norm_after_rope and hasattr(self, 'k_norm') and self.k_norm is not None:
                 key_states = self.k_norm(key_states)
             # gemma4 has v_norm (RMSNorm without scale)
             if hasattr(self, 'v_norm') and self.v_norm is not None:
@@ -214,6 +220,12 @@ class Attention(torch.nn.Module):
             query_states = self.rotary.apply_rotary_pos(query_states, cos, sin)
             if not use_shared_kv and self.k_proj is not None:
                 key_states = self.rotary.apply_rotary_pos(key_states, cos, sin)
+
+        if qk_norm_after_rope:
+            if hasattr(self, 'q_norm') and self.q_norm is not None:
+                query_states = self.q_norm(query_states)
+            if not use_shared_kv and self.k_proj is not None and hasattr(self, 'k_norm') and self.k_norm is not None:
+                key_states = self.k_norm(key_states)
 
         # MobileLLM model llama4_text has qk_norm after rotary
         if hasattr(self, 'qk_norm') and self.qk_norm is not None :


### PR DESCRIPTION
## Summary
- support `hunyuan_v1_dense` / Hy-MT2-1.8B in the LLM export path
- localize the q/k norm-after-RoPE handling to the attention module instead of hard-coding a model-name special case in config loading
- harden the LoRA merge guard so programmatic export calls with partial args do not fail

## Issue
- Fixes alibaba/MNN#4488

## Verification
- Python load and generation:
  - `/data1/lyxu18/miniconda3/envs/lightx2v/bin/python transformers/llm/export/llmexport.py --path /data1/models/Hy-MT2-1.8 --test 你好`
- MNN export:
  - `/data1/lyxu18/miniconda3/envs/lightx2v/bin/python transformers/llm/export/llmexport.py --path /data1/models/Hy-MT2-1.8 --export mnn --hqq --dst_path /tmp/hymt2_acceptance --mnnconvert /data1/lyxu18/opensource_pj/MNN/build/MNNConvert`
- C++ inference:
  - `./build/llm_demo /tmp/hymt2_acceptance/config.json /tmp/hymt2_prompt.txt`
- Regression checks:
  - `python3 -m py_compile transformers/llm/export/utils/config.py transformers/llm/export/utils/model.py transformers/llm/export/utils/transformers.py`

## Notes
- this PR only includes the production code changes for Hymt2 support
- local skill edits and the temporary regression test file were intentionally left out of the branch
