### PR TITLE
[LLM:Bugfix] Fix Qwen3-VL DeepStack dtype mismatch

### DIFF
--- a/transformers/llm/export/utils/vision.py
+++ b/transformers/llm/export/utils/vision.py
@@ -1073,7 +1073,9 @@ class Qwen3Vision(Qwen2Vision):
             input_embeds[image_mask] = torch.concat(self.image_embeds, dim=0).to(input_embeds.dtype)
             # deepsatck_embeds
             self.deepstack_embeds = torch.zeros_like(input_embeds).transpose(0, 1).repeat(3, 1, 1)
-            self.deepstack_embeds[:, image_mask, :] = torch.concat(self.deepstack_feature_list, dim=1)
+            self.deepstack_embeds[:, image_mask, :] = torch.concat(self.deepstack_feature_list, dim=1).to(
+                self.deepstack_embeds.dtype
+            )
         return input_embeds
 
     def deepstacks(self):


### PR DESCRIPTION
### Summary

Fix Qwen3-VL Python test/response path when DeepStack features have a different dtype from LLM input embeddings.

`deepstack_embeds` is created from `input_embeds`, so its dtype follows the LLM embedding dtype. Visual DeepStack features can remain fp32, and PyTorch indexed assignment requires source and destination dtypes to match. This patch casts DeepStack features to the destination tensor dtype before assignment, matching the existing image embedding cast behavior in the same function.

Related to #4493.

### Validation

- Qwen3-VL Python response path with an image prompt no longer fails on DeepStack dtype mismatch.
- `python -m py_compile transformers/llm/export/utils/vision.py`
- `git diff --check`
