### PR TITLE
[LLM:Bugfix] Fix embedding QNN export paths

### DIFF
--- a/transformers/llm/engine/tools/generateLlmIO.cpp
+++ b/transformers/llm/engine/tools/generateLlmIO.cpp
@@ -102,26 +102,63 @@ static void createInputsForEmbedding(int seqLen, int hiddenSize, const std::stri
     inputs.push_back(positionIds);
 }
 
-static bool isEmbeddingModel(const rapidjson::Document& doc) {
-    if (doc.HasMember("output_names") && doc["output_names"].IsArray()) {
-        for (auto iter = doc["output_names"].Begin(); iter != doc["output_names"].End(); ++iter) {
-            if (iter->IsString() && std::string(iter->GetString()) == "sentence_embeddings") {
-                return true;
-            }
+static bool hasStringValue(const rapidjson::Document& doc, const char* key, const std::string& value) {
+    if (!doc.HasMember(key)) {
+        return false;
+    }
+    auto& member = doc[key];
+    if (member.IsString()) {
+        return member.GetString() == value;
+    }
+    if (!member.IsArray()) {
+        return false;
+    }
+    for (auto iter = member.Begin(); iter != member.End(); ++iter) {
+        if (iter->IsString() && iter->GetString() == value) {
+            return true;
         }
     }
+    return false;
+}
+
+static bool isEmbeddingModel(const rapidjson::Document& doc, const std::string& modelDir) {
+    if (doc.HasMember("is_embedding") && doc["is_embedding"].IsBool() && doc["is_embedding"].GetBool()) {
+        return true;
+    }
+    if (hasStringValue(doc, "output_names", "sentence_embeddings")) {
+        return true;
+    }
+    if (doc.HasMember("llm_model") && doc["llm_model"].IsString()) {
+        auto modelName = std::string(doc["llm_model"].GetString());
+        if (modelName.find("embedding.mnn") != std::string::npos) {
+            return true;
+        }
+    }
+    if (doc.HasMember("embedding_model") && doc["embedding_model"].IsString()) {
+        auto modelName = std::string(doc["embedding_model"].GetString());
+        if (modelName.find("embedding.mnn") != std::string::npos) {
+            return true;
+        }
+    }
+    if (MNNFileExist(MNNFilePathConcat(modelDir, "embedding.mnn").c_str())) {
+        return true;
+    }
     auto modelType = std::string(doc.HasMember("model_type") && doc["model_type"].IsString() ? doc["model_type"].GetString() : "");
-    if (modelType == "bert" || modelType == "new" || modelType == "qwen3") {
+    if (modelType == "bert" || modelType == "new") {
+        return true;
+    }
+    if (modelType == "qwen3" && !doc.HasMember("layer_nums") && !doc.HasMember("attention_type") && !doc.HasMember("is_mrope")) {
         return true;
     }
     return false;
 }
 
-static bool generateForModel(const std::string& modelPath, const std::string& outputDir, const std::string& jsonPath, int blockSize) {
+static bool generateForModel(const std::string& modelDir, const std::string& outputDir, const std::string& jsonPath, int blockSize) {
     std::shared_ptr<MNN::Express::Module> net;
     std::vector<std::string> inputNames;
     std::vector<std::string> outputNames;
     bool isEmbedding = false;
+    std::string modelPath;
 
     int hiddenSize;
     std::string attentionMaskType;
@@ -152,8 +189,17 @@ static bool generateForModel(const std::string& modelPath, const std::string& ou
         }
         attentionMaskType = doc["attention_mask"].GetString();
 
-        isEmbedding = isEmbeddingModel(doc);
+        isEmbedding = isEmbeddingModel(doc, modelDir);
     }
+
+    modelPath = MNNFilePathConcat(modelDir, isEmbedding ? "embedding.mnn" : "llm.mnn");
+    if (isEmbedding && !MNNFileExist(modelPath.c_str())) {
+        auto llmModelPath = MNNFilePathConcat(modelDir, "llm.mnn");
+        if (MNNFileExist(llmModelPath.c_str())) {
+            modelPath = llmModelPath;
+        }
+    }
+    FUNC_PRINT_ALL(modelPath.c_str(), s);
 
     MNN::ScheduleConfig config;
     std::shared_ptr<MNN::Express::Executor::RuntimeManager> rtmgr(MNN::Express::Executor::RuntimeManager::createRuntimeManager(config));
@@ -229,9 +275,8 @@ int main(int argc, char* argv[]) {
     }
     FUNC_PRINT(blockSize);
 
-    std::string modelPath = std::string(argv[1]) + "/llm.mnn";
-    std::string llmConfigPath = std::string(argv[1]) + "/llm_config.json";
-    FUNC_PRINT_ALL(modelPath.c_str(), s);
+    std::string modelDir = argv[1];
+    std::string llmConfigPath = MNNFilePathConcat(modelDir, "llm_config.json");
     FUNC_PRINT_ALL(llmConfigPath.c_str(), s);
     std::string outputDir = argv[2];
 
@@ -239,7 +284,7 @@ int main(int argc, char* argv[]) {
         MNN_PRINT("Failed to create dir %s.\n", outputDir.c_str());
     }
 
-    if (!generateForModel(modelPath, outputDir, llmConfigPath, blockSize)) {
+    if (!generateForModel(modelDir, outputDir, llmConfigPath, blockSize)) {
         return 1;
     }
 

--- a/transformers/llm/export/llmexport.py
+++ b/transformers/llm/export/llmexport.py
@@ -713,6 +713,7 @@ class LlmExporter(torch.nn.Module):
 class EmbeddingExporter(LlmExporter):
     def __init__(self, args):
         super().__init__(args)
+        self.dst_name = 'embedding'
 
     def response(self, query):
         self.model.eval()

--- a/transformers/llm/export/npu/generate_llm_qnn.py
+++ b/transformers/llm/export/npu/generate_llm_qnn.py
@@ -20,66 +20,74 @@ def makeIO(args, model_name, inputjson, external_file = None):
     process.wait()
     return process.returncode
 
-def makeIOJson(args, seq_len, hidden_size, mask_type):
+def is_embedding_model(config_data, model_dir):
+    if config_data.get("is_embedding", False) is True:
+        return True
+
+    output_names = config_data.get("output_names", [])
+    if isinstance(output_names, str):
+        output_names = [output_names]
+    if "sentence_embeddings" in output_names:
+        return True
+
+    model_name = config_data.get("llm_model", config_data.get("embedding_model", ""))
+    if os.path.basename(model_name) == "embedding.mnn":
+        return True
+
+    if os.path.exists(os.path.join(model_dir, "embedding.mnn")):
+        return True
+
+    model_type = config_data.get("model_type", "")
+    if model_type in ("bert", "new"):
+        return True
+    if model_type == "qwen3" and not any(key in config_data for key in ("layer_nums", "attention_type", "is_mrope")):
+        return True
+    return False
+
+def makeIOJson(args, seq_len, hidden_size, mask_type, is_embedding=False):
+    def model_inputs(current_seq_len, logits_index=None):
+        inputs = [
+            {
+                "name": "input_ids",
+                "shape": [current_seq_len, 1, hidden_size]
+            },
+            {
+                "name": "attention_mask",
+                "shape": [1, 1, current_seq_len, current_seq_len],
+                "type": mask_type
+            },
+            {
+                "name": "position_ids",
+                "shape": [1, current_seq_len],
+                "type": "int"
+            }
+        ]
+        if logits_index is not None:
+            inputs.append({
+                "name": "logits_index",
+                "shape": [1],
+                "type": "int",
+                "value": logits_index
+            })
+        return inputs
+
     config = {
         "configs": [
             {
-                "inputs": [
-                    {
-                        "name": "input_ids",
-                        "shape": [seq_len, 1, hidden_size]
-                    },
-                    {
-                        "name": "attention_mask",
-                        "shape": [1, 1, seq_len, seq_len],
-                        "type": mask_type
-                    },
-                    {
-                        "name": "position_ids",
-                        "shape": [1, seq_len],
-                        "type": "int"
-                    },
-                    {
-                        "name": "logits_index",
-                        "shape": [1],
-                        "type": "int",
-                        "value": 0
-                    }
-                ],
+                "inputs": model_inputs(seq_len, None if is_embedding else 0),
                 "outputs": [
-                    "logits"
+                    "sentence_embeddings" if is_embedding else "logits"
                 ]
             },
             {
-                "inputs": [
-                    {
-                        "name": "input_ids",
-                        "shape": [1, 1, hidden_size]
-                    },
-                    {
-                        "name": "attention_mask",
-                        "shape": [1, 1, 1, 1],
-                        "type": mask_type
-                    },
-                    {
-                        "name": "position_ids",
-                        "shape": [1, 1],
-                        "type": "int"
-                    },
-                    {
-                        "name": "logits_index",
-                        "shape": [1],
-                        "type": "int",
-                        "value": -1
-                    }
-                ],
+                "inputs": model_inputs(1, None if is_embedding else -1),
                 "outputs": [
-                    "logits"
+                    "sentence_embeddings" if is_embedding else "logits"
                 ]
             }
         ]
     }
-    if "Qwen3.5" in args.model:
+    if not is_embedding and "Qwen3.5" in args.model:
         cfg = config["configs"]
         inputs = cfg[0]["inputs"]
         for inp in inputs:
@@ -94,7 +102,7 @@ def makeIOJson(args, seq_len, hidden_size, mask_type):
                 inp["shape"] = [2, 1, 1, 1, 3]		
             if inp["name"] == "position_ids":
                 inp["shape"] = [3, 1]
-    if "Qwen" in args.model and "VL" in args.model:
+    if not is_embedding and "Qwen" in args.model and "VL" in args.model:
         cfg = config["configs"]
         inputs = cfg[0]["inputs"]
         for inp in inputs:
@@ -242,7 +250,7 @@ def compile_qnn(args):
     process.wait()
     return process.returncode
 
-def output_qnn(args):
+def output_qnn(args, model_name=None):
     if os.path.exists(os.path.join(args.model, 'qnn')):
         shutil.rmtree(os.path.join(args.model, 'qnn'))
     shutil.move(os.path.join(args.cache_path, 'qnn'), os.path.join(args.model, 'qnn'))
@@ -252,9 +260,11 @@ def output_qnn(args):
         if os.path.exists(config_path):
             with open(config_path, 'r', encoding='utf-8') as f:
                 config_npu = json.load(f)
-        is_visual = args.model_name == "visual.mnn"
+        model_name = model_name or args.model_name
+        is_visual = model_name == "visual.mnn"
         if not is_visual:
-            config_npu["llm_model"] = "qnn/llm.mnn"
+            config_npu["llm_model"] = "qnn/" + model_name
+            config_npu["llm_weight"] = model_name + ".weight"
             config_npu["chunk_limits"] = [args.chunk_size, 1]
         else:
             config_npu["visual_model"] = "qnn/visual.mnn"
@@ -282,7 +292,7 @@ def convert_qnn(args, model_name, inputjson, external_file, ids):
     end = time.time()
     print("Cost: ", end - sta, ' s')
     print("Step4: Move result file to ", args.model)
-    output_qnn(args)
+    output_qnn(args, model_name)
 
     print("End")
 
@@ -322,22 +332,24 @@ def convert_llm(args):
     os.makedirs(cache, exist_ok=True)
     hidden_size = 768
     mask_type = "int"
-    config_file_path = os.path.join(os.getcwd(), args.model, 'llm_config.json')
+    model_dir = os.path.join(os.getcwd(), args.model)
+    config_file_path = os.path.join(model_dir, 'llm_config.json')
     with open(config_file_path, 'r', encoding='utf-8') as f:
         config_data = json.load(f)
         if "hidden_size" in config_data:
             hidden_size = config_data["hidden_size"]
         else:
-            print(f"Error: 'hidden_size' key not found in {config_file_path}")
-            return npu_convert
+            raise KeyError(f"'hidden_size' key not found in {config_file_path}")
         if "attention_mask" in config_data:
             mask_type = config_data["attention_mask"]
+        is_embedding = is_embedding_model(config_data, model_dir)
     
     ids = [0, 1]
-    external_file = os.path.join(os.getcwd(), args.model, 'llm.mnn.weight')
-    makeIOJson(args, args.chunk_size, hidden_size, mask_type)
+    model_name = 'embedding.mnn' if is_embedding else 'llm.mnn'
+    external_file = os.path.join(model_dir, model_name + '.weight')
+    makeIOJson(args, args.chunk_size, hidden_size, mask_type, is_embedding)
     inputjson = os.path.join(cache, 'input.json')
-    convert_qnn(args, 'llm.mnn', inputjson, external_file, ids)
+    convert_qnn(args, model_name, inputjson, external_file, ids)
 
 def convert_input_json(args):
     cache = os.path.join(os.getcwd(), args.cache_path)


### PR DESCRIPTION
### Summary
- detect embedding models in the QNN export wrapper and generate sentence_embeddings IO without logits_index
- use embedding.mnn / embedding.mnn.weight for embedding model QNN export and config_qnn.json
- restore embedding exporter output prefix and make generateLlmIO select embedding.mnn with safer qwen3 detection

Fixes #4481

### Tests
- python3 -m py_compile transformers/llm/export/npu/generate_llm_qnn.py transformers/llm/export/llmexport.py
- inline Python checks for embedding and normal LLM input.json generation
- cmake -S . -B build -DMNN_BUILD_LLM=ON -DMNN_LLM_BUILD_DEMO=ON -DMNN_BUILD_TEST=OFF -DMNN_BUILD_BENCHMARK=OFF -DMNN_BUILD_DEMO=OFF -DMNN_BUILD_CONVERTER=OFF -DMNN_BUILD_TRAIN=OFF -DMNN_BUILD_QUANTOOLS=OFF
- cmake --build build --target generateLlmIO -j4