### PR TITLE
[QNN:Feature] add vtmc_mb arg for vtcm size configurable

### DIFF
--- a/docs/transformers/llm.md
+++ b/docs/transformers/llm.md
@@ -951,6 +951,7 @@ make -j16
 | `--model` | str | (必填) | MNN 模型所在目录路径 |
 | `--soc_id` | int | (必填) | 目标设备的 SOC ID，如 8Gen3 为 57 |
 | `--dsp_arch` | str | (必填) | 目标设备的 DSP 架构，如 8Gen3 为 v75 |
+| `--vtcm_mb` | int | (选填) | 目标设备上用于缓存graph的vtcm_mb大小，默认配置为8 |
 | `--model_name` | str | `llm.mnn` | 要转换的模型文件名，如 `llm.mnn` 或 `visual.mnn` |
 | `--image_sizes` | str | `512x512` | 视觉模型的输入图片尺寸，支持多尺寸，如 `"224x224,384x384,512x512"` |
 | `--input_json` | str | `""` | 自定义输入 shape 的 JSON 文件路径，非空时使用自定义模式 |

--- a/source/backend/qnn/npu_convert.py
+++ b/source/backend/qnn/npu_convert.py
@@ -13,7 +13,8 @@ with open(sys.argv[1]) as f:
     post_treat = json.load(f)
 soc_id = int(sys.argv[2])
 dsp_arch = sys.argv[3]
-print('soc_id:', soc_id, "; dsp_arch:", dsp_arch)
+vtcm_mb = int(sys.argv[4])
+print('soc_id:', soc_id, "; dsp_arch:", dsp_arch, "; vtcm_mb:", vtcm_mb)
 qnn_bin_path = os.path.join(qnn_sdk, 'bin', 'x86_64-linux-clang')
 qnnModelLibGenerator = os.path.join(qnn_bin_path, 'qnn-model-lib-generator')
 qnnContextBinaryGenerator = os.path.join(qnn_bin_path, 'qnn-context-binary-generator')
@@ -94,7 +95,7 @@ htp_so = os.path.join(qnn_sdk, 'lib','x86_64-linux-clang','libQnnHtp.so')
 htp_backend_extensions = {
     "graphs": [
         {
-            "vtcm_mb": 8,
+            "vtcm_mb": vtcm_mb,
             "O": 3.0,
             "fp16_relaxed_precision": 1,
             "hvx_threads": 4

--- a/transformers/llm/export/npu/generate_llm_qnn.py
+++ b/transformers/llm/export/npu/generate_llm_qnn.py
@@ -232,7 +232,7 @@ def seperate(args, model_name, ids):
 def compile_qnn(args):
     exe = os.path.join(os.getcwd(), args.mnn_path, "..", "source", "backend", "qnn", "npu_convert.py")
     cache = os.path.join(os.getcwd(), args.cache_path)
-    process = subprocess.Popen("python3 " + exe + ' npu_postreat.json %d ' %args.soc_id + ' ' + args.dsp_arch, bufsize=1, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd = cache, text=True, shell=True)
+    process = subprocess.Popen("python3 " + exe + ' npu_postreat.json %d ' %args.soc_id + ' ' + args.dsp_arch + ' %d '  %args.vtcm_mb, bufsize=1, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd = cache, text=True, shell=True)
     for line in process.stdout:
         print(line, end='')
     process.wait()
@@ -366,6 +366,10 @@ def main():
     parser.add_argument('--dsp_arch', type=str, required=True,
                         help='type(`str`, *optional*):'
                         '\n\tThe dsp_arch, for 8gen3 is v75.'
+                        )
+    parser.add_argument('--vtcm_mb', type=int, default=8,
+                        help='type(`int`, *optional*):'
+                        '\n\tThe vtcm_mb size, default is 8'
                         )
     parser.add_argument('--mnn_path', type=str, default="../../../build/",
                         help='mnn build path(`str` or `os.PathLike`):\nCan be either:'


### PR DESCRIPTION
Npu's vtcm can't be all used by MNN, add vtcm_mb paramter in model conversion.

Layout:

 |<--     (1) 8MB Total Hardware VTCM     -->|
        |<-- (2) 7MB Addressable          -->|
 +------+------+------+------+------+------+------+------+
 |  CV  |      |      |      |      |      |      |      |
 +------+------+------+------+------+------+------+------+

The breakdown:

┌────────────────────────┬──────────────────┬──────────────────────────────────────────┐
│ VTCM Region            │ Size             │ Purpose                                  │
├────────────────────────┼──────────────────┼──────────────────────────────────────────┤
│ Total hardware         │ 8 MB             │ Physical VTCM                            │
├────────────────────────┼──────────────────┼──────────────────────────────────────────┤
│ CV core reserved       │ 1 MB (fixed)     │ Always held by Hexagon CV core           │
├────────────────────────┼──────────────────┼──────────────────────────────────────────┤
│ Addressable by HTP     │ 7 MB             │ Max available to graphs                  │
├────────────────────────┼──────────────────┼──────────────────────────────────────────┤
│ System/driver overhead │ ~1–2 MB          │ Context tracking, weight-sharing staging │
├────────────────────────┼──────────────────┼──────────────────────────────────────────┤

Qwen3-VL-4B-Instruct got error on 8gen3 with vtcm_mb = 8 (less than 8 is fine) 06-30 17:49:07.594 17188 17188 E QnnDsp  : QnnDsp <E> Skel failed to process context binary. 06-30 17:49:07.594 17188 17188 E QnnDsp  : QnnDsp <E> Context create from binary failed for deviceId 0 coreId 0 pdId 0 for context e, err 5005 06-30 17:49:07.597 17188 17188 E QnnDsp  : QnnDsp <E> Context 14 failed on pd 0 06-30 17:49:07.859 17188 17188 E QnnDsp  : QnnDsp <E> Skel failed to process context binary. 06-30 17:49:07.859 17188 17188 E QnnDsp  : QnnDsp <E> Context create from binary failed for deviceId 0 coreId 0 pdId 0 for context e, err 5005 06-30 17:49:07.861 17188 17188 E QnnDsp  : QnnDsp <E> Context 14 failed on pd 0 06-30 17:49:08.082 17188 17188 E QnnDsp  : QnnDsp <E> Skel failed to process context binary. 06-30 17:49:08.082 17188 17188 E QnnDsp  : QnnDsp <E> Context create from binary failed for deviceId 0 coreId 0 pdId 0 for context f, err 5005 06-30 17:49:08.084 17188 17188 E QnnDsp  : QnnDsp <E> Context 15 failed on pd 0 06-30 17:49:08.246 17188 17188 E QnnDsp  : QnnDsp <E> Skel failed to process context binary. 06-30 17:49:08.246 17188 17188 E QnnDsp  : QnnDsp <E> Context create from binary failed for deviceId 0 coreId 0 pdId 0 for context f, err 5005 06-30 17:49:08.248 17188 17188 E QnnDsp  : QnnDsp <E> Context 15 failed on pd 0 06-30 17:49:08.347 17188 17188 E QnnDsp  : QnnDsp <E> fastrpc memory map for fd: 227 with length: 203423744 failed with error: 0x1 06-30 17:49:08.347 17188 17188 E QnnDsp  : QnnDsp <E> fastrpc memory map error reporting failed 06-30 17:49:08.347 17188 17188 E QnnDsp  : QnnDsp <E> Mapping buffer fd 227 to FastRpc failed on domain 3 06-30 17:49:08.347 17188 17188 E QnnDsp  : QnnDsp <E> SharedMemoryMod failed to Map Buffer to SMMU for domain 0 06-30 17:49:08.347 17188 17188 E QnnDsp  : QnnDsp <E> Failed to map buffer of size 203423744 06-30 17:49:08.347 17188 17188 E QnnDsp  : QnnDsp <E> Failed to map weights buffer to device! 06-30 17:49:08.347 17188 17188 E QnnDsp  : QnnDsp <E> Could not map shared weights buffer! 06-30 17:49:08.347 17188 17188 E QnnDsp  : QnnDsp <E> Failed to map shared weights for contextId 16 on deviceId 0, coreId 0, pdId 0, err: 1002 06-30 17:49:08.347 17188 17188 E QnnDsp  : QnnDsp <E> Context create from binary failed for deviceId 0 coreId 0 pdId 0 for context 10, err 1002

## Description

<!-- Brief description of the changes -->

## Module

<!-- Which module does this PR affect? e.g. LLM, CPU, Metal, CUDA, OpenCL, Core, Infra -->

## Type

- [ *] Feature
- [ ] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [ ] Commit message follows `[Module:Type] Description` format
- [ ] Code compiles without errors
- [ *] Tested on relevant platform(s)
- [ ] No unrelated format or style changes included
