### PR TITLE
[LLM:Perf] Treat linear_attention layers as full attention

### DIFF
--- a/transformers/llm/export/utils/config.py
+++ b/transformers/llm/export/utils/config.py
@@ -104,12 +104,13 @@ class LlmConfig(PretrainedConfig):
                 llm_config.head_dim = llm_config.hidden_size // llm_config.num_attention_heads
 
         # Determine attention type.
-        # Qwen3.5 mixed-attention models mark non-full layers as
-        # `linear_attention`; reuse the existing mix path for them.
+        # Only `sliding_attention` layers need a sliding-window mask and
+        # therefore the "mix" path.  `linear_attention` layers (e.g. Qwen3.5)
+        # do not use the attention mask at all, so they are treated as full.
         sliding_attn_layers = []
         if hasattr(llm_config, 'layer_types') and llm_config.layer_types:
             for i in range(len(llm_config.layer_types)):
-                if llm_config.layer_types[i] in ('sliding_attention', 'linear_attention'):
+                if llm_config.layer_types[i] == 'sliding_attention':
                     sliding_attn_layers.append(i)
 
         if llm_config.num_hidden_layers and len(sliding_attn_layers) >= llm_config.num_hidden_layers:
@@ -119,7 +120,6 @@ class LlmConfig(PretrainedConfig):
             llm_config.sliding_attn_layers = sliding_attn_layers
         else:
             llm_config.attention_type = 'full'
-
         return llm_config
 
 # export config

--- a/transformers/llm/export/utils/transformers.py
+++ b/transformers/llm/export/utils/transformers.py
@@ -550,6 +550,9 @@ class ShortConvAttention(torch.nn.Module):
         hidden_states: torch.Tensor,
         attention_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        # Note: ShortConvAttention is mask-free; `attention_mask` is accepted
+        # only to keep the call signature uniform with `Attention.forward` and
+        # is intentionally unused.
         batch_size, seq_len, _ = hidden_states.shape
 
         # in_proj: [B, L, H] -> [B, L, 3H]
@@ -636,6 +639,9 @@ class LinearAttention(torch.nn.Module):
         hidden_states: torch.Tensor,
         attention_mask: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        # Note: LinearAttention is mask-free; `attention_mask` is accepted
+        # only to keep the call signature uniform with `Attention.forward` and
+        # is intentionally unused.
         batch_size, seq_len, _ = hidden_states.shape
 
         # 1. Linear Projections


### PR DESCRIPTION
Discussed-in: Merge-Request 28000559 , URL: https://code.alibaba-inc.com/AliNN/AliNNPrivate/codereview/28000559
GitOrigin-RevId: f814bab087efe1589dea9119a6f75142c673e980

## Description

<!-- Brief description of the changes -->

## Module

<!-- Which module does this PR affect? e.g. LLM, CPU, Metal, CUDA, OpenCL, Core, Infra -->

## Type

- [ ] Feature
- [ ] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [ ] Commit message follows `[Module:Type] Description` format
- [ ] Code compiles without errors
- [ ] Tested on relevant platform(s)
- [ ] No unrelated format or style changes included
