### PR TITLE
[CPU: Bugfix] fix the problem mentioned in  #4454 

### DIFF
--- a/source/backend/cpu/riscv/rvv/MNNAvgPoolInt8.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNAvgPoolInt8.cpp
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <sys/types.h>
 #include <limits.h>
+#include "../../compute/Int8FunctionsOpt.h"
 
 void MNNAvgPoolInt8_RVV(int8_t* dst, int8_t* src, size_t outputWidth, size_t inputWidth, size_t kernelx, size_t kernely,
                         size_t stridesx, ssize_t paddingx, ssize_t factor) {

--- a/source/backend/cpu/riscv/rvv/MNNFloat2Int8.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNFloat2Int8.cpp
@@ -7,11 +7,8 @@
 //
 #include <riscv_vector.h>
 #include <stdint.h>
-<<<<<<< HEAD
 #include <sys/types.h>
-=======
 #include "../../compute/Int8FunctionsOpt.h"
->>>>>>> fc26945b ([CPU:Bugfix] supplement missing headfile, and fix a bug in MNNLineDepthWiseInt8AddBiasScaleUnit which causse the error below:)
 
 void MNNFloat2Int8_RVV(const float* src, int8_t* dst, size_t sizeQuad, const float* scalep, ssize_t minValue,
                        ssize_t maxValue, const float* zeroPoint, ssize_t quanParamVec) {

--- a/source/backend/cpu/riscv/rvv/MNNFloat2Int8.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNFloat2Int8.cpp
@@ -7,7 +7,11 @@
 //
 #include <riscv_vector.h>
 #include <stdint.h>
+<<<<<<< HEAD
 #include <sys/types.h>
+=======
+#include "../../compute/Int8FunctionsOpt.h"
+>>>>>>> fc26945b ([CPU:Bugfix] supplement missing headfile, and fix a bug in MNNLineDepthWiseInt8AddBiasScaleUnit which causse the error below:)
 
 void MNNFloat2Int8_RVV(const float* src, int8_t* dst, size_t sizeQuad, const float* scalep, ssize_t minValue,
                        ssize_t maxValue, const float* zeroPoint, ssize_t quanParamVec) {

--- a/source/backend/cpu/riscv/rvv/MNNInt8ScaleToFloat.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNInt8ScaleToFloat.cpp
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include <sys/types.h>
 #include <string.h>
+#include "../../compute/Int8FunctionsOpt.h"
 
 void MNNInt8ScaleToFloat_RVV(float* dst, const int8_t* src, const float* scale, size_t size, const float* zeroPoint,
                              ssize_t quantParamVec) {

--- a/source/backend/cpu/riscv/rvv/MNNLineDepthWiseInt8AddBiasScaleUnit.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNLineDepthWiseInt8AddBiasScaleUnit.cpp
@@ -55,7 +55,9 @@ void MNNLineDepthWiseInt8AddBiasScaleUnit_RVV(int8_t* dst, const int8_t* src, co
             }
         }
 
-        vfloat32m4_t vec_bias = __riscv_vle32_v_f32m4(bias_z, vl);
+        // vfloat32m4_t vec_bias = __riscv_vle32_v_f32m4(bias_z, vl);
+        vint32m4_t vec_bias_int = __riscv_vle32_v_i32m4(bias_z, vl);
+        vfloat32m4_t vec_bias = __riscv_vfcvt_f_x_v_f32m4(vec_bias_int, vl);
         vfloat32m4_t f_sum = __riscv_vfcvt_f_x_v_f32m4(vec_sum, vl);
         f_sum = __riscv_vfadd_vv_f32m4(f_sum, vec_bias, vl);
 

--- a/source/backend/cpu/riscv/rvv/MNNLineDepthWiseInt8AddBiasScaleUnit.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNLineDepthWiseInt8AddBiasScaleUnit.cpp
@@ -20,7 +20,11 @@ void MNNLineDepthWiseInt8AddBiasScaleUnit_RVV(int8_t* dst, const int8_t* src, co
     const int8_t* srcPtr = src;
     const int8_t* weightPtr = weight;
 
+<<<<<<< HEAD
     const float* bias_z = (const float*)parameters->bias;
+=======
+    const int32_t* bias_z = parameters->bias;
+>>>>>>> d7f9d697 ([CPU:Bugfix] Fix the bug in MNNLineDepthWiseInt8AddBiasScaleUnit )
     const float* scale_z = parameters->scale;
     const int32_t max_val = parameters->maxValue;
     const int32_t min_val = parameters->minValue;

--- a/source/backend/cpu/riscv/rvv/MNNLineDepthWiseInt8AddBiasScaleUnit.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNLineDepthWiseInt8AddBiasScaleUnit.cpp
@@ -20,11 +20,7 @@ void MNNLineDepthWiseInt8AddBiasScaleUnit_RVV(int8_t* dst, const int8_t* src, co
     const int8_t* srcPtr = src;
     const int8_t* weightPtr = weight;
 
-<<<<<<< HEAD
-    const float* bias_z = (const float*)parameters->bias;
-=======
     const int32_t* bias_z = parameters->bias;
->>>>>>> d7f9d697 ([CPU:Bugfix] Fix the bug in MNNLineDepthWiseInt8AddBiasScaleUnit )
     const float* scale_z = parameters->scale;
     const int32_t max_val = parameters->maxValue;
     const int32_t min_val = parameters->minValue;


### PR DESCRIPTION
## Description

complete the PR that is closed in #4454 
I have rebased this PR onto the latest master and resolved the merge conflicts caused by the changes already merged through #4359.

Specifically:

Kept both #include <sys/types.h> (from master) and #include "Int8FunctionsOpt.h" as suggested.
Preserved the bias_z fix by changing its type from const float* to const int32_t* and using the explicit integer-to-float conversion path, avoiding the incorrect pointer cast in the previous implementation.
Verified that the PR now applies cleanly on top of the current master branch.

The PR has been force-pushed after the rebase. Please take another look when convenient. Thanks!

## Module

<!-- Which module does this PR affect? e.g. LLM, CPU, Metal, CUDA, OpenCL, Core, Infra -->

## Type

- [ ] Feature
- [x] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [x] Tested on relevant platform(s)
- [x] No unrelated format or style changes included
