### PR TITLE
[QNN:Feature] Add Interp/Resize op support for QNN backend

### DIFF
--- a/source/backend/qnn/backend/QNNUtils.cpp
+++ b/source/backend/qnn/backend/QNNUtils.cpp
@@ -155,6 +155,7 @@ void registerQNNOps() {
     ___QNNQuantCreator__OpType_FloatToInt8__();
     ___QNNDeQuantCreator__OpType_Int8ToFloat__();
     ___QNNTopKV2Creator__OpType_TopKV2__();
+    ___QNNInterpCreator__OpType_Interp__();
 }
 
 Tensor::DimensionType gQnnTensorDimType = Tensor::TENSORFLOW;

--- a/source/backend/qnn/backend/QNNUtils.hpp
+++ b/source/backend/qnn/backend/QNNUtils.hpp
@@ -113,6 +113,7 @@ extern void ___QNNAttentionCreator__OpType_Attention__();
 extern void ___QNNQuantCreator__OpType_FloatToInt8__();
 extern void ___QNNDeQuantCreator__OpType_Int8ToFloat__();
 extern void ___QNNTopKV2Creator__OpType_TopKV2__();
+extern void ___QNNInterpCreator__OpType_Interp__();
 
 void registerQNNOps();
 

--- a/source/backend/qnn/execution/QNNInterp.cpp
+++ b/source/backend/qnn/execution/QNNInterp.cpp
@@ -1,0 +1,93 @@
+//
+//  QNNInterp.cpp
+//  MNN
+//
+//  Copyright © 2018, Alibaba Group Holding Limited
+//
+
+#include "QNNInterp.hpp"
+#include "QnnOpDef.h"
+
+namespace MNN {
+namespace QNN {
+#ifdef ENABLE_QNN_ONLINE_FINALIZE
+
+ErrorCode QNNInterp::onEncode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) {
+    mParams.clear();
+    mInputs.clear();
+    mOutputs.clear();
+
+    auto interpParam = mOp->main_as_Interp();
+    int resizeType = interpParam->resizeType();
+    bool alignCorners = interpParam->alignCorners();
+    bool halfPixelCenters = interpParam->halfPixelCenters();
+
+    // MNN resizeType: 1=nearest, 2=bilinear, 3=cubic, 4=nearest_round
+    // Use QNN "Resize" op which supports interpolation_mode + transformation_mode
+
+    mNodeType = "Resize";
+
+    // Determine interpolation mode
+    uint32_t interpolationMode;
+    if (resizeType == 1 || resizeType == 4) {
+        interpolationMode = QNN_OP_RESIZE_INTERPOLATION_MODE_NEAREST;
+    } else if (resizeType == 2) {
+        interpolationMode = QNN_OP_RESIZE_INTERPOLATION_MODE_LINEAR;
+    } else if (resizeType == 3) {
+        interpolationMode = QNN_OP_RESIZE_INTERPOLATION_MODE_CUBIC;
+    } else {
+        interpolationMode = QNN_OP_RESIZE_INTERPOLATION_MODE_NEAREST;
+    }
+
+    // Determine transformation mode
+    uint32_t transformationMode;
+    if (alignCorners) {
+        transformationMode = QNN_OP_RESIZE_TRANSFORMATION_MODE_ALIGN_CORNERS;
+    } else if (halfPixelCenters) {
+        transformationMode = QNN_OP_RESIZE_TRANSFORMATION_MODE_HALF_PIXEL;
+    } else {
+        transformationMode = QNN_OP_RESIZE_TRANSFORMATION_MODE_ASYMMETRIC;
+    }
+
+    this->createParamScalar("interpolation_mode", interpolationMode);
+    this->createParamScalar("transformation_mode", transformationMode);
+    this->createParamScalar("exclude_outside", (uint32_t)0);
+
+    if (resizeType == 1 || resizeType == 4) {
+        uint32_t nearestMode = (resizeType == 4)
+            ? QNN_OP_RESIZE_NEAREST_MODE_ROUND_PREFER_FLOOR
+            : QNN_OP_RESIZE_NEAREST_MODE_FLOOR;
+        this->createParamScalar("nearest_mode", nearestMode);
+    }
+
+    if (resizeType == 3) {
+        float cubicCoeff = interpParam->cubicCoeffA();
+        this->createParamScalar("cubic_coeff", cubicCoeff);
+    }
+
+    // Add params
+    for (int i = 0; i < mParamScalarWrappers.size(); i++) {
+        mParams.push_back(*(mParamScalarWrappers[i]->getNativeParam()));
+    }
+
+    mInputs.push_back(*(mBackend->getNativeTensor(inputs[0])));
+    mOutputs.push_back(*(mBackend->getNativeTensor(outputs[0])));
+
+    mBackend->addNodeToGraph(mOpConfigVersion, mNodeName.c_str(), mPackageName.c_str(),
+                             mNodeType.c_str(), mParams, mInputs, mOutputs);
+
+    return NO_ERROR;
+}
+
+class QNNInterpCreator : public QnnBackend::Creator {
+public:
+    virtual QNNCommonExecution *onCreate(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs,
+                                         const MNN::Op *op, Backend *backend) const override {
+        return new QNNInterp(backend, op);
+    }
+};
+
+REGISTER_QNN_OP_CREATOR(QNNInterpCreator, OpType_Interp)
+#endif
+} // end namespace QNN
+} // end namespace MNN

--- a/source/backend/qnn/execution/QNNInterp.hpp
+++ b/source/backend/qnn/execution/QNNInterp.hpp
@@ -1,0 +1,27 @@
+//
+//  QNNInterp.hpp
+//  MNN
+//
+//  Copyright © 2018, Alibaba Group Holding Limited
+//
+
+#ifndef MNN_QNNINTERP_HPP
+#define MNN_QNNINTERP_HPP
+
+#include "QNNCommonExecution.hpp"
+#include "QnnTypes.h"
+
+namespace MNN {
+namespace QNN {
+#ifdef ENABLE_QNN_ONLINE_FINALIZE
+
+class QNNInterp : public QNNCommonExecution {
+public:
+    QNNInterp(Backend *backend, const Op *op) : QNNCommonExecution(backend, op) {}
+    virtual ErrorCode onEncode(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs) override;
+};
+#endif
+} // end namespace QNN
+} // end namespace MNN
+
+#endif


### PR DESCRIPTION
## Summary
Add QNNInterp execution class that maps MNN's `OpType_Interp` to QNN's `Resize` op with proper interpolation mode and transformation mode support.

## Changes
- **New files**: `QNNInterp.cpp`, `QNNInterp.hpp` — implements QNN Resize op mapping
- **Modified**: `QNNUtils.cpp`, `QNNUtils.hpp` — register `QNNInterpCreator` for `OpType_Interp`

## Details
- Supports interpolation modes: nearest, bilinear, cubic
- Supports transformation modes: align_corners, half_pixel, asymmetric
- Handles nearest_mode (floor vs round_prefer_floor) for nearest interpolation
- Supports cubic_coeff parameter for cubic interpolation

## Testing
Tested on Snapdragon 8 Gen 3 (SM8650) and Snapdragon 8 Elite (SM8750) devices with models containing Interp/Resize layers.