### PR TITLE
[Core:Bugfix] Per-RTM KVCACHE_INFO meta to fix Qwen3-VL repeating output

### DIFF
--- a/express/Executor.cpp
+++ b/express/Executor.cpp
@@ -247,10 +247,14 @@ void Executor::RuntimeManager::setExternalPath(std::string path, int type) {
     mInside->mContent->modes.setExternalPath(path, type);
 }
 void Executor::RuntimeManager::setHintPtr(Interpreter::HintMode mode, void* value) {
-    auto current = ExecutorScope::Current();
-    auto rt = current->getRuntime();
-    for (auto& iter : rt.first) {
-        iter.second->pMeta = value;
+    if (mode == Interpreter::KVCACHE_INFO) {
+        mInside->mMeta = value;
+    }
+}
+
+void Executor::RuntimeManager::applyMetaToRuntime() const {
+    for (auto& iter : mInside->mRuntime.first) {
+        iter.second->pMeta = mInside->mMeta;
     }
 }
 

--- a/express/RuntimeAttr.hpp
+++ b/express/RuntimeAttr.hpp
@@ -23,6 +23,8 @@ struct RuntimeAttr {
     RuntimeInfo mRuntime;
     std::shared_ptr<Runtime> mInfo;
     std::shared_ptr<Cache> mCache;
+    // Per-RTM KVCache meta; pushed to the (pooled) Runtime by applyMetaToRuntime().
+    void* mMeta = nullptr;
     // Use for static module to compute flops
     float mFlops;
     mutable int mResizeStatus = 0;

--- a/express/module/Module.cpp
+++ b/express/module/Module.cpp
@@ -284,6 +284,8 @@ public:
             config.numThread = origin->mContent->mNumberThread;
             std::shared_ptr<Executor::RuntimeManager> newRt (Executor::RuntimeManager::createRuntimeManager(config));
             const_cast<RuntimeAttr*>(newRt->getInside())->mContent = origin->mContent;
+            // Inherit pMeta so cloned modules don't push a stale nullptr at forward time.
+            const_cast<RuntimeAttr*>(newRt->getInside())->mMeta = origin->mMeta;
             ctx->pRuntimeManager = newRt;
         }
         std::shared_ptr<Module::Info> newInfo(new Module::Info);

--- a/express/module/PipelineModule.cpp
+++ b/express/module/PipelineModule.cpp
@@ -716,6 +716,8 @@ Module* PipelineModule::load(const std::vector<std::string>& inputs, const std::
 Module* PipelineModule::load(const std::vector<std::string>& inputs, const std::vector<std::string>& outputs, std::shared_ptr<BufferStorage> bufferStorage, std::shared_ptr<MNN::Express::Executor::RuntimeManager> rtMgr, const Module::Config* config, std::map<std::string, SubGraph>& subGraphMap) {
     MNN_ASSERT(nullptr != rtMgr);
     MNN_ASSERT(nullptr != config);
+    // Apply before constReplaceBackend / submodule Backends are created.
+    rtMgr->applyMetaToRuntime();
     std::shared_ptr<Schedule::ScheduleInfo> sharedConst;
     auto buffer = bufferStorage->buffer();
     auto length = bufferStorage->size();

--- a/express/module/StaticModule.cpp
+++ b/express/module/StaticModule.cpp
@@ -349,6 +349,8 @@ StaticModule::StaticModule(std::vector<int> inputs,
     mResource.reset(new Resource);
     mRuntimeManager = rtm;
     MNN_ASSERT(nullptr != rtm);
+    // Apply before createPipelineBackend creates Backends.
+    rtm->applyMetaToRuntime();
     auto rt = rtm->getInside()->mRuntime;
     mResource->mSharedConst = sharedConst;
     mResource->mModes = std::move(mode);
@@ -594,6 +596,10 @@ ErrorCode StaticModule::_execute() {
 std::vector<Express::VARP> StaticModule::onForward(const std::vector<Express::VARP>& inputs) {
 
     AUTOTIME;
+    // Apply before resize/clone may construct new Backends (e.g. onClone path).
+    if (mRuntimeManager) {
+        mRuntimeManager->applyMetaToRuntime();
+    }
     std::vector<Express::VARP> outputs;
     bool runResize = (!mShapeInferSeperate) || inputs.size() > 0;
     bool runCompute = (!mShapeInferSeperate) || inputs.size() == 0;
@@ -674,6 +680,8 @@ Module* StaticModule::clone(CloneContext* ctx) const {
     if (mResource->mOutputFromTensor.empty()) {
         return this->cloneBaseTo(ctx, module);
     }
+    // mSession->clone may construct new Backends.
+    ctx->pRuntimeManager->applyMetaToRuntime();
     auto rt = ctx->pRuntimeManager->getInside()->mRuntime;
     module->mSession.reset(mSession->clone(std::move(rt), mResource->mSharedConst));
     module->resetInputOutputs();

--- a/include/MNN/expr/Executor.hpp
+++ b/include/MNN/expr/Executor.hpp
@@ -129,6 +129,9 @@ public:
         void setHint(Interpreter::HintMode mode, int value);
         void setHint(Interpreter::HintMode mode, int* value, size_t size);
         void setHintPtr(Interpreter::HintMode mode, void* value);
+        // Push this RTM's KVCACHE_INFO meta onto its Runtime; call before any
+        // path that creates or clones Backends (Backends capture pMeta at ctor).
+        void applyMetaToRuntime() const;
         bool getInfo(Interpreter::SessionInfoCode code, void* ptr);
         static bool getDeviceInfo(const std::string& deviceKey, const MNNForwardType type, std::string& deviceValue);
         BackendConfig* getBnConfig();

--- a/transformers/llm/engine/src/omni.cpp
+++ b/transformers/llm/engine/src/omni.cpp
@@ -130,10 +130,8 @@ bool Omni::load() {
         module_config.shapeMutable = true;
         module_config.rearrange    = true;
     }
-    // Reset KVCACHE_INFO to nullptr so vision encoder's self-attention is
-    // not affected by the LLM's kvcache metadata. Otherwise past-kv from LLM
-    // accumulates during each vision forward, causing inference time to grow.
-    mProcessorRuntimeManager->setHintPtr(Interpreter::KVCACHE_INFO, nullptr);
+    // pMeta isolation between LLM and processor RTMs is now provided by
+    // per-RTM RuntimeAttr::mPMeta + applyMetaToRuntime; no manual reset needed.
     if (mConfig->is_visual()) {
         mVisionModule.reset(Module::load({}, {}, mConfig->visual_model().c_str(), mProcessorRuntimeManager, &module_config));
         if (nullptr == mVisionModule.get()) {
@@ -860,9 +858,7 @@ std::vector<int> Omni::audioProcess(MNN::Express::VARP waveform) {
         ::memcpy(fresh->writeMap<float>(), ptr, info->size * sizeof(float));
         input_features = fresh;
     }
-    // Reset KVCACHE_INFO to nullptr so audio encoder's self-attention is
-    // not affected by the LLM's kvcache metadata.
-    mProcessorRuntimeManager->setHintPtr(Interpreter::KVCACHE_INFO, nullptr);
+    // pMeta isolation handled by per-RTM RuntimeAttr::mPMeta; no reset needed.
     VARP audio_embedding;
     if (mAudioModule->getInfo()->inputNames.size() > 1) {
         int seqlen = UP_DIV(input_features->getInfo()->dim[2], 2);


### PR DESCRIPTION
#4441 reset Runtime::pMeta to nullptr from the processor RTM to isolate the vision/audio encoder from LLM kvcache state, but RuntimeManager::setHintPtr wrote to the ExecutorScope's pooled Runtime, which is shared across all RTMs of the same backend type — so the LLM RTM's pMeta got nullified too. Subsequent CPUAttention onClone captured nullptr, KV cache stopped growing during decode, and the LLM emitted "好的好的好的..." until max_tokens.

Move pMeta ownership to RuntimeAttr (per-RTM) and push it onto the Runtime at Backend create/forward boundaries via applyMetaToRuntime(). Drop the nullptr resets in omni.cpp; isolation is now architectural.

## Description

<!-- Brief description of the changes -->

## Module

<!-- Which module does this PR affect? e.g. LLM, CPU, Metal, CUDA, OpenCL, Core, Infra -->

## Type

- [ ] Feature
- [x] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [ ] Commit message follows `[Module:Type] Description` format
- [ ] Code compiles without errors
- [ ] Tested on relevant platform(s)
- [ ] No unrelated format or style changes included
