### PR TITLE
[Android:Bugfix] Add missing diffusion_session and sana_session sourc…

### DIFF
--- a/apps/Android/MnnLlmChat/app/src/main/cpp/CMakeLists.txt
+++ b/apps/Android/MnnLlmChat/app/src/main/cpp/CMakeLists.txt
@@ -30,6 +30,10 @@ add_library(${CMAKE_PROJECT_NAME} SHARED
         llm_session.cpp
         crash_util.cpp
         processor.cpp
+        diffusion_jni.cpp
+        diffusion_session.cpp
+        sana_jni.cpp
+        sana_session.cpp
         # Video processing files (moved to video/ directory)
         video/video_decoder.cpp
         video/byte_buffer_decoder.cpp


### PR DESCRIPTION
## 问题
fix #4562

diffusion_jni.cpp 和 sana_jni.cpp 依赖的 DiffusionSession、SanaSession 类实现（分别位于 diffusion_session.cpp 和 sana_session.cpp）未加入 CMakeLists.txt，导致链接时符号缺失，运行时抛出 UnsatisfiedLinkError。

## 修复
在 CMakeLists.txt 中补充缺失的源文件：
- `diffusion_session.cpp`
- `sana_session.cpp`

## 验证
本地编译 APK 验证通过。
