### PR TITLE
Add Ministral 3B Q4 MNN to model market

### DIFF
--- a/apps/Android/MnnLlmChat/app/src/main/assets/model_market.json
+++ b/apps/Android/MnnLlmChat/app/src/main/assets/model_market.json
@@ -1,5 +1,5 @@
 {
-    "version": "22",
+    "version": "23",
     "tagTranslations": {
         "Vision": "图像理解",
         "Video": "视频理解",
@@ -26,6 +26,7 @@
         "DeepSeek",
         "Gemma",
         "LFM",
+        "Mistral",
         "Smol",
         "stability.ai",
         "Llama",
@@ -463,6 +464,21 @@
             "size_gb": 1.5,
             "vendor": "LFM",
             "file_size": 828120793
+        },
+        {
+            "modelName": "Ministral-3-3B-Base-Q4-MNN",
+            "tags": [],
+            "categories": [
+                "chat",
+                "mistral"
+            ],
+            "sources": {
+                "HuggingFace": "shefowl/Ministral-3-3B-Base-Q4-MNN"
+            },
+            "min_app_version": "0.8.3",
+            "size_gb": 3.3,
+            "vendor": "Mistral",
+            "file_size": 1936851423
         },
         {
             "modelName": "Qwen3.5-0.8B-Claude-4.6-Opus-Reasoning-Distilled-MNN",


### PR DESCRIPTION
# PR: Add Ministral 3B Q4 MNN to the model market

## Title

Add Ministral 3B Q4 MNN to model market

## Body

### Summary

- Add `Ministral-3-3B-Base-Q4-MNN` to the Android MNN Chat model market.
- Add `Mistral` to the vendor ordering so the model is grouped consistently in filters.
- Bump `model_market.json` version from `22` to `23`.

### Model

- Hugging Face: https://huggingface.co/shefowl/Ministral-3-3B-Base-Q4-MNN
- Base model: https://huggingface.co/mistralai/Ministral-3-3B-Base-2512
- Quantization: 4-bit
- MNN export block size: 64
- Market payload size: 1,936,851,423 bytes

The repository contains the MNN runtime files at the repo root:

- `config.json`
- `export_args.json`
- `llm_config.json`
- `llm.mnn.json`
- `llm.mnn`
- `llm.mnn.weight`
- `tokenizer.mtok`

### Test Plan

- Parsed `apps/Android/MnnLlmChat/app/src/main/assets/model_market.json` with Python `json.loads`.
- Verified the new model appears exactly once in `models`.
- Verified `Mistral` is present in `vendorOrder`.
- Verified the Hugging Face repository is public and contains the root-level MNN files required by the downloader.

Android device runtime benchmarking was not run in this patch.
