### PR TITLE
[Infra:Refact] Modernize shader build scripts to handle complex paths

### DIFF
--- a/source/backend/metal/makeshader.py
+++ b/source/backend/metal/makeshader.py
@@ -2,15 +2,17 @@
 import sys
 import os
 import re
+import subprocess
+
 gOutputHeadFile = "AllShader.hpp"
 gOutputSourceFile = "AllShader.cpp"
+
 def findAllShader(path):
-    cmd = "find " + path + " -name \"*.metal\""
-    vexs = os.popen(cmd).read().split('\n')
     output = []
-    for f in vexs:
-        if len(f)>1:
-            output.append(f)
+    for root, dirs, files in os.walk(path):
+        for file in files:
+            if file.endswith(".metal"):
+                output.append(os.path.join(root, file))
     return output
 
 def getName(fileName):

--- a/source/backend/opengl/makeshader.py
+++ b/source/backend/opengl/makeshader.py
@@ -1,16 +1,17 @@
 #!/usr/bin/python
 import sys
 import os
+import subprocess
+
 gDefaultPath = sys.argv[1]#"glsl"
 gOutputHeadFile = sys.argv[2]#"AllShader.hpp"
 gOutputSourceFile = sys.argv[3]#"AllShader.cpp"
 def findAllShader(path):
-    cmd = "find " + path + " -name \"*.glsl\""
-    vexs = os.popen(cmd).read().split('\n')
     output = []
-    for f in vexs:
-        if len(f)>1:
-            output.append(f)
+    for root, dirs, files in os.walk(path):
+        for file in files:
+            if file.endswith(".glsl"):
+                output.append(os.path.join(root, file))
     return output
 
 def getName(fileName):

--- a/source/backend/vulkan/buffer/compiler/makeshader.py
+++ b/source/backend/vulkan/buffer/compiler/makeshader.py
@@ -74,16 +74,12 @@ def _build_generated_shader_path(raw, macro, precision):
     return os.path.join(gGeneratedShaderDir, fileName)
 
 def findAllShader(path):
-    cmd = "find " + path + " -name \"*.comp\""
-    vexs = os.popen(cmd).read().split('\n')
-    cmd = "find " + path + " -name \"*.frag\""
-    vexs += os.popen(cmd).read().split('\n')
-    cmd = "find " + path + " -name \"*.vert\""
-    vexs += os.popen(cmd).read().split('\n')
     output = []
-    for f in vexs:
-        if len(f) > 1:
-            output.append(f)
+    extensions = [".comp", ".frag", ".vert"]
+    for root, dirs, files in os.walk(path):
+        for file in files:
+            if any(file.endswith(ext) for ext in extensions):
+                output.append(os.path.join(root, file))
     return output
 
 
@@ -95,22 +91,22 @@ def getName(fileName):
 
 
 def generateFileAsm(headfile, sourcefile, asmdirs):
-    cmd = "find " + asmdirs + " -name \"*.spirv\""
-    vexs = os.popen(cmd).read().split('\n')
     output = []
-    for f in vexs:
-        if len(f) > 1:
-            output.append(f)
+    for root, dirs, files in os.walk(asmdirs):
+        for file in files:
+            if file.endswith(".spirv"):
+                output.append(os.path.join(root, file))
     h = "#ifndef SPRIV_SHADER_AUTO_GENERATE_H\n#define SPRIV_SHADER_AUTO_GENERATE_H\n"
 
     cpp = "#include \"" + headfile + "\"\n"
     for s in output:
         name = getName(s)
         print(name)
-        print(os.popen("spirv-as " + s + " -o tempspv --target-env vulkan1.0").read())
+        subprocess.run(["spirv-as", s, "-o", "tempspv", "--target-env", "vulkan1.0"])
         h += "extern const unsigned char " + name + "[];\n"
         h += 'extern unsigned int ' + name + '_len;\n'
-        print(os.popen("xxd -i tempspv > temp.spv.cpp").read())
+        with open("temp.spv.cpp", "w") as tmp_cpp:
+            subprocess.run(["xxd", "-i", "tempspv"], stdout=tmp_cpp)
         with open('temp.spv.cpp') as f:
             allContent = f.read().replace('tempspv', name)
         cpp += 'const ' + allContent + '\n'
@@ -119,8 +115,8 @@ def generateFileAsm(headfile, sourcefile, asmdirs):
         f.write(h)
     with open(sourcefile, "w") as f:
         f.write(cpp)
-    os.popen('rm temp.spv.cpp').read()
-    os.popen('rm tempspv').read()
+    if os.path.exists('temp.spv.cpp'): os.remove('temp.spv.cpp')
+    if os.path.exists('tempspv'): os.remove('tempspv')
 
 
 class ShaderFile:

--- a/source/backend/vulkan/buffer/render/compiler/makeshader.py
+++ b/source/backend/vulkan/buffer/render/compiler/makeshader.py
@@ -8,22 +8,20 @@ import hashlib # md5 sha1
 import configparser # ini (python 3.0 use configparser)
 import fcntl # file lock
 import datetime # format file modify time
+import subprocess
+
 gDefaultPath = "../glsl"
 gOutputHeadFile = "AllShaderRender.h"
 gOutputSourceFile = "AllShaderRender.cpp"
 mapFile = "VulkanShaderMapRender.cpp"
 
 def findAllShader(path):
-    cmd = "find " + path + " -name \"*.comp\""
-    vexs = os.popen(cmd).read().split('\n')
-    cmd = "find " + path + " -name \"*.frag\""
-    vexs += os.popen(cmd).read().split('\n')
-    cmd = "find " + path + " -name \"*.vert\""
-    vexs += os.popen(cmd).read().split('\n')
     output = []
-    for f in vexs:
-        if len(f) > 1:
-            output.append(f)
+    extensions = [".comp", ".frag", ".vert"]
+    for root, dirs, files in os.walk(path):
+        for file in files:
+            if any(file.endswith(ext) for ext in extensions):
+                output.append(os.path.join(root, file))
     return output
 
 
@@ -35,22 +33,22 @@ def getName(fileName):
 
 
 def generateFileAsm(headfile, sourcefile, asmdirs):
-    cmd = "find " + asmdirs + " -name \"*.spirv\""
-    vexs = os.popen(cmd).read().split('\n')
     output = []
-    for f in vexs:
-        if len(f) > 1:
-            output.append(f)
+    for root, dirs, files in os.walk(asmdirs):
+        for file in files:
+            if file.endswith(".spirv"):
+                output.append(os.path.join(root, file))
     h = "#ifndef SPRIV_SHADER_AUTO_GENERATE_H\n#define SPRIV_SHADER_AUTO_GENERATE_H\n"
 
     cpp = "#include \"" + headfile + "\"\n"
     for s in output:
         name = getName(s)
         print(name)
-        print(os.popen("spirv-as " + s + " -o tempspv --target-env vulkan1.0").read())
+        subprocess.run(["spirv-as", s, "-o", "tempspv", "--target-env", "vulkan1.0"])
         h += "extern const unsigned char " + name + "[];\n"
         h += 'extern unsigned int ' + name + '_len;\n'
-        print(os.popen("xxd -i tempspv > temp.spv.cpp").read())
+        with open("temp.spv.cpp", "w") as tmp_cpp:
+            subprocess.run(["xxd", "-i", "tempspv"], stdout=tmp_cpp)
         with open('temp.spv.cpp') as f:
             allContent = f.read().replace('tempspv', name)
         cpp += 'const ' + allContent + '\n'
@@ -59,8 +57,8 @@ def generateFileAsm(headfile, sourcefile, asmdirs):
         f.write(h)
     with open(sourcefile, "w") as f:
         f.write(cpp)
-    os.popen('rm temp.spv.cpp').read()
-    os.popen('rm tempspv').read()
+    if os.path.exists('temp.spv.cpp'): os.remove('temp.spv.cpp')
+    if os.path.exists('tempspv'): os.remove('tempspv')
 
 
 class ShaderFile:
@@ -410,12 +408,13 @@ def genCppFile(objs, inc, dst):
             if len(spirv_save) > 0:
                 out = spirv_save
                 rm = False
-            print(os.popen("glslangValidator -V " + s + " -Os -o " + out).read())
+            subprocess.run(["glslangValidator", "-V", s, "-Os", "-o", out])
         else:
             out = spirv_cache
             rm = False
         cpp_tmp_file = 'temp.spv.cpp'
-        os.popen("xxd -i "+ out +" > " + cpp_tmp_file).read()
+        with open(cpp_tmp_file, "w") as tmp_cpp:
+            subprocess.run(["xxd", "-i", out], stdout=tmp_cpp)
         with open(cpp_tmp_file) as f:
             rep = out.replace(os.sep,'_')
             rep = rep.replace('.','_')

--- a/source/backend/vulkan/image/compiler/makeshader.py
+++ b/source/backend/vulkan/image/compiler/makeshader.py
@@ -8,18 +8,19 @@ import hashlib # md5 sha1
 import configparser # ini (python 3.0 use configparser)
 import fcntl # file lock
 import datetime # format file modify time
+import subprocess
+
 gDefaultPath = "../execution/glsl"
 gOutputHeadFile = "../shaders/AllShader.h"
 gOutputSourceFile = "AllShader.cpp"
 
 
 def findAllShader(path):
-    cmd = "find " + path + " -name \"*.comp\""
-    vexs = os.popen(cmd).read().split('\n')
     output = []
-    for f in vexs:
-        if len(f) > 1:
-            output.append(f)
+    for root, dirs, files in os.walk(path):
+        for file in files:
+            if file.endswith(".comp"):
+                output.append(os.path.join(root, file))
     return output
 
 
@@ -31,22 +32,22 @@ def getName(fileName):
 
 
 def generateFileAsm(headfile, sourcefile, asmdirs):
-    cmd = "find " + asmdirs + " -name \"*.spirv\""
-    vexs = os.popen(cmd).read().split('\n')
     output = []
-    for f in vexs:
-        if len(f) > 1:
-            output.append(f)
+    for root, dirs, files in os.walk(asmdirs):
+        for file in files:
+            if file.endswith(".spirv"):
+                output.append(os.path.join(root, file))
     h = "#ifndef SPRIV_SHADER_AUTO_GENERATE_H\n#define SPRIV_SHADER_AUTO_GENERATE_H\n"
 
     cpp = "#include \"" + headfile + "\"\n"
     for s in output:
         name = getName(s)
         print(name)
-        print(os.popen("spirv-as " + s + " -o tempspv --target-env vulkan1.0").read())
+        subprocess.run(["spirv-as", s, "-o", "tempspv", "--target-env", "vulkan1.0"])
         h += "extern const unsigned char " + name + "[];\n"
         h += 'extern unsigned int ' + name + '_len;\n'
-        print(os.popen("xxd -i tempspv > temp.spv.cpp").read())
+        with open("temp.spv.cpp", "w") as tmp_cpp:
+            subprocess.run(["xxd", "-i", "tempspv"], stdout=tmp_cpp)
         with open('temp.spv.cpp') as f:
             allContent = f.read().replace('tempspv', name)
         cpp += 'const ' + allContent + '\n'
@@ -55,8 +56,8 @@ def generateFileAsm(headfile, sourcefile, asmdirs):
         f.write(h)
     with open(sourcefile, "w") as f:
         f.write(cpp)
-    os.popen('rm temp.spv.cpp').read()
-    os.popen('rm tempspv').read()
+    if os.path.exists('temp.spv.cpp'): os.remove('temp.spv.cpp')
+    if os.path.exists('tempspv'): os.remove('tempspv')
 
 
 class ShaderFile:
@@ -405,13 +406,13 @@ def genCppFile(objs, inc, dst):
             if len(spirv_save) > 0:
                 out = spirv_save
                 rm = False
-            cmd = "glslangValidator -V " + s + " -Os -o " + out
-            print(os.popen(cmd).read())
+            subprocess.run(["glslangValidator", "-V", s, "-Os", "-o", out])
         else:
             out = spirv_cache
             rm = False
         cpp_tmp_file = 'temp.spv.cpp'
-        os.popen("xxd -i "+ out +" > " + cpp_tmp_file).read()
+        with open(cpp_tmp_file, "w") as tmp_cpp:
+            subprocess.run(["xxd", "-i", out], stdout=tmp_cpp)
         with open(cpp_tmp_file) as f:
             rep = out.replace(os.sep,'_')
             rep = rep.replace('.','_')


### PR DESCRIPTION
## Description

Refactored several `makeshader.py` scripts across Vulkan, Metal, and OpenGL backends to replace legacy shell execution patterns. The previous implementation relied on `os.popen` with string concatenation, which I found could fail when encountering file paths with spaces or special characters. 

By switching to `os.walk` for file discovery and using `subprocess.run` with list arguments, these scripts are now significantly more robust across different environments. This change also cleans up the temporary file management during the SPIR-V assembly process. I have verified the changes locally by generating shaders for each affected backend, and the resulting C++ source files remain consistent with the original logic.

## Module

Infra, Vulkan, Metal, OpenCL

## Type

- [ ] Feature
- [ ] Bugfix
- [ ] Perf
- [x] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [x] Tested on relevant platform(s)
- [x] No unrelated format or style changes included