### PR TITLE
[LLM:Bugfix] Move gapLen computation after null mask early return in …

### DIFF
--- a/source/backend/cpu/CPUAttention.cpp
+++ b/source/backend/cpu/CPUAttention.cpp
@@ -93,7 +93,6 @@ static void _maskQK(float * qkPacked, const float* scale, size_t seqLen, size_t 
     constexpr float NEG_INF = -std::numeric_limits<float>::infinity();
     auto source = (T*)qkPacked;
     float scaleVal = scale[0];
-    int gapLen = (mask->elementSize() == (seqLen + padKvSeqLen) * (kvSeqLen + padKvSeqLen)) ? 0 : static_cast<int>(kvSeqLen - seqLen);
 
     auto kvBlockCount = UP_DIV(processedKvSeq, pack);
     auto qkSize = ROUND_UP(processedKvSeq, pack) * seqLen;
@@ -109,9 +108,8 @@ static void _maskQK(float * qkPacked, const float* scale, size_t seqLen, size_t 
         return;
     }
 
+    int gapLen = (mask->elementSize() == (seqLen + padKvSeqLen) * (kvSeqLen + padKvSeqLen)) ? 0 : static_cast<int>(kvSeqLen - seqLen);
     auto maskPtr = mask->host<T>();
-
-    // not lower triangular
     auto maskCols = (mask->elementSize() == (seqLen + padKvSeqLen) * (kvSeqLen + padKvSeqLen)) ? kvSeqLen + padKvSeqLen : seqLen + padKvSeqLen;
     for (int i = 0; i < kvBlockCount; ++i) {
         T* blockDataPtr = source + (i * seqLen * pack);


### PR DESCRIPTION
…_maskQK

Discussed-in: Merge-Request 27957084 , URL: https://code.alibaba-inc.com/AliNN/AliNNPrivate/codereview/27957084
GitOrigin-RevId: fb8f3d7365b8a972182a7f258094ef2f97877ab0

fix #4525

## Description

<!-- Brief description of the changes -->

## Module

<!-- Which module does this PR affect? e.g. LLM, CPU, Metal, CUDA, OpenCL, Core, Infra -->

## Type

- [ ] Feature
- [x] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [x] Tested on relevant platform(s)
- [x] No unrelated format or style changes included
