### PR TITLE
[LLM:Bugfix] Fix Qwen3-VL Python DeepStack dtype mismatch

### DIFF
--- a/transformers/llm/export/utils/vision.py
+++ b/transformers/llm/export/utils/vision.py
@@ -1073,7 +1073,9 @@ class Qwen3Vision(Qwen2Vision):
             input_embeds[image_mask] = torch.concat(self.image_embeds, dim=0).to(input_embeds.dtype)
             # deepsatck_embeds
             self.deepstack_embeds = torch.zeros_like(input_embeds).transpose(0, 1).repeat(3, 1, 1)
-            self.deepstack_embeds[:, image_mask, :] = torch.concat(self.deepstack_feature_list, dim=1)
+            self.deepstack_embeds[:, image_mask, :] = torch.concat(self.deepstack_feature_list, dim=1).to(
+                self.deepstack_embeds.dtype
+            )
         return input_embeds
 
     def deepstacks(self):


### PR DESCRIPTION
### Summary

Fix an independent Qwen3-VL Python `--test` / `response()` path failure caused by mismatched DeepStack assignment dtypes.

This is not intended to fix the C++ runtime repeating-output issue. It only fixes a Python-path hard error hit before generation.

### Repro

```bash
python llmexport.py \
  --path /path/to/Qwen3-VL-2B-Instruct \
  --test '<img>/path/to/cat.jpg</img>用一句中文描述这张图片。'
```

Before this patch, `Qwen3Vision.embed()` can fail at DeepStack assignment:

```text
RuntimeError: Index put requires the source and destination dtypes match,
got BFloat16 for the destination and Float for the source.
```

Screenshot:

<!-- Please attach the error screenshot here. -->
<img width="977" height="416" alt="image" src="https://github.com/user-attachments/assets/858f20e0-77c2-4515-8767-28ba29f1e13d" />

### Cause

`deepstack_embeds` is created with `torch.zeros_like(input_embeds)`, so its dtype follows the LLM input embedding dtype, e.g. bf16. Visual DeepStack features can remain fp32. PyTorch indexed assignment requires source and destination dtypes to match.

This patch casts the DeepStack features to the destination tensor dtype before assignment, consistent with the image embedding cast in the same function.

### Validation

- Qwen3-VL Python response path with an image prompt no longer fails on DeepStack dtype mismatch.
- `python -m py_compile transformers/llm/export/utils/vision.py`
- `git diff --check`
