### PR TITLE
[LLM:Bugfix] Fix CPULinearAttention prefix disk cache accuracy and hybrid model support

### DIFF
--- a/source/backend/cpu/CPULinearAttention.cpp
+++ b/source/backend/cpu/CPULinearAttention.cpp
@@ -41,6 +41,35 @@ static inline void _writeElement(int8_t* ptr, int index, float val, int bytes) {
     ((float*)ptr)[index] = val;
 }
 
+// Snapshot the post-prefix recurrent state (lazy-allocated) for eraseHistory
+// rollback. Allocation failure leaves mSnapshotValid=false; rollback then
+// falls back to zeroing.
+static void snapshotPrefixState(StateCache* cache, Backend* backend) {
+    if (cache == nullptr || cache->mConvState.get() == nullptr) {
+        return;
+    }
+    int convStateBytes = cache->mConvState->elementSize();
+    if (cache->mConvStateSnapshot.get() == nullptr) {
+        cache->mConvStateSnapshot.reset(Tensor::createDevice<int8_t>({convStateBytes}));
+        if (!backend->onAcquireBuffer(cache->mConvStateSnapshot.get(), Backend::STATIC)) {
+            cache->mConvStateSnapshot.reset();
+            return;
+        }
+    }
+    ::memcpy(cache->mConvStateSnapshot->host<int8_t>(), cache->mConvState->host<int8_t>(), convStateBytes);
+    if (cache->mRecurrentState.get() != nullptr) {
+        int rnnBytes = cache->mRecurrentState->elementSize();
+        if (cache->mRecurrentStateSnapshot.get() == nullptr) {
+            cache->mRecurrentStateSnapshot.reset(Tensor::createDevice<int8_t>({rnnBytes}));
+            if (!backend->onAcquireBuffer(cache->mRecurrentStateSnapshot.get(), Backend::STATIC)) {
+                cache->mRecurrentStateSnapshot.reset();
+                return;
+            }
+        }
+        ::memcpy(cache->mRecurrentStateSnapshot->host<int8_t>(), cache->mRecurrentState->host<int8_t>(), rnnBytes);
+    }
+    cache->mSnapshotValid = true;
+}
 
 ErrorCode CPULinearAttention::onResize(const std::vector<Tensor*>& inputs, const std::vector<Tensor*>& outputs) {
     auto qkv = inputs[0];
@@ -77,19 +106,47 @@ ErrorCode CPULinearAttention::onResize(const std::vector<Tensor*>& inputs, const
             ::memset(mStateCache->mRecurrentState->host<int8_t>(), 0, batch * H * dk * dv * mBytes);
         }
     } else if (seqLen > 1) {
-        // Prefill: reset state for new sequence, UNLESS:
-        // 1. Loading from prefix cache (PendingRead), or
-        // 2. Reusing KV from previous inference (reuse_kv=true, i.e. previous != remove)
+        // Prefill: decide keep/restore/reset from meta. LA state isn't
+        // token-indexed, so eraseHistory triggers a snapshot restore rather
+        // than a truncation.
         bool loadingFromDisk = (mMeta != nullptr && mMeta->file_flag == KVMeta::PendingRead && mMeta->file_name.size() > 0);
-        bool reusingKV = (mMeta != nullptr && mMeta->previous != mMeta->remove);
-        if (!loadingFromDisk && !reusingKV) {
-            int convStateBytes = batch * convChannels * convStateSize * mBytes;
+        bool isExplicitRollback = (mMeta != nullptr && mMeta->remove > 0);
+        bool isFreshPrefill = (mMeta == nullptr || mMeta->previous == 0);
+        int convStateBytes = batch * convChannels * convStateSize * mBytes;
+        int rnnBytes = 0;
+        if (mStateCache->mRecurrentState.get() != nullptr) {
+            int H = mNumVHeads, dk = mHeadKDim, dv = mHeadVDim;
+            rnnBytes = batch * H * dk * dv * mBytes;
+        }
+        if (loadingFromDisk) {
+            // onExecute will mmap-load the prefix state and snapshot it.
+        } else if (isExplicitRollback) {
+            // eraseHistory(): roll back to the saved post-prefix snapshot. If no
+            // snapshot exists (rollback before any prefix prefill ran), zero out.
+            if (mStateCache->mSnapshotValid && mStateCache->mConvStateSnapshot.get() != nullptr) {
+                ::memcpy(mStateCache->mConvState->host<int8_t>(), mStateCache->mConvStateSnapshot->host<int8_t>(),
+                         convStateBytes);
+                if (mStateCache->mRecurrentState.get() != nullptr &&
+                    mStateCache->mRecurrentStateSnapshot.get() != nullptr) {
+                    ::memcpy(mStateCache->mRecurrentState->host<int8_t>(),
+                             mStateCache->mRecurrentStateSnapshot->host<int8_t>(), rnnBytes);
+                }
+            } else {
+                ::memset(mStateCache->mConvState->host<int8_t>(), 0, convStateBytes);
+                if (mStateCache->mRecurrentState.get() != nullptr) {
+                    ::memset(mStateCache->mRecurrentState->host<int8_t>(), 0, rnnBytes);
+                }
+            }
+        } else if (isFreshPrefill) {
+            // Fresh sequence: zero the state and drop any stale snapshot.
             ::memset(mStateCache->mConvState->host<int8_t>(), 0, convStateBytes);
             if (mStateCache->mRecurrentState.get() != nullptr) {
-                int H = mNumVHeads, dk = mHeadKDim, dv = mHeadVDim;
-                ::memset(mStateCache->mRecurrentState->host<int8_t>(), 0, batch * H * dk * dv * mBytes);
+                ::memset(mStateCache->mRecurrentState->host<int8_t>(), 0, rnnBytes);
             }
+            mStateCache->mSnapshotValid = false;
         }
+        // Else (mMeta->previous > 0 && mMeta->remove == 0): reuse_kv continuation.
+        // Keep the live state so the new prefill extends from it.
     }
 
     // ─── Temporary buffers (DYNAMIC) ───
@@ -325,43 +382,69 @@ ErrorCode CPULinearAttention::onExecute(const std::vector<Tensor*>& inputs, cons
         }
     }
 
+    // Capture layer_index once per prefix-cache session (chunk 1, marked by
+    // previous == remove); chunks 2..N reuse it. Mirrors CPUKVCacheManager,
+    // which only advances layer_index in onAlloc (chunk 1) and not in onRealloc
+    // (chunks 2..N) — advancing on every chunk would drift LA past FA layers
+    // and clobber FA's prefix files (SIGBUS in hybrid models).
+    if (mMeta != nullptr && mMeta->file_name.size() > 0 &&
+        (mMeta->file_flag == KVMeta::PendingWrite || mMeta->file_flag == KVMeta::PendingRead) &&
+        mMeta->previous == mMeta->remove) {
+        mStateCache->mPrefixLayerIndex = mMeta->layer_index;
+        mMeta->layer_index = (mMeta->layer_index + 1) % mMeta->layer_nums;
+    }
+
     // Load prefix cache from disk (PendingRead)
     if (mMeta != nullptr && mMeta->file_name.size() > 0 && mMeta->file_flag == KVMeta::PendingRead) {
-        int layer_index = mMeta->layer_index;
-        std::string basePath = MNNFilePathConcat(mPrefixCacheDir, mMeta->file_name) + "_" + std::to_string(layer_index);
-        std::string pathk = basePath + ".k";
-        std::string pathv = basePath + ".v";
-        // Load conv state (.k file)
-        auto kfd = MNNOpenFile(pathk.c_str(), MNN_FILE_READ);
-        if (kfd != INVALID_FILE) {
-            size_t kSize = MNNGetFileSize(kfd);
-            if (kSize > 0 && kSize != INVALID_SIZE) {
-                void* kMap = MNNMmapFile(kfd, kSize, true);
-                if (kMap != nullptr) {
-                    ::memcpy(mStateCache->mConvState->host<int8_t>(), kMap, kSize);
-                    MNNUnmapFile(kMap, kSize);
-                }
-            }
-            MNNCloseFile(kfd);
+        // Sentinel guard: capture above only fires on previous == remove.
+        // On other paths (e.g. partial eraseHistory) the index stays -1; using
+        // it would write/read "_-1.k" and corrupt the cache dir, so skip with
+        // a diagnostic.
+        if (mStateCache->mPrefixLayerIndex < 0) {
+            MNN_ERROR(
+                "CPULinearAttention: PendingRead skipped, no prefix-layer-index captured "
+                "for this session (previous=%zu remove=%zu — capture predicate requires "
+                "previous == remove)\n",
+                mMeta->previous, mMeta->remove);
         } else {
-            MNN_PRINT("CPULinearAttention: Failed to open prefix cache file: %s\n", pathk.c_str());
-        }
-        // Load recurrent state (.v file)
-        auto vfd = MNNOpenFile(pathv.c_str(), MNN_FILE_READ);
-        if (vfd != INVALID_FILE) {
-            size_t vSize = MNNGetFileSize(vfd);
-            if (vSize > 0 && vSize != INVALID_SIZE && mStateCache->mRecurrentState.get() != nullptr) {
-                void* vMap = MNNMmapFile(vfd, vSize, true);
-                if (vMap != nullptr) {
-                    ::memcpy(mStateCache->mRecurrentState->host<int8_t>(), vMap, vSize);
-                    MNNUnmapFile(vMap, vSize);
+            int layer_index = mStateCache->mPrefixLayerIndex;
+            std::string basePath =
+                MNNFilePathConcat(mPrefixCacheDir, mMeta->file_name) + "_" + std::to_string(layer_index);
+            std::string pathk = basePath + ".k";
+            std::string pathv = basePath + ".v";
+            // Load conv state (.k file)
+            auto kfd = MNNOpenFile(pathk.c_str(), MNN_FILE_READ);
+            if (kfd != INVALID_FILE) {
+                size_t kSize = MNNGetFileSize(kfd);
+                if (kSize > 0 && kSize != INVALID_SIZE) {
+                    void* kMap = MNNMmapFile(kfd, kSize, true);
+                    if (kMap != nullptr) {
+                        ::memcpy(mStateCache->mConvState->host<int8_t>(), kMap, kSize);
+                        MNNUnmapFile(kMap, kSize);
+                    }
                 }
+                MNNCloseFile(kfd);
+            } else {
+                MNN_PRINT("CPULinearAttention: Failed to open prefix cache file: %s\n", pathk.c_str());
             }
-            MNNCloseFile(vfd);
-        } else {
-            MNN_PRINT("CPULinearAttention: Failed to open prefix cache file: %s\n", pathv.c_str());
+            // Load recurrent state (.v file)
+            auto vfd = MNNOpenFile(pathv.c_str(), MNN_FILE_READ);
+            if (vfd != INVALID_FILE) {
+                size_t vSize = MNNGetFileSize(vfd);
+                if (vSize > 0 && vSize != INVALID_SIZE && mStateCache->mRecurrentState.get() != nullptr) {
+                    void* vMap = MNNMmapFile(vfd, vSize, true);
+                    if (vMap != nullptr) {
+                        ::memcpy(mStateCache->mRecurrentState->host<int8_t>(), vMap, vSize);
+                        MNNUnmapFile(vMap, vSize);
+                    }
+                }
+                MNNCloseFile(vfd);
+            } else {
+                MNN_PRINT("CPULinearAttention: Failed to open prefix cache file: %s\n", pathv.c_str());
+            }
+            // Snapshot the loaded state for in-memory eraseHistory rollback.
+            snapshotPrefixState(mStateCache.get(), backend());
         }
-        mMeta->layer_index = (layer_index + 1) % mMeta->layer_nums;
     }
 
     // Normal execution
@@ -373,42 +456,54 @@ ErrorCode CPULinearAttention::onExecute(const std::vector<Tensor*>& inputs, cons
 
     // Save prefix cache to disk (PendingWrite)
     if (mMeta != nullptr && mMeta->file_name.size() > 0 && mMeta->file_flag == KVMeta::PendingWrite) {
-        MNNCreateDir(mPrefixCacheDir.c_str());
-        int layer_index = mMeta->layer_index;
-        std::string basePath = MNNFilePathConcat(mPrefixCacheDir, mMeta->file_name) + "_" + std::to_string(layer_index);
-        std::string pathk = basePath + ".k";
-        std::string pathv = basePath + ".v";
-        // Save conv state (.k file)
-        size_t convBytes = mStateCache->mConvState->elementSize();
-        auto kfd = MNNCreateFile(pathk.c_str());
-        if (kfd != INVALID_FILE) {
-            MNNSetFileSize(kfd, convBytes);
-            void* kMap = MNNMmapFile(kfd, convBytes);
-            if (kMap != nullptr) {
-                ::memcpy(kMap, mStateCache->mConvState->host<int8_t>(), convBytes);
-                MNNUnmapFile(kMap, convBytes);
-            }
-            MNNCloseFile(kfd);
+        // Sentinel guard: same rationale as PendingRead above.
+        if (mStateCache->mPrefixLayerIndex < 0) {
+            MNN_ERROR(
+                "CPULinearAttention: PendingWrite skipped, no prefix-layer-index captured "
+                "for this session (previous=%zu remove=%zu — capture predicate requires "
+                "previous == remove)\n",
+                mMeta->previous, mMeta->remove);
         } else {
-            MNN_PRINT("CPULinearAttention: Failed to create prefix cache file: %s\n", pathk.c_str());
-        }
-        // Save recurrent state (.v file) — may be empty for short_conv
-        size_t recurrentBytes = (mStateCache->mRecurrentState.get() != nullptr) ? mStateCache->mRecurrentState->elementSize() : 0;
-        auto vfd = MNNCreateFile(pathv.c_str());
-        if (vfd != INVALID_FILE) {
-            if (recurrentBytes > 0) {
-                MNNSetFileSize(vfd, recurrentBytes);
-                void* vMap = MNNMmapFile(vfd, recurrentBytes);
-                if (vMap != nullptr) {
-                    ::memcpy(vMap, mStateCache->mRecurrentState->host<int8_t>(), recurrentBytes);
-                    MNNUnmapFile(vMap, recurrentBytes);
+            MNNCreateDir(mPrefixCacheDir.c_str());
+            int layer_index = mStateCache->mPrefixLayerIndex;
+            std::string basePath =
+                MNNFilePathConcat(mPrefixCacheDir, mMeta->file_name) + "_" + std::to_string(layer_index);
+            std::string pathk = basePath + ".k";
+            std::string pathv = basePath + ".v";
+            // Save conv state (.k file)
+            size_t convBytes = mStateCache->mConvState->elementSize();
+            auto kfd = MNNCreateFile(pathk.c_str());
+            if (kfd != INVALID_FILE) {
+                MNNSetFileSize(kfd, convBytes);
+                void* kMap = MNNMmapFile(kfd, convBytes);
+                if (kMap != nullptr) {
+                    ::memcpy(kMap, mStateCache->mConvState->host<int8_t>(), convBytes);
+                    MNNUnmapFile(kMap, convBytes);
                 }
+                MNNCloseFile(kfd);
+            } else {
+                MNN_PRINT("CPULinearAttention: Failed to create prefix cache file: %s\n", pathk.c_str());
             }
-            MNNCloseFile(vfd);
-        } else {
-            MNN_PRINT("CPULinearAttention: Failed to create prefix cache file: %s\n", pathv.c_str());
+            // Save recurrent state (.v file) — may be empty for short_conv
+            size_t recurrentBytes =
+                (mStateCache->mRecurrentState.get() != nullptr) ? mStateCache->mRecurrentState->elementSize() : 0;
+            auto vfd = MNNCreateFile(pathv.c_str());
+            if (vfd != INVALID_FILE) {
+                if (recurrentBytes > 0) {
+                    MNNSetFileSize(vfd, recurrentBytes);
+                    void* vMap = MNNMmapFile(vfd, recurrentBytes);
+                    if (vMap != nullptr) {
+                        ::memcpy(vMap, mStateCache->mRecurrentState->host<int8_t>(), recurrentBytes);
+                        MNNUnmapFile(vMap, recurrentBytes);
+                    }
+                }
+                MNNCloseFile(vfd);
+            } else {
+                MNN_PRINT("CPULinearAttention: Failed to create prefix cache file: %s\n", pathv.c_str());
+            }
+            // Snapshot the written state for in-memory eraseHistory rollback.
+            snapshotPrefixState(mStateCache.get(), backend());
         }
-        mMeta->layer_index = (layer_index + 1) % mMeta->layer_nums;
     }
 
     return NO_ERROR;

--- a/source/backend/cpu/CPULinearAttention.hpp
+++ b/source/backend/cpu/CPULinearAttention.hpp
@@ -19,9 +19,21 @@
 
 namespace MNN {
 
+// shared_ptr-shared across prefill/decode clones (see onClone). All tensors
+// are Backend::STATIC and freed with the backend — no per-Execution release.
 struct StateCache {
     std::shared_ptr<Tensor> mConvState;      // Conv1D padding state: [B, D, kernel_size - 1]
     std::shared_ptr<Tensor> mRecurrentState; // Gated Delta Rule recurrent state S: [B, H, d_k, d_v]
+    // Post-prefix snapshot. LA state is not token-indexed, so eraseHistory
+    // can't truncate per-token; the next prefill restores from here instead.
+    std::shared_ptr<Tensor> mConvStateSnapshot;
+    std::shared_ptr<Tensor> mRecurrentStateSnapshot;
+    bool mSnapshotValid = false;
+    // Prefix-cache file index captured once per session (previous == remove);
+    // chunks 2..N reuse it instead of re-advancing mMeta->layer_index, which
+    // would drift past Full Attention layers and cause SIGBUS in hybrid models.
+    // Sentinel -1 = not captured.
+    int mPrefixLayerIndex = -1;
 };
 
 class CPULinearAttention : public Execution {

--- a/test/op/LinearAttentionTest.cpp
+++ b/test/op/LinearAttentionTest.cpp
@@ -14,10 +14,12 @@
 #include "MNNTestSuite.h"
 #include "TestUtils.h"
 #include <cmath>
+#include <cstdio>
 #include <cstring>
 #include <vector>
 #include <numeric>
 #include <algorithm>
+#include <sys/stat.h>
 
 using namespace MNN::Express;
 
@@ -847,5 +849,468 @@ public:
 };
 
 MNNTestSuiteRegister(LinearAttentionDecodeTest, "op/linear_attention_decode");
+
+// ─── Local mirror of MNN::Transformer::KVMeta (must match layout) ───
+// Used to drive the rollback signal mMeta->remove without depending on the
+// internal Llm header. See test/op/AttentionTest.cpp for the same pattern.
+struct LATestKVMeta {
+    enum { NoChange, PendingWrite, PendingRead } file_operation;
+    size_t block = 4096;
+    size_t previous = 0;
+    size_t remove = 0;
+    int* reserve = nullptr;
+    int n_reserve = 0;
+    size_t add = 0;
+    std::string file_name = "";
+    int file_flag = NoChange;
+    int seqlen_in_disk = 0;
+    int layer_index = 0;
+    int layer_nums = 0;
+    std::vector<int> reserveHost;
+};
+
+// Variant of _makeLinearAttentionModule that wires a caller-owned KVMeta
+// pointer via the runtime KVCACHE_INFO hint. The CPULinearAttention op reads
+// this through backend->getMetaPtr() in its constructor.
+static std::shared_ptr<Module> _makeLinearAttentionModuleWithMeta(int numKHeads, int numVHeads, int headKDim,
+                                                                  int headVDim, bool useL2Norm, LATestKVMeta* meta) {
+    auto qkv = _Input();
+    auto gate = _Input();
+    auto beta = _Input();
+    auto convW = _Input();
+
+    std::shared_ptr<MNN::OpT> op(new MNN::OpT);
+    op->type = MNN::OpType_LinearAttention;
+    op->main.type = MNN::OpParameter_LinearAttentionParam;
+    op->main.value = new MNN::LinearAttentionParamT;
+    auto* param = op->main.AsLinearAttentionParam();
+    param->attn_type = "gated_delta_rule";
+    param->num_k_heads = numKHeads;
+    param->num_v_heads = numVHeads;
+    param->head_k_dim = headKDim;
+    param->head_v_dim = headVDim;
+    param->use_qk_l2norm = useL2Norm;
+
+    auto o = Variable::create(Expr::create(op.get(), {qkv, gate, beta, convW}));
+    auto buffer = Variable::save({o});
+
+    MNN::ScheduleConfig config;
+    auto status = MNNTestSuite::get()->pStaus;
+    config.type = (MNNForwardType)status.forwardType;
+    MNN::BackendConfig bnConfig;
+    bnConfig.memory = (MNN::BackendConfig::MemoryMode)status.memory;
+    bnConfig.precision = (MNN::BackendConfig::PrecisionMode)status.precision;
+    bnConfig.power = (MNN::BackendConfig::PowerMode)status.power;
+    config.backendConfig = &bnConfig;
+    config.numThread = 1;
+
+    std::shared_ptr<Executor::RuntimeManager> rtmgr(Executor::RuntimeManager::createRuntimeManager(config));
+    rtmgr->setHintPtr(MNN::Interpreter::KVCACHE_INFO, meta);
+    std::shared_ptr<Module> m(Module::load({}, {}, (uint8_t*)buffer.data(), buffer.size(), rtmgr));
+    return m;
+}
+
+// ─── Rollback test: verify the explicit-rollback path in CPULinearAttention::onResize ───
+//
+// Background: LinearAttention's recurrent state has no token-level structure,
+// so Llm::eraseHistory() cannot truncate it. The fix introduces:
+//   (a) a snapshot of the post-prefix state taken inside the prefix-cache
+//       disk file_flag branches (PendingRead/PendingWrite), and
+//   (b) an explicit-rollback branch in onResize that, when mMeta->remove > 0,
+//       restores from the snapshot if mSnapshotValid is true, otherwise zeros
+//       the state.
+//
+// This test covers branch (b) without snapshot (mSnapshotValid=false), the
+// most common rollback path when prefix cache is not in use:
+//
+//   Module A: prefill(X)  -> internal state advances  (no snapshot taken,
+//                            since file_flag stays NoChange throughout)
+//             [simulate Llm: meta.previous = X.len, meta.remove = X.len]
+//             prefill(Y)  -> isExplicitRollback fires, mSnapshotValid=false,
+//                            so state is zeroed before Y is applied.
+//
+//   Module B: prefill(Y) on a brand-new module starting from zero state.
+//
+// Module A's second-prefill output and Module B's only-prefill output must
+// match byte-for-byte (within float tolerance), proving:
+//   - the rollback branch is hit when remove>0 in prefill,
+//   - it correctly clears state to zero when no snapshot is available, and
+//   - subsequent computation is equivalent to a fresh-init module.
+//
+// The "snapshot exists" path (mSnapshotValid=true) requires real prefix-cache
+// disk files (.k/.v + setExternalPath(EXTERNAL_PATH_PREFIXCACHE_DIR, ...)) and
+// is exercised by rollback_demo Stage 3 against actual model bundles.
+class LinearAttentionRollbackTest : public MNNTestCase {
+public:
+    LinearAttentionRollbackTest() = default;
+    virtual ~LinearAttentionRollbackTest() = default;
+
+    virtual bool run(int precision) {
+        const int B = 1, numKHeads = 2, numVHeads = 2;
+        const int headKDim = 4, headVDim = 4, K_conv = 4;
+        const int key_dim = numKHeads * headKDim;
+        const int val_dim = numVHeads * headVDim;
+        const int D = 2 * key_dim + val_dim;
+        const int prefillLen = 4;
+        const float tolerance = 0.001f;
+        const int outSize = B * prefillLen * numVHeads * headVDim;
+
+        // Shared conv weight across both modules so the only variable is state.
+        auto convWVar = _Input({D, 1, K_conv}, NCHW, halide_type_of<float>());
+        fillConvWeight(convWVar->writeMap<float>(), D * 1 * K_conv);
+
+        // ─── Module A: prefill(X) -> simulate eraseHistory -> prefill(Y) ───
+        LATestKVMeta metaA;
+        auto moduleA = _makeLinearAttentionModuleWithMeta(numKHeads, numVHeads, headKDim, headVDim, true, &metaA);
+        if (!moduleA) {
+            MNN_PRINT("RollbackTest: failed to create moduleA\n");
+            return false;
+        }
+
+        // Step 1: prefill X. metaA.previous=0 here makes onResize treat this as
+        // a fresh prefill (zeros state, drops any snapshot — none yet anyway).
+        {
+            auto qkvVar = _Input({B, D, prefillLen}, NCHW, halide_type_of<float>());
+            auto gateVar = _Input({B, prefillLen, numVHeads}, NCHW, halide_type_of<float>());
+            auto betaVar = _Input({B, prefillLen, numVHeads}, NCHW, halide_type_of<float>());
+            fillDeterministic(qkvVar->writeMap<float>(), B * D * prefillLen, 0.07f, 0.0f);
+            fillGate(gateVar->writeMap<float>(), B * prefillLen * numVHeads);
+            fillBeta(betaVar->writeMap<float>(), B * prefillLen * numVHeads);
+            auto outputs = moduleA->onForward({qkvVar, gateVar, betaVar, convWVar});
+            if (outputs.empty()) {
+                MNN_PRINT("RollbackTest: moduleA prefill X returned empty output\n");
+                return false;
+            }
+            // Force evaluation so internal state is fully updated before next call.
+            (void)outputs[0]->readMap<float>();
+        }
+
+        // Step 2: simulate the meta updates Llm performs around eraseHistory.
+        //   - updateContext after prefill X: meta.previous += prefillLen
+        //   - eraseHistory(0, previous): meta.remove = previous
+        metaA.previous = prefillLen;
+        metaA.remove = prefillLen;
+
+        // Step 3: prefill Y. onResize sees remove>0 -> isExplicitRollback;
+        // mSnapshotValid=false (no PendingRead/PendingWrite ever fired), so
+        // the rollback branch zeros mConvState/mRecurrentState before forward.
+        std::vector<float> outputA(outSize, 0.0f);
+        {
+            auto qkvVar = _Input({B, D, prefillLen}, NCHW, halide_type_of<float>());
+            auto gateVar = _Input({B, prefillLen, numVHeads}, NCHW, halide_type_of<float>());
+            auto betaVar = _Input({B, prefillLen, numVHeads}, NCHW, halide_type_of<float>());
+            // Use distinct input from X so we don't accidentally pass the test
+            // when the rollback is silently skipped (state would carry X's effect).
+            fillDeterministic(qkvVar->writeMap<float>(), B * D * prefillLen, 0.05f, 0.1f);
+            fillGate(gateVar->writeMap<float>(), B * prefillLen * numVHeads);
+            fillBeta(betaVar->writeMap<float>(), B * prefillLen * numVHeads);
+            auto outputs = moduleA->onForward({qkvVar, gateVar, betaVar, convWVar});
+            if (outputs.empty()) {
+                MNN_PRINT("RollbackTest: moduleA prefill Y after rollback returned empty output\n");
+                return false;
+            }
+            const float* p = outputs[0]->readMap<float>();
+            ::memcpy(outputA.data(), p, outSize * sizeof(float));
+        }
+
+        // ─── Module B: fresh prefill(Y) baseline ───
+        LATestKVMeta metaB;
+        auto moduleB = _makeLinearAttentionModuleWithMeta(numKHeads, numVHeads, headKDim, headVDim, true, &metaB);
+        if (!moduleB) {
+            MNN_PRINT("RollbackTest: failed to create moduleB\n");
+            return false;
+        }
+        std::vector<float> outputB(outSize, 0.0f);
+        {
+            auto qkvVar = _Input({B, D, prefillLen}, NCHW, halide_type_of<float>());
+            auto gateVar = _Input({B, prefillLen, numVHeads}, NCHW, halide_type_of<float>());
+            auto betaVar = _Input({B, prefillLen, numVHeads}, NCHW, halide_type_of<float>());
+            // Identical Y inputs as moduleA's step 3.
+            fillDeterministic(qkvVar->writeMap<float>(), B * D * prefillLen, 0.05f, 0.1f);
+            fillGate(gateVar->writeMap<float>(), B * prefillLen * numVHeads);
+            fillBeta(betaVar->writeMap<float>(), B * prefillLen * numVHeads);
+            auto outputs = moduleB->onForward({qkvVar, gateVar, betaVar, convWVar});
+            if (outputs.empty()) {
+                MNN_PRINT("RollbackTest: moduleB fresh prefill Y returned empty output\n");
+                return false;
+            }
+            const float* p = outputs[0]->readMap<float>();
+            ::memcpy(outputB.data(), p, outSize * sizeof(float));
+        }
+
+        // ─── Compare: A's post-rollback prefill must equal B's fresh prefill ───
+        for (int i = 0; i < outSize; ++i) {
+            float diff = fabs(outputA[i] - outputB[i]);
+            if (diff > tolerance) {
+                MNN_PRINT(
+                    "Rollback (mSnapshotValid=false) FAILED at index %d: "
+                    "rollback=%.6f fresh=%.6f diff=%.6f\n",
+                    i, outputA[i], outputB[i], diff);
+                return false;
+            }
+        }
+        MNN_PRINT("LinearAttention Rollback (no snapshot, state zeroed) PASSED\n");
+        return true;
+    }
+};
+
+MNNTestSuiteRegister(LinearAttentionRollbackTest, "op/linear_attention_rollback");
+
+// ─── Chunked prefix-cache layer_index drift test ───
+//
+// Background: prefix-cache file naming uses mMeta->layer_index as a counter
+// that each layer's onExecute advances by 1, wrapping mod layer_nums. The
+// counter is shared between LinearAttention and CPUKVCacheManager (Full
+// Attention). CPUKVCacheManager advances it ONLY inside onAlloc, which fires
+// on chunk 1 (when mMeta->previous == mMeta->remove); chunks 2..N go through
+// onRealloc, which does NOT touch layer_index.
+//
+// Before the fix, CPULinearAttention advanced layer_index inside its
+// PendingWrite/PendingRead branches on EVERY chunk's onExecute. In hybrid
+// models (attention_type="mix"), this caused LinearAttention's counter to
+// drift past Full Attention's layer positions on chunks 2..N — LA would
+// compute the wrong file index and overwrite Full Attention's prefix cache
+// .k/.v files, corrupting their live mmap regions and triggering SIGBUS on
+// subsequent FA access.
+//
+// The fix captures layer_index ONCE per session (when previous == remove)
+// into mStateCache->mPrefixLayerIndex; subsequent chunks reuse the cached
+// value and do NOT touch mMeta->layer_index. This mirrors CPUKVCacheManager's
+// once-per-session advancement semantics so the two co-exist correctly.
+//
+// This test exercises the layer_index lifecycle directly on a single
+// LinearAttention op (no FA dependency needed to expose the regression):
+//   chunk 1 (previous == remove == 0): expect layer_index to advance by 1.
+//   chunk 2 (previous > 0, remove == 0): expect layer_index UNCHANGED.
+// A failure here means chunks 2..N would clobber some other layer's file.
+class LinearAttentionChunkedLayerIndexTest : public MNNTestCase {
+public:
+    LinearAttentionChunkedLayerIndexTest() = default;
+    virtual ~LinearAttentionChunkedLayerIndexTest() = default;
+
+    virtual bool run(int precision) {
+        const int B = 1, numKHeads = 2, numVHeads = 2;
+        const int headKDim = 4, headVDim = 4, K_conv = 4;
+        const int key_dim = numKHeads * headKDim;
+        const int val_dim = numVHeads * headVDim;
+        const int D = 2 * key_dim + val_dim;
+        const int prefillLen = 4;
+        // Starting layer_index value chosen to be non-zero so we can
+        // distinguish "no advance" from "reset to zero".
+        const int kInitialLayerIndex = 5;
+        const int kLayerNums = 24;
+
+        // Shared conv weight across both chunks.
+        auto convWVar = _Input({D, 1, K_conv}, NCHW, halide_type_of<float>());
+        fillConvWeight(convWVar->writeMap<float>(), D * 1 * K_conv);
+
+        // Simulate the meta state at the start of a chunked prefix-cache
+        // write session:
+        //   - file_name + file_flag=PendingWrite trigger the prefix-cache
+        //     write branch in CPULinearAttention::onExecute.
+        //   - layer_index = 5 simulates this op being not-first in a multi-
+        //     layer forward pass (previous layers' onExecute have already
+        //     advanced the counter).
+        //   - previous = 0, remove = 0 marks "first chunk" — the per-session
+        //     capture-and-advance block should fire on this call only.
+        LATestKVMeta meta;
+        meta.file_name = "test_chunked_layer_index";
+        meta.file_flag = LATestKVMeta::PendingWrite;
+        meta.layer_index = kInitialLayerIndex;
+        meta.layer_nums = kLayerNums;
+        meta.previous = 0;
+        meta.remove = 0;
+
+        auto module = _makeLinearAttentionModuleWithMeta(numKHeads, numVHeads, headKDim, headVDim, true, &meta);
+        if (!module) {
+            MNN_PRINT("ChunkedLayerIndexTest: failed to create module\n");
+            return false;
+        }
+
+        auto runChunk = [&](float seed_offset) -> bool {
+            auto qkvVar = _Input({B, D, prefillLen}, NCHW, halide_type_of<float>());
+            auto gateVar = _Input({B, prefillLen, numVHeads}, NCHW, halide_type_of<float>());
+            auto betaVar = _Input({B, prefillLen, numVHeads}, NCHW, halide_type_of<float>());
+            fillDeterministic(qkvVar->writeMap<float>(), B * D * prefillLen, 0.07f, seed_offset);
+            fillGate(gateVar->writeMap<float>(), B * prefillLen * numVHeads);
+            fillBeta(betaVar->writeMap<float>(), B * prefillLen * numVHeads);
+            auto outputs = module->onForward({qkvVar, gateVar, betaVar, convWVar});
+            if (outputs.empty()) {
+                return false;
+            }
+            // Force evaluation so onExecute (and its meta-state mutations) runs.
+            (void)outputs[0]->readMap<float>();
+            return true;
+        };
+
+        // ─── Chunk 1: should capture layer_index=5 and advance to 6 ───
+        if (!runChunk(0.0f)) {
+            MNN_PRINT("ChunkedLayerIndexTest: chunk 1 forward failed\n");
+            return false;
+        }
+        if (meta.layer_index != kInitialLayerIndex + 1) {
+            MNN_PRINT(
+                "ChunkedLayerIndexTest FAIL: after chunk 1, layer_index = %d, "
+                "expected %d (capture-and-advance must bump once on the first "
+                "PendingWrite call of a session)\n",
+                meta.layer_index, kInitialLayerIndex + 1);
+            return false;
+        }
+
+        // ─── Between chunks: simulate the meta updates Llm performs ───
+        //   sync() at end of forwardRaw: previous += add (= prefillLen), remove resets
+        // layer_index is intentionally NOT touched here — in real hybrid
+        // models, FA layers' onRealloc on chunks 2..N also does NOT touch it.
+        meta.previous = prefillLen;
+        meta.remove = 0;
+        int layer_index_before_chunk2 = meta.layer_index;
+
+        // ─── Chunk 2: must NOT re-advance layer_index ───
+        if (!runChunk(0.1f)) {
+            MNN_PRINT("ChunkedLayerIndexTest: chunk 2 forward failed\n");
+            return false;
+        }
+        if (meta.layer_index != layer_index_before_chunk2) {
+            MNN_PRINT(
+                "ChunkedLayerIndexTest FAIL: after chunk 2, layer_index = %d, "
+                "expected %d (chunks 2..N must reuse mStateCache->mPrefixLayerIndex "
+                "without re-advancing mMeta->layer_index — the drift was the "
+                "root cause of LA overwriting FA's prefix cache files in hybrid "
+                "models, manifesting as SIGBUS on subsequent FA mmap access)\n",
+                meta.layer_index, layer_index_before_chunk2);
+            return false;
+        }
+
+        // Cleanup: PendingWrite branch writes the per-layer prefix cache files
+        // as a side effect. Default prefix cache dir relative to CWD is
+        // "prefixcache/". Remove them so we don't leave artifacts behind.
+        ::remove("prefixcache/test_chunked_layer_index_5.k");
+        ::remove("prefixcache/test_chunked_layer_index_5.v");
+        // (leave the empty prefixcache/ dir behind; harmless and cross-platform-friendly)
+
+        MNN_PRINT("LinearAttention Chunked LayerIndex (per-session capture) PASSED\n");
+        return true;
+    }
+};
+MNNTestSuiteRegister(LinearAttentionChunkedLayerIndexTest, "op/linear_attention_chunked_layer_index");
+
+// ─── Edge case: PendingWrite when previous != remove (capture must be skipped) ───
+//
+// The capture-and-advance block in CPULinearAttention::onExecute only fires
+// when (file_name set, file_flag in {PendingWrite, PendingRead}, previous ==
+// remove). The `previous == remove` predicate identifies "first call of a
+// fresh-or-fully-rolled-back session" (chunk 1 of a new write, or chunk 1
+// after eraseHistory(0, previous)).
+//
+// If something triggers PendingWrite/PendingRead outside that entry path
+// (e.g. partial eraseHistory(begin>0, end) followed by a forced cache write
+// while `mMeta->remove < mMeta->previous`), the capture block is skipped and
+// mStateCache->mPrefixLayerIndex stays at its initial sentinel -1.
+//
+// The PendingWrite branch then constructs a file path using -1 as the layer
+// index, writing junk to "<dir>/<name>_-1.k". This corrupts the prefix cache
+// directory layout — silent on success but reads as a phantom layer to any
+// future PendingRead pass.
+//
+// This test pins down the desired behavior on that mismatched-meta path:
+//   (a) mMeta->layer_index must NOT advance (consistent with all advancement
+//       being moved into the capture block), and
+//   (b) no junk "_-1.{k,v}" file should be created.
+//
+// Failure on (b) means production code needs either a fallback (use
+// mMeta->layer_index when mPrefixLayerIndex == -1) or an early-out guard
+// inside the PendingWrite/PendingRead branches. The test cleans up any junk
+// it may have produced so subsequent runs are not affected by today's bug.
+class LinearAttentionPendingWriteUnsyncedTest : public MNNTestCase {
+public:
+    LinearAttentionPendingWriteUnsyncedTest() = default;
+    virtual ~LinearAttentionPendingWriteUnsyncedTest() = default;
+
+    virtual bool run(int precision) {
+        const int B = 1, numKHeads = 2, numVHeads = 2;
+        const int headKDim = 4, headVDim = 4, K_conv = 4;
+        const int key_dim = numKHeads * headKDim;
+        const int val_dim = numVHeads * headVDim;
+        const int D = 2 * key_dim + val_dim;
+        const int prefillLen = 4;
+        const int kInitialLayerIndex = 5;
+        const int kLayerNums = 24;
+        const std::string cacheName = "test_pending_write_unsynced";
+        const std::string junkK = "prefixcache/" + cacheName + "_-1.k";
+        const std::string junkV = "prefixcache/" + cacheName + "_-1.v";
+
+        // Defensive: remove any pre-existing junk from a previous failing run
+        // so we measure THIS run's behavior.
+        ::remove(junkK.c_str());
+        ::remove(junkV.c_str());
+
+        auto convWVar = _Input({D, 1, K_conv}, NCHW, halide_type_of<float>());
+        fillConvWeight(convWVar->writeMap<float>(), D * 1 * K_conv);
+
+        // Construct meta where PendingWrite fires but the capture-and-advance
+        // condition fails (previous != remove). 4/2 mimics a partial
+        // eraseHistory(begin=2, end=4) followed by a forced cache write.
+        LATestKVMeta meta;
+        meta.file_name = cacheName;
+        meta.file_flag = LATestKVMeta::PendingWrite;
+        meta.layer_index = kInitialLayerIndex;
+        meta.layer_nums = kLayerNums;
+        meta.previous = 4;
+        meta.remove = 2;
+
+        auto module = _makeLinearAttentionModuleWithMeta(numKHeads, numVHeads, headKDim, headVDim, true, &meta);
+        if (!module) {
+            MNN_PRINT("PendingWriteUnsyncedTest: failed to create module\n");
+            return false;
+        }
+
+        auto qkvVar = _Input({B, D, prefillLen}, NCHW, halide_type_of<float>());
+        auto gateVar = _Input({B, prefillLen, numVHeads}, NCHW, halide_type_of<float>());
+        auto betaVar = _Input({B, prefillLen, numVHeads}, NCHW, halide_type_of<float>());
+        fillDeterministic(qkvVar->writeMap<float>(), B * D * prefillLen, 0.07f, 0.0f);
+        fillGate(gateVar->writeMap<float>(), B * prefillLen * numVHeads);
+        fillBeta(betaVar->writeMap<float>(), B * prefillLen * numVHeads);
+
+        auto outputs = module->onForward({qkvVar, gateVar, betaVar, convWVar});
+        if (outputs.empty()) {
+            MNN_PRINT("PendingWriteUnsyncedTest: forward failed\n");
+            return false;
+        }
+        (void)outputs[0]->readMap<float>();
+
+        // (a) layer_index must NOT have advanced
+        bool layerIndexOk = (meta.layer_index == kInitialLayerIndex);
+        if (!layerIndexOk) {
+            MNN_PRINT(
+                "PendingWriteUnsyncedTest FAIL (a): layer_index = %d, expected %d "
+                "(capture-and-advance must not fire when previous != remove)\n",
+                meta.layer_index, kInitialLayerIndex);
+        }
+
+        // (b) no junk "_-1.{k,v}" file should be written
+        struct stat st;
+        bool junkKExists = (::stat(junkK.c_str(), &st) == 0);
+        bool junkVExists = (::stat(junkV.c_str(), &st) == 0);
+        bool junkOk = !junkKExists && !junkVExists;
+        if (!junkOk) {
+            MNN_PRINT(
+                "PendingWriteUnsyncedTest FAIL (b): junk files written at sentinel "
+                "index -1: %s=%d %s=%d. Production code should either skip the disk "
+                "write or fall back to mMeta->layer_index when mPrefixLayerIndex is -1.\n",
+                junkK.c_str(), (int)junkKExists, junkV.c_str(), (int)junkVExists);
+        }
+
+        // Cleanup regardless of pass/fail so subsequent runs start clean.
+        ::remove(junkK.c_str());
+        ::remove(junkV.c_str());
+
+        bool ok = layerIndexOk && junkOk;
+        if (ok) {
+            MNN_PRINT("LinearAttention PendingWrite-Unsynced (no capture, no junk write) PASSED\n");
+        }
+        return ok;
+    }
+};
+MNNTestSuiteRegister(LinearAttentionPendingWriteUnsyncedTest, "op/linear_attention_pending_write_unsynced");
 
 #endif // MNN_SUPPORT_TRANSFORMER_FUSE

--- a/transformers/llm/engine/demo/rollback_demo.cpp
+++ b/transformers/llm/engine/demo/rollback_demo.cpp
@@ -166,6 +166,42 @@ static int benchmark(Llm* llm, const std::vector<std::string>& prompts, int max_
         MNN_PRINT("prefill speed = %.2f tok/s\n", prompt_len / prefill_s);
         MNN_PRINT(" decode speed = %.2f tok/s\n", decode_len / decode_s);
         MNN_PRINT("##################################\n");
+
+        // step 6 (Stage 3): full clear after prefix load + new prompt.
+        // Exercises the only path where the alignment block (PR #4424 reset)
+        // in CPULinearAttention::onExecute changes behavior vs. the prior
+        // snapshot restore: previous == remove > 0 AND not loading from disk.
+        // We then reset + re-run the same prompt to get a clean-session
+        // baseline, and compare textually.
+        if (prompts.size() >= 4) {
+            MNN_PRINT("\n[Stage 3] Full clear after prefix load, then new prompt\n");
+            const auto& new_prompt = prompts[3];
+
+            // Path A: from current prefix-loaded session, full clear then re-prefill+decode.
+            // max_new_tokens=-1 lets response() decode to EOS (the demo's other decode
+            // calls do the same via default arg). Passing 0 here would prefill-only.
+            llm->eraseHistory(0, llm->getCurrentHistory());
+            std::ostringstream after_clear_out;
+            llm->response(new_prompt, &after_clear_out, nullptr, -1);
+            std::string after_clear_text = after_clear_out.str();
+            MNN_PRINT("[Stage 3] Response after full clear:\n%s\n", after_clear_text.c_str());
+
+            // Path B: reset to a fully clean state and run the same prompt.
+            llm->reset();
+            llm->eraseHistory(0, 0);
+            std::ostringstream baseline_out;
+            llm->response(new_prompt, &baseline_out, nullptr, -1);
+            std::string baseline_text = baseline_out.str();
+            MNN_PRINT("[Stage 3] Baseline (clean session) response:\n%s\n", baseline_text.c_str());
+
+            if (after_clear_text == baseline_text) {
+                MNN_PRINT("[TEST PASS] Stage 3: full clear after prefix load matches clean session.\n");
+            } else {
+                MNN_PRINT("[TEST FAIL] Stage 3: output mismatch after full clear vs clean session.\n");
+            }
+        } else {
+            MNN_PRINT("[Stage 3] Skipped: needs at least 4 prompts (got %zu)\n", prompts.size());
+        }
     } else {
         
         MNN_PRINT("Prefill\n");

--- a/transformers/llm/engine/src/llm.cpp
+++ b/transformers/llm/engine/src/llm.cpp
@@ -958,6 +958,20 @@ std::vector<int> Llm::generate(MNN::Express::VARP input_embeds, int max_tokens) 
     mContext->prefill_us += _t.durationInUs();
     MNN::Express::ExecutorScope::Current()->gc(); // after prefill
 
+    // Clear file_flag after prefill, before the decode loop. Otherwise each
+    // L=1 decode step re-enters op-level PendingWrite and overwrites the
+    // on-disk prefix with post-decode state.
+    //
+    // The max_tokens > 0 gate distinguishes the two call paths:
+    //   non-chunked (max_tokens > 0, prefill+decode in one call): clear here
+    //   chunked (max_tokens == 0 per chunk): don't clear — chunks 2..N must
+    //   keep writing; completePrefixWrite() in the caller clears after the loop.
+    if (mPrefixCacheMode && mCallIndex == 1 && mMeta->file_flag == KVMeta::PendingWrite && max_tokens > 0) {
+        mMeta->file_name = "";
+        mMeta->file_flag = KVMeta::NoChange;
+        mMeta->layer_index = 0;
+    }
+
     // prefix cache mode and response second time
     if(mPrefixCacheMode && mCallIndex == 2) {
         if(mIsPrefixFileExist) {
@@ -1214,6 +1228,16 @@ std::vector<Express::VARP> Llm::getOutputs() const {
 }
 
 bool Llm::setPrefixCacheFile(const std::string& filename, int flag) {
+    // Prefix cache requires kvcache_mmap. Without it mKVCacheDir is unset and
+    // the disk-backed alloc in CPUKVCacheManager::onAlloc crashes with a
+    // nullptr mmap. Reject up-front instead of crashing deep in the backend.
+    if (!mConfig->kvcache_mmap()) {
+        MNN_ERROR(
+            "setPrefixCacheFile requires kvcache_mmap=true in config. "
+            "Prefix cache is a disk-backed feature; please enable kvcache_mmap.\n");
+        return false;
+    }
+
     mPrefixCacheFileName = filename;
     mCallIndex = 0;
     mPrefixCacheMode = true;
@@ -1239,6 +1263,11 @@ bool Llm::setPrefixCacheFile(const std::string& filename, int flag) {
     // actual data files were deleted / truncated / partially written, which would otherwise
     // lead to a crash in CPUKVCacheManager::onAlloc (e.g. memset on a null mmap address).
     if (mIsPrefixFileExist) {
+        // Only "mix" (LA + regular attention) has intrinsically non-uniform
+        // per-layer KV sizes. Everything else (full / sliding / unset → "full")
+        // stays under the cross-layer uniformity check that catches partial or
+        // corrupted writes.
+        const bool isHybrid = (mConfig->attention_type() == "mix");
         size_t refKeySize = 0;
         size_t refValueSize = 0;
         for (int i = 0; i < mConfig->layer_nums(); i++) {
@@ -1264,17 +1293,19 @@ bool Llm::setPrefixCacheFile(const std::string& filename, int flag) {
                 mIsPrefixFileExist = false;
                 break;
             }
-            if (i == 0) {
-                refKeySize = kSize;
-                refValueSize = vSize;
-            } else if (kSize != refKeySize || vSize != refValueSize) {
-                // All layers share the same model shape, so their .k (and .v) files must
-                // have identical sizes. Any mismatch means the cache directory has been
-                // corrupted / partially overwritten and must be rebuilt.
-                MNN_PRINT("Prefix cache size mismatch at layer %d: k=%zu(ref=%zu) v=%zu(ref=%zu)\n", i, kSize,
-                          refKeySize, vSize, refValueSize);
-                mIsPrefixFileExist = false;
-                break;
+            if (!isHybrid) {
+                if (i == 0) {
+                    refKeySize = kSize;
+                    refValueSize = vSize;
+                } else if (kSize != refKeySize || vSize != refValueSize) {
+                    // Non-hybrid: all layers share the same model shape, so their .k (and .v)
+                    // files must have identical sizes. Any mismatch means the cache directory
+                    // has been corrupted / partially overwritten and must be rebuilt.
+                    MNN_PRINT("Prefix cache size mismatch at layer %d: k=%zu(ref=%zu) v=%zu(ref=%zu)\n", i, kSize,
+                              refKeySize, vSize, refValueSize);
+                    mIsPrefixFileExist = false;
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
## Description

修复 LinearAttention 在 prefix 磁盘缓存（`setPrefixCacheFile`）+ `eraseHistory` 回滚组合下的精度退化与崩溃。

共修复 3 个问题：

1. **LinearAttention prefix 缓存污染 + 缺少回滚快照**
   - 首次写盘后 `mMeta->file_flag` 未清零，decode 循环每步都重新 mmap-write，把磁盘 prefix 覆盖成 decode 后的脏状态。
   - LinearAttention 的 recurrent state 无 token 级结构，`eraseHistory()` 无法按 token 回滚。
   - 修复：[[llm.cpp](app://localhost/epitaxy/transformers/llm/engine/src/llm.cpp)](transformers/llm/engine/src/llm.cpp) 在 prefill 完成后立即把 `file_flag` 重置为 `NoChange`；[[CPULinearAttention](app://localhost/epitaxy/source/backend/cpu/CPULinearAttention.cpp)](source/backend/cpu/CPULinearAttention.cpp) 在 mmap load/write 后做 state 快照，`onResize` prefill 分支改为三态决策（disk-load / explicit rollback / fresh prefill），rollback 时从快照恢复。

2. **`setPrefixCacheFile` 误判混合模型 cache 损坏**
   - 旧校验要求所有层 `.k`/`.v` 大小一致，对 hybrid 模型必然失败。
   - 修复：[[llm.cpp](app://localhost/epitaxy/transformers/llm/engine/src/llm.cpp)](transformers/llm/engine/src/llm.cpp) 仅对 `attention_type == "full"` 保留跨层一致性校验，混合模型回退到逐层存在性 + 非零校验。

[[rollback_demo.cpp](app://localhost/epitaxy/transformers/llm/engine/demo/rollback_demo.cpp)](transformers/llm/engine/demo/rollback_demo.cpp) 新增 Stage 3：disk prefix 加载后做完整 `eraseHistory` 再重新 prefill，与 `reset()` 干净会话输出做精确比对。

## Module

LLM

## Type

- [ ] Feature
- [x] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors（`MNN_BUILD_LLM=ON -DMNN_LOW_MEMORY=ON`）
- [x] Tested on relevant platform(s)
  - Qwen3-Next 混合模型（18 LinearAttention + 6 Attention）：3 次连续启动答案稳定，cache 命中正常
  - Qwen3 0.6B（`attention_type="full"`）：行为不变，二次启动 prefill 提速约 9x
  - rollback_demo Stage 3：与 clean session 输出逐字符匹配
- [x] No unrelated format or style changes included