### PR TITLE
[CPU:Bugfix]Fix the KleidiAI path mapping while using MNN as a subpro…

### DIFF
--- a/cmake/KleidiAI.cmake
+++ b/cmake/KleidiAI.cmake
@@ -15,6 +15,13 @@
 #   download_kleidiai_and_collect_sources()
 #   Use MNN_SOURCES_KLEIDIAI and KLEIDIAI_FILES_SME2 in subsequent build steps.
 # ------------------------------------------------------------------------------
+
+# Capture the MNN cmake/ directory at include time. Inside a CMake function,
+# CMAKE_CURRENT_LIST_DIR resolves to the *caller's* directory, so we must
+# snapshot it here (file scope) to always get the MNN repo root regardless of
+# whether MNN is the top-level project or an embedded dependency.
+set(_MNN_KLEIDIAI_CMAKE_LIST_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
 function (download_kleidiai_and_collect_sources)
     set(MNN_SOURCES_KLEIDIAI "" PARENT_SCOPE)
     set(KLEIDIAI_FILES_SME2 "" PARENT_SCOPE)
@@ -30,7 +37,11 @@ function (download_kleidiai_and_collect_sources)
     if(DEFINED KLEIDIAI_SRC_DIR AND EXISTS "${KLEIDIAI_SRC_DIR}")
         set(_kleidiai_src_dir "${KLEIDIAI_SRC_DIR}")
     else()
-        set(_deps_dir "${CMAKE_BINARY_DIR}/_deps")
+        # Anchor downloads to MNN's own binary dir. CMAKE_BINARY_DIR points at the
+        # top-level project's build tree, which is wrong (and pollutes the parent)
+        # when MNN is consumed as a subproject. CMAKE_CURRENT_BINARY_DIR follows the
+        # include() chain and always resolves to MNN's build directory.
+        set(_deps_dir "${CMAKE_CURRENT_BINARY_DIR}/_deps")
         file(MAKE_DIRECTORY "${_deps_dir}")
 
         set(_tar_path "${_deps_dir}/v${KLEIDIAI_COMMIT_SHA}.tar.gz")
@@ -73,7 +84,16 @@ function (download_kleidiai_and_collect_sources)
             CACHE PATH "Path to KleidiAI source (downloaded or provided)" FORCE)
     endif()
 
-    set(MNN_KLEIDIAI_DIR "${CMAKE_SOURCE_DIR}/source/backend/cpu/kleidiai")
+    set(MNN_KLEIDIAI_DIR "${_MNN_KLEIDIAI_CMAKE_LIST_DIR}/../source/backend/cpu/kleidiai")
+    if(NOT EXISTS "${MNN_KLEIDIAI_DIR}/mnn_kleidiai.cpp")
+        # These sources live inside the MNN repo itself (committed alongside this
+        # file), so a correctly-resolved path always finds them. Reaching here means
+        # the MNN checkout is incomplete/corrupted, not an external dependency issue
+        # -- fail loudly instead of silently disabling a feature the user enabled.
+        message(FATAL_ERROR "KleidiAI MNN source files not found at ${MNN_KLEIDIAI_DIR}. "
+                            "Your MNN checkout looks incomplete; update it to a version that "
+                            "includes source/backend/cpu/kleidiai, or pass -DMNN_KLEIDIAI=OFF.")
+    endif()
     list(APPEND MNN_SOURCES_KLEIDIAI ${MNN_KLEIDIAI_DIR}/mnn_kleidiai.cpp)
     list(APPEND MNN_SOURCES_KLEIDIAI ${MNN_KLEIDIAI_DIR}/mnn_kleidiai_util.cpp)
     list(APPEND MNN_SOURCES_KLEIDIAI ${MNN_KLEIDIAI_DIR}/KleidiAIConvolution.cpp)


### PR DESCRIPTION
…ject

Change-Id: Ia6ea29991f946859fa05970596410322752fff4b

## Description

<!-- Brief description of the changes -->

## Module

<!-- Which module does this PR affect? e.g. LLM, CPU, Metal, CUDA, OpenCL, Core, Infra -->

## Type

- [ ] Feature
- [ ] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [ ] Commit message follows `[Module:Type] Description` format
- [ ] Code compiles without errors
- [ ] Tested on relevant platform(s)
- [ ] No unrelated format or style changes included
