### PR TITLE
[LLM:Bugfix] Fix WikiText calibration dataset loading

### DIFF
--- a/transformers/llm/collect/README.md
+++ b/transformers/llm/collect/README.md
@@ -35,7 +35,7 @@ python get_max_values.py -m <mnn_model_path> [options]
 
 **Arguments:**
 - `-m, --mnn-path`: Path to MNN model config (required)
-- `-d, --eval_dataset`: Dataset for evaluation (default: 'wikitext/wikitext-2-raw-v1')
+- `-d, --eval_dataset`: Dataset for evaluation (default: 'Salesforce/wikitext/wikitext-2-raw-v1')
 - `-o, --output-path`: Output file path (default: 'max_values.json')
 - `-l, --length`: Sample length for processing (default: 512)
 
@@ -53,7 +53,7 @@ python get_thresholds.py -m <mnn_model_path> [options]
 
 **Arguments:**
 - `-m, --mnn-path`: Path to MNN model config(required)
-- `-d, --eval_dataset`: Dataset for evaluation (default: 'wikitext/wikitext-2-raw-v1')
+- `-d, --eval_dataset`: Dataset for evaluation (default: 'Salesforce/wikitext/wikitext-2-raw-v1')
 - `-o, --output-path`: Output file path (default: 'thresholds.json')
 - `-t, --target-sparsity`: Target sparsity level (default: 0.5)
 - `-l, --length`: Sample length for processing (default: 512)

--- a/transformers/llm/collect/get_maxval.py
+++ b/transformers/llm/collect/get_maxval.py
@@ -18,8 +18,11 @@ def main(args):
     model.enable_collection_mode(2, args.output_path)
 
     eval_dataset = args.eval_dataset
-    dataset_name = eval_dataset.split("/")[0]
-    dataset_dir = eval_dataset.split("/")[1]
+    dataset_parts = eval_dataset.split("/")
+    if len(dataset_parts) < 2:
+        raise ValueError("eval_dataset must be formatted as dataset/config or namespace/dataset/config.")
+    dataset_name = "/".join(dataset_parts[:-1])
+    dataset_dir = dataset_parts[-1]
 
     dataset = load_dataset(dataset_name, dataset_dir, split="test")
     input_ids = model.tokenizer_encode("\n\n".join(dataset["text"]))
@@ -39,7 +42,7 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "-d", "--eval_dataset", type=str, default='wikitext/wikitext-2-raw-v1', help="dataset, default is `wikitext/wikitext-2-raw-v1`."
+        "-d", "--eval_dataset", type=str, default='Salesforce/wikitext/wikitext-2-raw-v1', help="dataset, default is `Salesforce/wikitext/wikitext-2-raw-v1`."
     )
 
     parser.add_argument(

--- a/transformers/llm/collect/get_thresholds.py
+++ b/transformers/llm/collect/get_thresholds.py
@@ -18,8 +18,11 @@ def main(args):
     model.enable_collection_mode(1, args.output_path, args.target_sparsity)
 
     eval_dataset = args.eval_dataset
-    dataset_name = eval_dataset.split("/")[0]
-    dataset_dir = eval_dataset.split("/")[1]
+    dataset_parts = eval_dataset.split("/")
+    if len(dataset_parts) < 2:
+        raise ValueError("eval_dataset must be formatted as dataset/config or namespace/dataset/config.")
+    dataset_name = "/".join(dataset_parts[:-1])
+    dataset_dir = dataset_parts[-1]
 
     dataset = load_dataset(dataset_name, dataset_dir, split="test")
     input_ids = model.tokenizer_encode("\n\n".join(dataset["text"]))
@@ -40,7 +43,7 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "-d", "--eval_dataset", type=str, default='wikitext/wikitext-2-raw-v1', help="dataset, default is `wikitext/wikitext-2-raw-v1`."
+        "-d", "--eval_dataset", type=str, default='Salesforce/wikitext/wikitext-2-raw-v1', help="dataset, default is `Salesforce/wikitext/wikitext-2-raw-v1`."
     )
 
     parser.add_argument(

--- a/transformers/llm/eval/README.md
+++ b/transformers/llm/eval/README.md
@@ -23,7 +23,7 @@
     - `-d`：数据集名称
   - **示例**
     ```sh
-    python evaluate_perplexity.py -m /path/to/model/config.json -d "wikitext/wikitext-2-raw-v1"
+    python evaluate_perplexity.py -m /path/to/model/config.json -d "Salesforce/wikitext/wikitext-2-raw-v1"
     ```
 
 ### llm_eval.py
@@ -46,7 +46,7 @@
     - `-d`：数据集名称
   - **示例**
     ```sh
-    python download_data.py -o wiki -d "wikitext/wikitext-2-raw-v1"
+    python download_data.py -o wiki -d "Salesforce/wikitext/wikitext-2-raw-v1"
     ```
 
 ### `ppl_eval`

--- a/transformers/llm/eval/download_data.py
+++ b/transformers/llm/eval/download_data.py
@@ -5,8 +5,11 @@ def main(args):
     output_path = args.output_path
     # load dataset
     eval_dataset = args.eval_dataset
-    dataset_name = eval_dataset.split("/")[0]
-    dataset_dir = eval_dataset.split("/")[1]
+    dataset_parts = eval_dataset.split("/")
+    if len(dataset_parts) < 2:
+        raise ValueError("eval_dataset must be formatted as dataset/config or namespace/dataset/config.")
+    dataset_name = "/".join(dataset_parts[:-1])
+    dataset_dir = dataset_parts[-1]
 
     dataset = load_dataset(dataset_name, dataset_dir, split="test")
     os.makedirs(output_path, exist_ok = True)
@@ -31,7 +34,7 @@ if __name__ == "__main__":
     # Provide extra arguments required for tasks
     group = parser.add_argument_group(title="Evaluation options")
     group.add_argument(
-        "-d", "--eval_dataset", type=str, default='wikitext/wikitext-2-raw-v1', help="Evaluation dataset, default is `wikitext/wikitext-2-raw-v1`."
+        "-d", "--eval_dataset", type=str, default='Salesforce/wikitext/wikitext-2-raw-v1', help="Evaluation dataset, default is `Salesforce/wikitext/wikitext-2-raw-v1`."
     )
 
     args = parser.parse_args()

--- a/transformers/llm/eval/evaluate_perplexity.py
+++ b/transformers/llm/eval/evaluate_perplexity.py
@@ -21,8 +21,11 @@ def main(args):
         print("Loading dataset from disk: {}".format(eval_dataset))
         dataset = load_from_disk(eval_dataset)
     else:
-        dataset_name = eval_dataset.split("/")[0]
-        dataset_dir = eval_dataset.split("/")[1]
+        dataset_parts = eval_dataset.split("/")
+        if len(dataset_parts) < 2:
+            raise ValueError("eval_dataset must be formatted as dataset/config or namespace/dataset/config.")
+        dataset_name = "/".join(dataset_parts[:-1])
+        dataset_dir = dataset_parts[-1]
         dataset = load_dataset(dataset_name, dataset_dir, split="test")
 
     input_ids = model.tokenizer_encode("\n\n".join(dataset["text"]))
@@ -69,7 +72,7 @@ if __name__ == "__main__":
     # Provide extra arguments required for tasks
     group = parser.add_argument_group(title="Evaluation options")
     group.add_argument(
-        "-d", "--eval_dataset", type=str, default='wikitext/wikitext-2-raw-v1', help="Evaluation dataset, default is `wikitext/wikitext-2-raw-v1`."
+        "-d", "--eval_dataset", type=str, default='Salesforce/wikitext/wikitext-2-raw-v1', help="Evaluation dataset, default is `Salesforce/wikitext/wikitext-2-raw-v1`."
     )
     group.add_argument(
         "--attention_mode",

--- a/transformers/llm/export/utils/awq_quantizer.py
+++ b/transformers/llm/export/utils/awq_quantizer.py
@@ -695,7 +695,7 @@ class AwqQuantizer:
                 dataset = load_dataset("mit-han-lab/pile-val-backup", split="validation")
             elif data == "wikitext":
 
-                dataset = load_dataset('wikitext', 'wikitext-2-raw-v1', split=split)
+                dataset = load_dataset("Salesforce/wikitext", "wikitext-2-raw-v1", split=split)
             else:
                 dataset = load_dataset(data, split=split)
 

--- a/transformers/llm/export/utils/omni_quantizer.py
+++ b/transformers/llm/export/utils/omni_quantizer.py
@@ -99,7 +99,7 @@ class OmniQuantizer:
             if data == "pileval":
                 dataset = load_dataset("mit-han-lab/pile-val-backup", split="validation")
             elif data == "wikitext":
-                dataset = load_dataset('wikitext', 'wikitext-2-raw-v1', split=split)
+                dataset = load_dataset("Salesforce/wikitext", "wikitext-2-raw-v1", split=split)
             else:
                 custom_calib_data = True
                 with open(data, 'r', encoding='utf-8') as f:

--- a/transformers/llm/export/utils/smooth_quantizer.py
+++ b/transformers/llm/export/utils/smooth_quantizer.py
@@ -115,7 +115,7 @@ class SmoothQuantizer:
             if data == "pileval":
                 dataset = load_dataset("mit-han-lab/pile-val-backup", split="validation")
             elif data == "wikitext":
-                dataset = load_dataset('wikitext', 'wikitext-2-raw-v1', split=split)
+                dataset = load_dataset("Salesforce/wikitext", "wikitext-2-raw-v1", split=split)
             else:
                 custom_calib_data = True
                 # dataset = load_dataset(data, split=split)


### PR DESCRIPTION
## Description

Fix LLM calibration dataset loading with recent `datasets` / `huggingface_hub` versions.

Recent HuggingFace Hub clients require dataset repo IDs to include a namespace. The old `load_dataset("wikitext", ...)` path now fails with an invalid HF URI error. This updates built-in WikiText calibration loading to `Salesforce/wikitext`.

Also updates `download_data.py` to accept dataset specs like `Salesforce/wikitext/wikitext-2-raw-v1` by treating the final path component as the dataset config and the preceding components as the repo ID.

## Module

LLM

## Type

- [ ] Feature
- [x] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [x] Tested on relevant platform(s)
- [x] No unrelated format or style changes included