### PR TITLE
[Diffusion:Bugfix] Fix SD1.5 resize cache warmup

### DIFF
--- a/transformers/diffusion/engine/include/diffusion/stable_diffusion.hpp
+++ b/transformers/diffusion/engine/include/diffusion/stable_diffusion.hpp
@@ -40,6 +40,7 @@ public:
 
 private:
     VARP step_plms(VARP sample, VARP model_output, int index);
+    std::vector<VARP> forwardWithResizeCache(int index, const std::vector<VARP>& inputs);
     VARP text_encoder(const std::vector<int>& ids);
     VARP unet(VARP text_embeddings, int iterNum, int randomSeed, std::function<void(int)> progressCallback);
     VARP vae_decoder(VARP latent);
@@ -51,6 +52,7 @@ private:
     VARP mSample;
     VARP mLatentVar, mPromptVar, mTimestepVar, mSampleVar;
     std::vector<float> mInitNoise;
+    std::vector<bool> mResizeCachePrepared;
     int mMaxTextLen = 77;
     std::unique_ptr<Tokenizer> mTokenizer;
 };

--- a/transformers/diffusion/engine/src/stable_diffusion.cpp
+++ b/transformers/diffusion/engine/src/stable_diffusion.cpp
@@ -95,6 +95,7 @@ bool StableDiffusion::load() {
     
     VARP text_embeddings;
     mModules.resize(3);
+    mResizeCachePrepared.assign(3, false);
     // load text_encoder model
     {
         std::string model_path = mModelPath + "/text_encoder.mnn";
@@ -131,20 +132,17 @@ bool StableDiffusion::load() {
         return false;
     }
 
-    // Resize fix
-    for (auto& m : mModules) {
-        m->traceOrOptimize(MNN::Interpreter::Session_Resize_Fix);
-    }
     // text encoder
     {
-        auto outputs = mModules[0]->onForward({mPromptVar});
+        auto outputs = forwardWithResizeCache(0, {mPromptVar});
         text_embeddings = _Convert(outputs[0], NCHW);
+        text_embeddings.fix(VARP::CONSTANT);
     }
-    
+
     if(mMemoryMode > 0) {
         // unet
         {
-            auto outputs = mModules[1]->onForward({mSampleVar, mTimestepVar, text_embeddings});
+            auto outputs = forwardWithResizeCache(1, {mSampleVar, mTimestepVar, text_embeddings});
             auto output = _Convert(outputs[0], NCHW);
             output->readMap<float>();
         }
@@ -152,7 +150,7 @@ bool StableDiffusion::load() {
     if(mMemoryMode == 1) {
         // vae decoder
         {
-            auto outputs = mModules[2]->onForward({mLatentVar});
+            auto outputs = forwardWithResizeCache(2, {mLatentVar});
             auto output = _Convert(outputs[0], NCHW);
             output->readMap<float>();
         }
@@ -161,12 +159,36 @@ bool StableDiffusion::load() {
     return true;
 }
 
+std::vector<VARP> StableDiffusion::forwardWithResizeCache(int index, const std::vector<VARP>& inputs) {
+    if (index < 0 || index >= mModules.size() || !mModules[index]) {
+        MNN_ERROR("Invalid diffusion module index: %d\n", index);
+        return {};
+    }
+    if (mResizeCachePrepared.size() != mModules.size()) {
+        mResizeCachePrepared.assign(mModules.size(), false);
+    }
+    if (!mResizeCachePrepared[index]) {
+        auto code = mModules[index]->traceOrOptimize(MNN::Interpreter::Session_Resize_Check);
+        if (code != 0) {
+            MNN_PRINT("Resize check is not supported for diffusion module %d, code = %d\n", index, code);
+        } else {
+            mModules[index]->onForward(inputs);
+            code = mModules[index]->traceOrOptimize(MNN::Interpreter::Session_Resize_Fix);
+            if (code != 0) {
+                MNN_PRINT("Resize fix is not supported for diffusion module %d, code = %d\n", index, code);
+            }
+        }
+        mResizeCachePrepared[index] = true;
+    }
+    return mModules[index]->onForward(inputs);
+}
+
 VARP StableDiffusion::text_encoder(const std::vector<int>& ids) {
     AUTOTIME;
-    
+
     memcpy((void *)mPromptVar->writeMap<int8_t>(), ids.data(), 2*mMaxTextLen*sizeof(int));
-    
-    auto outputs = mModules[0]->onForward({mPromptVar});
+
+    auto outputs = forwardWithResizeCache(0, {mPromptVar});
     auto output = _Convert(outputs[0], NCHW);
     output.fix(VARP::CONSTANT);
     return output;
@@ -234,40 +256,40 @@ VARP StableDiffusion::unet(VARP text_embeddings, int iterNum, int randomSeed, st
         mInitNoise[i] = normal(rng);
     }
 #endif
-    
+
     memcpy((void *)mLatentVar->writeMap<int8_t>(), mInitNoise.data(), 16384*sizeof(float));
     
     VARP scalevar = _Input({1}, NCHW, halide_type_of<float>());
     auto scaleptr = scalevar->writeMap<float>();
     scaleptr[0] = 7.5;
-    
+
     
     auto floatVar = _Input({1}, NCHW, halide_type_of<float>());
     auto ptr = floatVar->writeMap<float>();
     auto plms = mLatentVar;
-    
+
     for (int i = 0; i < mTimeSteps.size(); i++) {
         AUTOTIME;
-        
+
         int timestep = mTimeSteps[i];
         ptr[0] = timestep;
         auto temp = _Cast(floatVar, halide_type_of<int>());
         mTimestepVar->input(temp);
 
         mSampleVar = _Concat({plms, plms}, 0);
-        auto outputs = mModules[1]->onForward({mSampleVar, mTimestepVar, text_embeddings});
+        auto outputs = forwardWithResizeCache(1, {mSampleVar, mTimestepVar, text_embeddings});
         auto output = _Convert(outputs[0], NCHW);
-        
+
         auto noise_pred = output;
-        
+
         auto splitvar = _Split(noise_pred, {2}, 0);
         auto noise_pred_uncond = splitvar[0];
         auto noise_pred_text = splitvar[1];
-        
+
         noise_pred = scalevar * (noise_pred_text - noise_pred_uncond) + noise_pred_uncond;
-        
+
         plms = step_plms(plms, noise_pred, i);
-        
+
         if (progressCallback) {
             progressCallback((2 + i) * 100 / (iterNum + 3)); // percent
         }
@@ -283,9 +305,9 @@ VARP StableDiffusion::vae_decoder(VARP latent) {
     latent = latent * _Const(1 / 0.18215);
     
     AUTOTIME;
-    auto outputs = mModules[2]->onForward({latent});
+    auto outputs = forwardWithResizeCache(2, {latent});
     auto output = _Convert(outputs[0], NCHW);
-    
+
     auto image = output;
     image = _Relu6(image * _Const(0.5) + _Const(0.5), 0, 1);
     image = _Squeeze(_Transpose(image, {0, 2, 3, 1}));
@@ -316,12 +338,12 @@ bool StableDiffusion::run(const std::string prompt, const std::string imagePath,
     auto ids = mTokenizer->encode(prompt, mMaxTextLen);
 
     auto text_embeddings = text_encoder(ids);
-    
+
     if (progressCallback) {
         progressCallback(1 * 100 / (iterNum + 3)); // percent
     }
     auto latent = unet(text_embeddings, iterNum, randomSeed, progressCallback);
-    
+
     auto image = vae_decoder(latent);
     bool res = imwrite(imagePath, image);
     if (res) {

--- a/transformers/diffusion/engine/src/stable_diffusion.cpp
+++ b/transformers/diffusion/engine/src/stable_diffusion.cpp
@@ -263,7 +263,6 @@ VARP StableDiffusion::unet(VARP text_embeddings, int iterNum, int randomSeed, st
     auto scaleptr = scalevar->writeMap<float>();
     scaleptr[0] = 7.5;
 
-    
     auto floatVar = _Input({1}, NCHW, halide_type_of<float>());
     auto ptr = floatVar->writeMap<float>();
     auto plms = mLatentVar;


### PR DESCRIPTION
## Summary

Fix SD1.5 `diffusion_demo` crash on CPU backend while preserving resize-cache optimization when it is supported.

Before this change, `StableDiffusion::load()` called `Session_Resize_Fix` directly for the text encoder, UNet, and VAE decoder before any resize-check warmup. On CPU, this produced `Fix: 0 - Total: ...`, and the subsequent load-time text encoder forward crashed in the AVX Strassen 1x1 convolution path.

This patch routes SD1.5 module forwards through a helper that attempts the resize-cache lifecycle once per module:

```text
Session_Resize_Check
-> warmup onForward
-> Session_Resize_Fix
-> normal onForward
```

If resize-check or resize-fix is unsupported, the helper logs the return code, marks the module as attempted, and falls back to ordinary `onForward()`.

Preparation happens once per module:

- text encoder is prepared during `load()`
- UNet is prepared during `load()` when preloaded by the selected memory mode, otherwise on first denoise use
- VAE decoder is prepared during `load()` only in full preload mode, otherwise on first decode use

Later forwards reuse the prepared/fallback state instead of repeating the resize-cache attempt on every denoise step.

## Reproduction Before Fix

Build the CPU diffusion demo, then run SD1.5 with CPU backend:

```bash
stdbuf -oL -eL ./build_sd15_run/diffusion_demo \
  /data1/models/stable-diffusion-v1-5-MNN \
  0 0 0 10 42 \
  /data1/models/stable-diffusion-v1-5-MNN/sd15_demo.jpg \
  "a cute cat playing with yarn"
```

Observed output before the fix:

```text
Model resource path: /data1/models/stable-diffusion-v1-5-MNN
Model type is stable diffusion 1.5
Backend type: 0
Fix: 0 - Total: 373, rate = 0.000000
Fix: 0 - Total: 1503, rate = 0.000000
Fix: 0 - Total: 291, rate = 0.000000
```

The process then exits with SIGSEGV during `StableDiffusion::load()`, before image generation.

Captured stack:

```text
_AVX_MNNPackC4ForMatMul_A
MNN::StrassenMatrixComputor::_generateTrivalMatMul(...)
MNN::StrassenMatrixComputor::onExecute(...)
MNN::Convolution1x1Strassen::onExecute(...)
MNN::Pipeline::execute()
MNN::Session::run()
MNN::Express::StaticModule::onForward(...)
MNN::DIFFUSION::StableDiffusion::load()
main()
```

## Root Cause

`Session_Resize_Fix` is intended to run after a resize-check warmup. The expected flow is:

```text
Session_Resize_Check
-> representative forward
-> Session_Resize_Fix
```

The old SD1.5 code skipped `Session_Resize_Check` and the representative forward, then directly called `Session_Resize_Fix` for all modules during `load()`.

Because no check/warmup had collected resize-cache information, the fix step produced:

```text
Fix: 0 - Total: ...
```

Even in this state, `fixResizeCache()` still enters backend resize and dynamic allocation paths. The captured crash then lands in the CPU AVX Strassen 1x1 convolution packing path. This is consistent with the invalid resize-cache lifecycle leaving resize/dynamic-allocation state in an unsafe configuration, though this patch does not isolate the exact corrupted pointer source.

The OpenCL smoke test did not reproduce the crash because execution stayed on the OpenCL backend path rather than the CPU AVX Strassen path.

## Fix

Add a private `StableDiffusion::forwardWithResizeCache()` helper.

For each module, on first use only, it attempts:

```cpp
module->traceOrOptimize(MNN::Interpreter::Session_Resize_Check);
module->onForward(inputs); // warmup
module->traceOrOptimize(MNN::Interpreter::Session_Resize_Fix);
return module->onForward(inputs);
```

The prepared state is tracked with `mResizeCachePrepared`, so later forwards do not repeat the resize-cache attempt.

If `Session_Resize_Check` or `Session_Resize_Fix` returns an unsupported/error code, the helper logs it and continues with normal `onForward()`.

The previous upfront direct `Session_Resize_Fix` loop in `StableDiffusion::load()` is removed. The load-time text embeddings are also fixed as a constant before reuse by UNet warmup.

## Validation

CPU backend, 1-step SD1.5:

```bash
stdbuf -oL -eL ./build_sd15_run/diffusion_demo \
  /data1/models/stable-diffusion-v1-5-MNN \
  0 0 0 1 42 \
  /tmp/sd15_cpu_1step_final.jpg \
  "a cute cat playing with yarn"
```

Result:

```text
Fix: 373 - Total: 373, rate = 1.000000
Fix: 1503 - Total: 1503, rate = 1.000000
Fix: 291 - Total: 291, rate = 1.000000
SUCCESS! write generated image to /tmp/sd15_cpu_1step_final.jpg
```

CPU backend, 10-step SD1.5:

```bash
stdbuf -oL -eL ./build_sd15_run/diffusion_demo \
  /data1/models/stable-diffusion-v1-5-MNN \
  0 0 0 10 42 \
  /tmp/sd15_cpu_rerun_check.jpg \
  "a cute cat playing with yarn"
```

Result:

```text
Fix: 373 - Total: 373, rate = 1.000000
Fix: 1503 - Total: 1503, rate = 1.000000
Fix: 291 - Total: 291, rate = 1.000000
SUCCESS! write generated image to /tmp/sd15_cpu_rerun_check.jpg
```

Generated file:

```text
/tmp/sd15_cpu_rerun_check.jpg: JPEG image data, 512x512, components 3
```

OpenCL preload smoke test:

```bash
LD_PRELOAD=/data1/lyxu18/opensource_pj/MNN/build_sd15_opencl/source/backend/opencl/libMNN_CL.so \
stdbuf -oL -eL ./build_sd15_opencl/diffusion_demo \
  /data1/models/stable-diffusion-v1-5-MNN \
  0 2 3 1 42 \
  /tmp/sd15_opencl_1step_resize_cache.jpg \
  "a cute cat playing with yarn"
```

Also verified:

```bash
cmake --build build_sd15_run --target diffusion_demo -j$(nproc)
cmake --build build_sd15_opencl --target diffusion_demo -j$(nproc)
git diff --check
```
