### PR TITLE
[ARM:Bugfix] Enable MNNRankOneUpdate fallback on Apple Silicon

### DIFF
--- a/source/backend/cpu/compute/CommonOptFunction.cpp
+++ b/source/backend/cpu/compute/CommonOptFunction.cpp
@@ -3913,7 +3913,7 @@ void MNNVectorTop1Int32(int32_t* input, int32_t* maxValue, int32_t* maxIndex, si
 
 #endif
 
-#ifndef __aarch64__
+#if !defined(__aarch64__) || defined(__APPLE__)
 static void MNNRankOneUpdateDefault(float* S, const float* k, const float* delta, size_t dk, size_t dv) {
     for (size_t i = 0; i < dk; ++i) {
         float k_val = k[i];


### PR DESCRIPTION
## Description

The `MNNRankOneUpdateDefault` C++ fallback was guarded by `#ifndef __aarch64__`, which excludes Apple Silicon (which also defines `__aarch64__`). However, the NEON assembly path for `MNNRankOneUpdate` is not wired up for this op on Apple platforms, causing a missing implementation at link/runtime.

Fix by changing the guard to `#if !defined(__aarch64__) || defined(__APPLE__)`, so the fallback is compiled on Apple Silicon as well.

**Tested on**: Apple M4 (ARM64, Apple Silicon)

## Module

- [x] ARM

## Type

- [x] Bugfix

## Checklist

- [x] Commit message format: `[Module:Type] Description`
- [x] Compiles without errors
- [x] Tested on Apple M4
- [x] No unrelated style changes