### PR TITLE
[QNN:Bugfix] Raise stack limit for context generation

### DIFF
--- a/source/backend/qnn/npu_convert.py
+++ b/source/backend/qnn/npu_convert.py
@@ -6,6 +6,7 @@ import subprocess
 import json
 import concurrent.futures
 import multiprocessing
+import resource
 post_treat = {}
 qnn_sdk = os.environ["QNN_SDK_ROOT"]
 print(qnn_sdk)
@@ -22,6 +23,21 @@ cache_dir = 'res'
 if 'cache' in post_treat:
     cache_dir = post_treat['cache']
 clean_tmp = True
+
+
+def raise_stack_limit():
+    try:
+        soft, hard = resource.getrlimit(resource.RLIMIT_STACK)
+        if soft == resource.RLIM_INFINITY:
+            return
+        target = hard
+        if hard == resource.RLIM_INFINITY:
+            target = resource.RLIM_INFINITY
+        if target > soft or target == resource.RLIM_INFINITY:
+            resource.setrlimit(resource.RLIMIT_STACK, (target, hard))
+            print(f"[QNN] raise stack limit: {soft} -> {target}", flush=True)
+    except Exception as e:
+        print(f"[QNN] skip raising stack limit: {e}", flush=True)
 
 
 def run_subprocess(cmd, cwd=None, retries=3):
@@ -176,6 +192,7 @@ def process_merge(key, merge_index):
                 raise RuntimeError(f"Remove workdir failed: {workdir}")
 
 merge_keys = list(post_treat["merge"])
+raise_stack_limit()
 merge_workers = max(1, min(os.cpu_count()//2 or 1, len(merge_keys)))
 print(f"[Merge Parallel] running {len(merge_keys)} merge task(s), max_workers={merge_workers}", flush=True)
 


### PR DESCRIPTION
## Description

When converting Qwen3/Qwen3.5 4B LLM models to QNN context binaries on v73, the conversion may fail at the last large graph, which appears to include the lm_head part.

We debugged the failed `qnn-context-binary-generator` command with gdb and found that it crashes inside the generated QNN model shared library:

```text
SIGSEGV in QnnModel_composeGraphs() from libgraph1_37.so
```

The generated C++ for the final graph contains very large local stack arrays for lm_head quantization metadata, for example:

```cpp
Qnn_ScaleOffset_t tensor__lm_lm_head_Linear_bias_axis_scale_offset[] = { ... };
```

In our case, this array had about 151,936 entries. `Qnn_ScaleOffset_t` contains a `float` and an `int32_t`, so this single local array is roughly:

```text
151,936 * 8 bytes = 1,215,488 bytes ~= 1.16 MiB
```

The generated function also contains many other local tensors and metadata arrays. With the default Linux stack limit:

```bash
ulimit -s
# 8192
```

the available stack is only `8192 KB`, about `8 MiB`. This can make `qnn-context-binary-generator` segfault while composing the graph.

After raising the stack limit:

```bash
ulimit -s unlimited
```

the same `qnn-context-binary-generator` command succeeds.

This PR raises the Python process stack limit before invoking QNN tools in `npu_convert.py`. The QNN subprocesses inherit this limit, so `qnn-context-binary-generator` can compose the large graph successfully.

No QNN graph options are changed in this PR.

Tested with Qwen3-4B QNN conversion on v73 using QNN SDK 2.42.

## Module

QNN

## Type

- [x] Bugfix

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [x] Tested on relevant platform(s)
- [x] No unrelated format or style changes included

fix: https://github.com/alibaba/MNN/issues/4567