### PR TITLE
[Embedding:Bugfix] Use causal mask for decoder embedding export

### DIFF
--- a/transformers/llm/export/llmexport.py
+++ b/transformers/llm/export/llmexport.py
@@ -744,7 +744,11 @@ class EmbeddingExporter(LlmExporter):
         self.llm_config = {
             'model_type': self.config.model_type,
             'hidden_size' : self.config.hidden_size,
-            'attention_mask': 'int',
+            # qwen3 embedding is a causal decoder (last-token pooling) and needs a
+            # causal mask; bert/gte encoders are bidirectional and use the all-ones
+            # ('int') mask. Using 'int' for qwen3 makes attention bidirectional and
+            # degrades the embeddings (see issue: identical/low-quality vectors).
+            'attention_mask': 'float' if self.config.model_type == 'qwen3' else 'int',
             "jinja": {
                 "chat_template": self.build_prompt("{{ messages | map(attribute='content') | join('') }}")
             },


### PR DESCRIPTION
## Summary
- set decoder-style embedding exports to use the existing causal float attention mask path
- keep encoder embedding exports on the existing int mask path

## Why
The exported runtime config previously forced all embedding models through the bidirectional mask path. Decoder-style embeddings use last-token pooling, so that changes sentence vectors at runtime compared with the traced export mask.

## Validation
- git diff --check upstream/master...HEAD
- python3 -m py_compile transformers/llm/export/llmexport.py transformers/llm/export/utils/model.py