### PR TITLE
[LLM:Bugfix] Align Qwen3-VL runtime preprocessing

### DIFF
--- a/transformers/llm/engine/src/omni.cpp
+++ b/transformers/llm/engine/src/omni.cpp
@@ -1235,8 +1235,10 @@ void Omni::addPositionIds(int t, int h, int w) {
                 }
             }
         }
-        // vision end
-        mPositionIds.push_back();
+        // Match Qwen3-VL MRoPE: after a vision segment, continue from
+        // start + max(llm_grid_h, llm_grid_w), not from the last W index.
+        int next_idx = cur_idx + std::max(h, w);
+        mPositionIds.push_back(next_idx, next_idx, next_idx);
     }
 }
 

--- a/transformers/llm/engine/src/omni.cpp
+++ b/transformers/llm/engine/src/omni.cpp
@@ -11,6 +11,8 @@
 #endif
 #include <regex>
 #include <algorithm>
+#include <cmath>
+#include <cstdint>
 #include <random>
 #include <MNN/AutoTime.hpp>
 #include <MNN/expr/ExecutorScope.hpp>
@@ -32,6 +34,202 @@
 namespace MNN {
 using namespace Express;
 namespace Transformer {
+
+static int roundHalfToEven(float value) {
+    float floorValue = std::floor(value);
+    float diff = value - floorValue;
+    int rounded = static_cast<int>(floorValue);
+    constexpr float eps = 1e-6f;
+    if (diff > 0.5f + eps) {
+        return rounded + 1;
+    }
+    if (diff < 0.5f - eps) {
+        return rounded;
+    }
+    return (rounded % 2 == 0) ? rounded : rounded + 1;
+}
+
+static std::pair<int, int> qwenVlSmartResize(int height, int width, int factor, int minPixels, int maxPixels) {
+    int resizedHeight = roundHalfToEven(static_cast<float>(height) / factor) * factor;
+    int resizedWidth = roundHalfToEven(static_cast<float>(width) / factor) * factor;
+    int64_t resizedPixels = static_cast<int64_t>(resizedHeight) * resizedWidth;
+    if (resizedPixels > maxPixels) {
+        float beta = std::sqrt(static_cast<float>(height) * width / maxPixels);
+        resizedHeight = static_cast<int>(std::floor(height / beta / factor)) * factor;
+        resizedWidth = static_cast<int>(std::floor(width / beta / factor)) * factor;
+    } else if (resizedPixels < minPixels) {
+        float beta = std::sqrt(static_cast<float>(minPixels) / (static_cast<float>(height) * width));
+        resizedHeight = static_cast<int>(std::ceil(height * beta / factor)) * factor;
+        resizedWidth = static_cast<int>(std::ceil(width * beta / factor)) * factor;
+    }
+    return std::make_pair(resizedHeight, resizedWidth);
+}
+
+static constexpr int kPillowResizePrecisionBits = 32 - 8 - 2;
+static constexpr int kPillowResizePrecision = 1 << kPillowResizePrecisionBits;
+
+static inline double pillowBicubicFilter(double x) {
+    if (x < 0.0) {
+        x = -x;
+    }
+    if (x < 1.0) {
+        return ((1.5 * x - 2.5) * x) * x + 1.0;
+    }
+    if (x < 2.0) {
+        return (((-0.5 * x + 2.5) * x - 4.0) * x) + 2.0;
+    }
+    return 0.0;
+}
+
+struct PillowResizeCoeffs {
+    int ksize = 0;
+    std::vector<int> bounds;
+    std::vector<int> weights;
+};
+
+static PillowResizeCoeffs precomputePillowResizeCoeffs(int inSize, int outSize) {
+    const double filterSupport = 2.0;
+    const double scale = static_cast<double>(inSize) / static_cast<double>(outSize);
+    const double filterScale = std::max(scale, 1.0);
+    const double support = filterSupport * filterScale;
+    const int ksize = static_cast<int>(std::ceil(support)) * 2 + 1;
+
+    PillowResizeCoeffs coeffs;
+    coeffs.ksize = ksize;
+    coeffs.bounds.resize(outSize * 2);
+    coeffs.weights.assign(outSize * ksize, 0);
+
+    std::vector<double> floatWeights(ksize);
+    for (int xx = 0; xx < outSize; ++xx) {
+        const double center = (xx + 0.5) * scale;
+        int xmin = static_cast<int>(center - support + 0.5);
+        xmin = std::max(xmin, 0);
+        int xmax = static_cast<int>(center + support + 0.5);
+        xmax = std::min(xmax, inSize);
+        xmax -= xmin;
+
+        double weightSum = 0.0;
+        for (int x = 0; x < xmax; ++x) {
+            const double arg = (x + xmin - center + 0.5) / filterScale;
+            floatWeights[x] = pillowBicubicFilter(arg);
+            weightSum += floatWeights[x];
+        }
+        if (weightSum != 0.0) {
+            for (int x = 0; x < xmax; ++x) {
+                floatWeights[x] /= weightSum;
+            }
+        }
+        for (int x = 0; x < xmax; ++x) {
+            coeffs.weights[xx * ksize + x] = static_cast<int>(floatWeights[x] * kPillowResizePrecision);
+        }
+        for (int x = xmax; x < ksize; ++x) {
+            coeffs.weights[xx * ksize + x] = 0;
+        }
+        coeffs.bounds[xx * 2] = xmin;
+        coeffs.bounds[xx * 2 + 1] = xmax;
+    }
+    return coeffs;
+}
+
+static inline uint8_t pillowClipU8(int v) {
+    if (v < 0) {
+        return 0;
+    }
+    if (v > 255) {
+        return 255;
+    }
+    return static_cast<uint8_t>(v);
+}
+
+static void pillowHorizontalResizePass(const uint8_t* src, int inW, int inH, int channels, uint8_t* dst, int outW,
+                                       const PillowResizeCoeffs& xCoeffs) {
+    const int rounding = 1 << (kPillowResizePrecisionBits - 1);
+    for (int y = 0; y < inH; ++y) {
+        for (int x = 0; x < outW; ++x) {
+            const int xmin = xCoeffs.bounds[x * 2];
+            const int xmax = xCoeffs.bounds[x * 2 + 1];
+            const int* weights = xCoeffs.weights.data() + x * xCoeffs.ksize;
+            for (int c = 0; c < channels; ++c) {
+                int sum = 0;
+                for (int k = 0; k < xmax; ++k) {
+                    sum += src[(y * inW + xmin + k) * channels + c] * weights[k];
+                }
+                dst[(y * outW + x) * channels + c] = pillowClipU8((sum + rounding) >> kPillowResizePrecisionBits);
+            }
+        }
+    }
+}
+
+static void pillowVerticalResizePass(const uint8_t* src, int inW, int inH, int channels, uint8_t* dst, int outH,
+                                     const PillowResizeCoeffs& yCoeffs) {
+    const int rounding = 1 << (kPillowResizePrecisionBits - 1);
+    for (int y = 0; y < outH; ++y) {
+        const int ymin = yCoeffs.bounds[y * 2];
+        const int ymax = yCoeffs.bounds[y * 2 + 1];
+        const int* weights = yCoeffs.weights.data() + y * yCoeffs.ksize;
+        for (int x = 0; x < inW; ++x) {
+            for (int c = 0; c < channels; ++c) {
+                int sum = 0;
+                for (int k = 0; k < ymax; ++k) {
+                    sum += src[((ymin + k) * inW + x) * channels + c] * weights[k];
+                }
+                dst[(y * inW + x) * channels + c] = pillowClipU8((sum + rounding) >> kPillowResizePrecisionBits);
+            }
+        }
+    }
+}
+
+static std::vector<uint8_t> pillowLikeBicubicResizeRgb(const uint8_t* bgr, int inW, int inH, int outW, int outH) {
+    constexpr int channels = 3;
+    std::vector<uint8_t> rgb(static_cast<size_t>(inW) * inH * channels);
+    for (int y = 0; y < inH; ++y) {
+        for (int x = 0; x < inW; ++x) {
+            const uint8_t* src = bgr + (y * inW + x) * channels;
+            uint8_t* dst = rgb.data() + (y * inW + x) * channels;
+            dst[0] = src[2];
+            dst[1] = src[1];
+            dst[2] = src[0];
+        }
+    }
+
+    auto xCoeffs = precomputePillowResizeCoeffs(inW, outW);
+    auto yCoeffs = precomputePillowResizeCoeffs(inH, outH);
+    std::vector<uint8_t> tmp(static_cast<size_t>(outW) * inH * channels);
+    std::vector<uint8_t> resized(static_cast<size_t>(outW) * outH * channels);
+    pillowHorizontalResizePass(rgb.data(), inW, inH, channels, tmp.data(), outW, xCoeffs);
+    pillowVerticalResizePass(tmp.data(), outW, inH, channels, resized.data(), outH, yCoeffs);
+    return resized;
+}
+
+static VARP qwen3VlPillowResizeAndNormalize(VARP image, int outW, int outH) {
+    if (image.get() == nullptr || image->getInfo() == nullptr) {
+        return nullptr;
+    }
+    auto info = image->getInfo();
+    if (info->dim.size() != 3 || info->dim[2] != 3) {
+        MNN_ERROR("qwen3VlPillowResizeAndNormalize expects HWC 3-channel image\n");
+        return nullptr;
+    }
+    const int inH = info->dim[0];
+    const int inW = info->dim[1];
+    auto bgr = image->readMap<uint8_t>();
+    if (bgr == nullptr) {
+        MNN_ERROR("qwen3VlPillowResizeAndNormalize failed to map input image\n");
+        return nullptr;
+    }
+
+    auto resized = pillowLikeBicubicResizeRgb(bgr, inW, inH, outW, outH);
+    auto output = Express::_Input({outH, outW, 3}, NHWC, halide_type_of<float>());
+    auto outPtr = output->writeMap<float>();
+    if (outPtr == nullptr) {
+        MNN_ERROR("qwen3VlPillowResizeAndNormalize failed to map output\n");
+        return nullptr;
+    }
+    for (size_t i = 0; i < resized.size(); ++i) {
+        outPtr[i] = (static_cast<float>(resized[i]) / 255.0f - 0.5f) / 0.5f;
+    }
+    return output;
+}
 
 template <typename T>
 static inline VARP _var(std::vector<T> vec, const std::vector<int> &dims) {
@@ -321,11 +519,29 @@ std::vector<int> Omni::qwen2VisionProcess(VARP image) {
     constexpr int merge_size = 2;
     const int align_size = patch_size * merge_size;
     // Qwen2-VL / Qwen2.5-VL / Qwen3-VL
-    mVisionHeight = round(mVisionHeight / (float)align_size) * align_size;
-    mVisionWidth = round(mVisionWidth / (float)align_size) * align_size;
-    image = MNN::CV::resize(image, {mVisionWidth, mVisionHeight}, 0, 0,
-                            MNN::CV::INTER_LINEAR, MNN::CV::COLOR_BGR2RGB,
-                            mVisionMean, mVisionNorm);
+    const int defaultMinPixels = isQwen3VL ? 65536 : 3136;
+    const int defaultMaxPixels = isQwen3VL ? 16777216 : 12845056;
+    const int minPixels = mConfig->config_.value("image_min_pixels", defaultMinPixels);
+    const int maxPixels = mConfig->config_.value("image_max_pixels", defaultMaxPixels);
+    auto resizedSize = qwenVlSmartResize(mVisionHeight, mVisionWidth, align_size, minPixels, maxPixels);
+    mVisionHeight = resizedSize.first;
+    mVisionWidth = resizedSize.second;
+    bool usePillowResize = isQwen3VL && mConfig->config_.value("qwen3_vl_pillow_resize", true);
+    if (usePillowResize) {
+        auto pillowImage = qwen3VlPillowResizeAndNormalize(image, mVisionWidth, mVisionHeight);
+        if (pillowImage.get() != nullptr) {
+            image = pillowImage;
+        } else {
+            MNN_ERROR("qwen3VlPillowResizeAndNormalize failed, fallback to MNN CV resize\n");
+            image = MNN::CV::resize(image, {mVisionWidth, mVisionHeight}, 0, 0,
+                                    MNN::CV::INTER_LINEAR, MNN::CV::COLOR_BGR2RGB,
+                                    mVisionMean, mVisionNorm);
+        }
+    } else {
+        image = MNN::CV::resize(image, {mVisionWidth, mVisionHeight}, 0, 0,
+                                MNN::CV::INTER_LINEAR, MNN::CV::COLOR_BGR2RGB,
+                                mVisionMean, mVisionNorm);
+    }
     image = Express::_Unsqueeze(image, {0});
     image = Express::_Convert(image, NCHW);
     auto patches = Express::_Concat({image, image}, 0);
@@ -1235,8 +1451,7 @@ VARP Omni::gen_position_ids(int seq_len) {
     auto ptr = positionIds->writeMap<int>();
     if (mContext->gen_seq_len > 0) {
         for (int i=0; i<seq_len; ++i) {
-            // auto pos = mContext->gen_seq_len + mPositionIds.back() + i;
-            auto pos = mContext->all_seq_len + i;
+            auto pos = mContext->gen_seq_len + mPositionIds.back() + i;
             ptr[i + 0] = pos;
             ptr[i + seq_len] = pos;
             ptr[i + seq_len * 2] = pos;

--- a/transformers/llm/engine/src/omni.cpp
+++ b/transformers/llm/engine/src/omni.cpp
@@ -12,6 +12,7 @@
 #include <regex>
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <random>
 #include <MNN/AutoTime.hpp>
 #include <MNN/expr/ExecutorScope.hpp>
@@ -33,6 +34,50 @@
 namespace MNN {
 using namespace Express;
 namespace Transformer {
+
+static int roundHalfToEven(float value) {
+    float floorValue = std::floor(value);
+    float diff = value - floorValue;
+    int rounded = static_cast<int>(floorValue);
+    constexpr float eps = 1e-6f;
+    if (diff > 0.5f + eps) {
+        return rounded + 1;
+    }
+    if (diff < 0.5f - eps) {
+        return rounded;
+    }
+    return (rounded % 2 == 0) ? rounded : rounded + 1;
+}
+
+static std::pair<int, int> qwenVlSmartResize(int height, int width, int factor, int minPixels, int maxPixels) {
+    if (factor <= 0 || height < factor || width < factor) {
+        MNN_ERROR("Qwen-VL smart resize requires height and width >= factor, got %dx%d with factor %d\n", height, width,
+                  factor);
+        return std::make_pair(0, 0);
+    }
+    if (minPixels <= 0 || maxPixels < minPixels) {
+        MNN_ERROR("Qwen-VL smart resize got invalid pixel limits: min=%d, max=%d\n", minPixels, maxPixels);
+        return std::make_pair(0, 0);
+    }
+    const double aspectRatio = static_cast<double>(std::max(height, width)) / std::min(height, width);
+    if (aspectRatio > 200.0) {
+        MNN_ERROR("Qwen-VL smart resize requires an aspect ratio no larger than 200, got %.2f\n", aspectRatio);
+        return std::make_pair(0, 0);
+    }
+    int resizedHeight = roundHalfToEven(static_cast<float>(height) / factor) * factor;
+    int resizedWidth = roundHalfToEven(static_cast<float>(width) / factor) * factor;
+    int64_t resizedPixels = static_cast<int64_t>(resizedHeight) * resizedWidth;
+    if (resizedPixels > maxPixels) {
+        double beta = std::sqrt(static_cast<double>(height) * width / maxPixels);
+        resizedHeight = std::max(factor, static_cast<int>(std::floor(height / beta / factor)) * factor);
+        resizedWidth = std::max(factor, static_cast<int>(std::floor(width / beta / factor)) * factor);
+    } else if (resizedPixels < minPixels) {
+        double beta = std::sqrt(static_cast<double>(minPixels) / (static_cast<double>(height) * width));
+        resizedHeight = static_cast<int>(std::ceil(height * beta / factor)) * factor;
+        resizedWidth = static_cast<int>(std::ceil(width * beta / factor)) * factor;
+    }
+    return std::make_pair(resizedHeight, resizedWidth);
+}
 
 template <typename T>
 static inline VARP _var(std::vector<T> vec, const std::vector<int> &dims) {
@@ -382,36 +427,28 @@ std::vector<int> Omni::qwen2VisionProcess(VARP image) {
     // Use actual image dimensions (matching Python Qwen3VLProcessor)
     auto imgInfo = image->getInfo();
     if (imgInfo && imgInfo->dim.size() >= 2) {
-        mVisionHeight = imgInfo->dim[0];
-        mVisionWidth = imgInfo->dim[1];
+        if (!mVisionSizeOverridden) {
+            mVisionHeight = imgInfo->dim[0];
+            mVisionWidth = imgInfo->dim[1];
+        }
         if (imgInfo->dim.size() >= 3 && imgInfo->dim[2] == 4) {
             image = _Slice(image, _var<int>({0, 0, 0}, {3}), _var<int>({-1, -1, 3}, {3}));
             imgInfo = image->getInfo();
         }
     }
-    if (isQwen3VL) {
-        // Qwen3-VL's smart_resize uses Python round(), whose ties are rounded
-        // to the nearest even integer. std::round rounds ties away from zero.
-        const auto roundByFactor = [](int size, int factor) {
-            const int quotient = size / factor;
-            const int remainder = size % factor;
-            if (remainder * 2 < factor) {
-                return quotient * factor;
-            }
-            if (remainder * 2 > factor) {
-                return (quotient + 1) * factor;
-            }
-            return (quotient % 2 == 0 ? quotient : quotient + 1) * factor;
-        };
-        mVisionHeight = roundByFactor(mVisionHeight, align_size);
-        mVisionWidth = roundByFactor(mVisionWidth, align_size);
-    } else {
-        mVisionHeight = round(mVisionHeight / (float)align_size) * align_size;
-        mVisionWidth = round(mVisionWidth / (float)align_size) * align_size;
+    // Qwen2-VL / Qwen2.5-VL / Qwen3-VL
+    const int defaultMinPixels = isQwen3VL ? 65536 : 3136;
+    const int defaultMaxPixels = isQwen3VL ? 16777216 : 12845056;
+    const int minPixels = mConfig->config_.value("image_min_pixels", defaultMinPixels);
+    const int maxPixels = mConfig->config_.value("image_max_pixels", defaultMaxPixels);
+    auto resizedSize = qwenVlSmartResize(mVisionHeight, mVisionWidth, align_size, minPixels, maxPixels);
+    if (resizedSize.first == 0 || resizedSize.second == 0) {
+        return {};
     }
-    auto interp = isQwen3VL ? MNN::CV::INTER_CUBIC : MNN::CV::INTER_LINEAR;
-    image = MNN::CV::resize(image, {mVisionWidth, mVisionHeight}, 0, 0, interp, MNN::CV::COLOR_BGR2RGB, mVisionMean,
-                            mVisionNorm);
+    mVisionHeight = resizedSize.first;
+    mVisionWidth = resizedSize.second;
+    image = MNN::CV::resize(image, {mVisionWidth, mVisionHeight}, 0, 0, MNN::CV::INTER_CUBIC, MNN::CV::COLOR_BGR2RGB,
+                            mVisionMean, mVisionNorm);
     image = Express::_Unsqueeze(image, {0});
     image = Express::_Convert(image, NCHW);
     auto patches = Express::_Concat({image, image}, 0);
@@ -1261,8 +1298,10 @@ void Omni::addPositionIds(int t, int h, int w) {
                 }
             }
         }
-        // vision end
-        mPositionIds.push_back();
+        // Match Qwen3-VL MRoPE: after a vision segment, continue from
+        // start + max(llm_grid_h, llm_grid_w), not from the last W index.
+        int next_idx = cur_idx + std::max(h, w);
+        mPositionIds.push_back(next_idx, next_idx, next_idx);
     }
 }
 
@@ -1504,8 +1543,7 @@ VARP Omni::gen_position_ids(int seq_len) {
     auto ptr = positionIds->writeMap<int>();
     if (mContext->gen_seq_len > 0) {
         for (int i = 0; i < seq_len; ++i) {
-            // auto pos = mContext->gen_seq_len + mPositionIds.back() + i;
-            auto pos = mContext->all_seq_len + i;
+            auto pos = mContext->gen_seq_len + mPositionIds.back() + i;
             for (int axis = 0; axis < axes; axis++) {
                 ptr[i + seq_len * axis] = pos;
             }

--- a/transformers/llm/export/utils/vision.py
+++ b/transformers/llm/export/utils/vision.py
@@ -370,7 +370,7 @@ class Qwen2Vision(Vision):
                 h_index = torch.arange(h).view(1, -1, 1).expand(t, -1, w).flatten()
                 w_index = torch.arange(w).view(1, 1, -1).expand(t, h, -1).flatten()
                 position_ids_list.append(torch.stack([t_index, h_index, w_index]) + cur_idx)
-                cur_idx += w
+                cur_idx += max(h, w)
                 vision_idx += 1
         if txt_len > 0:
             text_index = torch.arange(cur_idx, cur_idx + txt_len, dtype=torch.int)

--- a/transformers/llm/export/utils/vision.py
+++ b/transformers/llm/export/utils/vision.py
@@ -267,11 +267,17 @@ class Qwen2Vision(Vision):
         super().__init__(visual, base)
         self.quant_bit = 4
 
+    def refresh_image_resize_config(self):
+        self.llm_config['image_size_unit'] = self.patch_size * self.merge_size
+        self.llm_config['image_min_pixels'] = self.min_pixels
+        self.llm_config['image_max_pixels'] = self.max_pixels
+
     def load(self):
         self.vision_start_id = self.config.vision_start_token_id
         self.vision_end_id = self.config.vision_end_token_id
         self.image_pad_id = self.config.image_token_id
         self.llm_config['image_size'] = self.image_height
+        self.refresh_image_resize_config()
         self.llm_config['vision_start'] = self.vision_start_id
         self.llm_config['vision_end'] = self.vision_end_id
         self.llm_config['image_pad'] = self.image_pad_id
@@ -985,6 +991,7 @@ class Qwen3Vision(Qwen2Vision):
 
         self.min_pixels = 65536
         self.max_pixels = 16777216
+        self.refresh_image_resize_config()
         self.merge_unit = self.merge_size * self.merge_size
         self.deepstack_visual_indexes = visual.deepstack_visual_indexes
         self.num_grid_per_side = visual.num_grid_per_side
@@ -1151,6 +1158,7 @@ class Qwen3_5Vision(Qwen2Vision):
 
         self.min_pixels = 65536
         self.max_pixels = 16777216
+        self.refresh_image_resize_config()
         self.merge_unit = self.merge_size * self.merge_size
         self.num_grid_per_side = visual.num_grid_per_side
         self.pos_embed = visual.pos_embed

--- a/transformers/llm/export/utils/vision.py
+++ b/transformers/llm/export/utils/vision.py
@@ -270,11 +270,17 @@ class Qwen2Vision(Vision):
         super().__init__(visual, base)
         self.quant_bit = 4
 
+    def refresh_image_resize_config(self):
+        self.llm_config['image_size_unit'] = self.patch_size * self.merge_size
+        self.llm_config['image_min_pixels'] = self.min_pixels
+        self.llm_config['image_max_pixels'] = self.max_pixels
+
     def load(self):
         self.vision_start_id = self.config.vision_start_token_id
         self.vision_end_id = self.config.vision_end_token_id
         self.image_pad_id = self.config.image_token_id
         self.llm_config['image_size'] = self.image_height
+        self.refresh_image_resize_config()
         self.llm_config['vision_start'] = self.vision_start_id
         self.llm_config['vision_end'] = self.vision_end_id
         self.llm_config['image_pad'] = self.image_pad_id
@@ -367,7 +373,7 @@ class Qwen2Vision(Vision):
                 h_index = torch.arange(h).view(1, -1, 1).expand(t, -1, w).flatten()
                 w_index = torch.arange(w).view(1, 1, -1).expand(t, h, -1).flatten()
                 position_ids_list.append(torch.stack([t_index, h_index, w_index]) + cur_idx)
-                cur_idx += w
+                cur_idx += max(h, w)
                 vision_idx += 1
         if txt_len > 0:
             text_index = torch.arange(cur_idx, cur_idx + txt_len, dtype=torch.int)
@@ -458,8 +464,8 @@ class Qwen2Vision(Vision):
         w_bar = round(width / factor) * factor
         if h_bar * w_bar > max_pixels:
             beta = math.sqrt((height * width) / max_pixels)
-            h_bar = math.floor(height / beta / factor) * factor
-            w_bar = math.floor(width / beta / factor) * factor
+            h_bar = max(factor, math.floor(height / beta / factor) * factor)
+            w_bar = max(factor, math.floor(width / beta / factor) * factor)
         elif h_bar * w_bar < min_pixels:
             beta = math.sqrt(min_pixels / (height * width))
             h_bar = math.ceil(height * beta / factor) * factor
@@ -988,6 +994,7 @@ class Qwen3Vision(Qwen2Vision):
 
         self.min_pixels = 65536
         self.max_pixels = 16777216
+        self.refresh_image_resize_config()
         self.merge_unit = self.merge_size * self.merge_size
         self.deepstack_visual_indexes = visual.deepstack_visual_indexes
         self.num_grid_per_side = visual.num_grid_per_side
@@ -1154,6 +1161,7 @@ class Qwen3_5Vision(Qwen2Vision):
 
         self.min_pixels = 65536
         self.max_pixels = 16777216
+        self.refresh_image_resize_config()
         self.merge_unit = self.merge_size * self.merge_size
         self.num_grid_per_side = visual.num_grid_per_side
         self.pos_embed = visual.pos_embed


### PR DESCRIPTION
## Description

修复 Qwen3-VL 导出到 MNN 后的多模态输出异常问题。

本 PR 将 MNN Qwen3-VL 的 runtime/export 路径与 HuggingFace/AutoProcessor进行对齐：

1. 对齐huggingface中 Qwen3-VL 的 `smart_resize`
   - 使用 `image_size_unit = patch_size * merge_size`
   - 使用导出的 `image_min_pixels` 和 `image_max_pixels`
   - 对齐 Python round-half-to-even 行为

2. 增加huggingface中 Qwen3-VL resize用的 Pillow库 的 BICUBIC resize 
   - HF/AutoProcessor 使用 Pillow 风格的 BICUBIC 图像缩放
   - 原 MNN runtime 这里使用的是 linear resize
   - 新路径仅作用于 Qwen3-VL

3. 修复 Qwen3-VL decode 阶段 MRoPE position
   - decode 阶段从 prefill 最后的 MRoPE position 继续
   - 不再使用多模态场景下不正确的原始累计 token length 
 
从我的测试结果来看，第3点对精度影响最大。


### 验证结果

#### 端到端验证
修改后模型输出正常。用Qwen3-VL-2B-Instrcut，输入相同的图片和prompt：

- 修改前:  `AnAnAnAnAnAn...` 重复 token 异常
- 修改后:  `An elderly man in a U.S. Navy uniform stands in front of an American flag.`  可理解的图像描述输出，语义上与 Torch/HF greedy 对齐

#### vision部分验证
修改后与 HF/AutoProcessor 的 tensor 的余弦相似度提升到了0.999，对比如下：

| Tensor | Before | After |
| --- | ---: | ---: |
| image patches / pixel values | 0.9920087 | 0.9999987 |
| vision encoder `image_embeds` | 0.9024969 | 0.9999431 |
| `deepstack_feature` | 0.9583789 | 0.9999789 |


### Qwen-VL MRoPE Position Id 修复说明

#### 背景

Qwen2-VL、Qwen2.5-VL、Qwen3-VL 在图像 token 上使用多模态 RoPE
position ids。一个视觉段不是单一路径的位置编码，而是三路位置：

- temporal position
- height position
- width position

在 MNN runtime 中，Qwen-VL 图像路径会先把图片转换成视觉 grid，然后按
merge 后的尺寸调用：

```cpp
addPositionIds(grid_t, grid_h / merge_size, grid_w / merge_size);
```

这个三参数调用就是 Qwen-VL 风格的视觉 MRoPE position id 生成路径。

#### 问题

修复前，Qwen-VL 的 position id 生成逻辑在视觉段结束后，只按视觉 grid
的宽度推进下一个文本位置。

Python export 侧原逻辑是：

```python
cur_idx += w
```

C++ runtime 侧视觉段结束位置原本依赖最后一个 position entry。由于
`MropeInfo::back()` 返回的是最后一个 width position，高图场景下，后续文本
position 可能会和视觉 token 的 height position 范围重叠。

例如一张高图经过 merge 后得到：

```text
grid = (1, 38, 8)
```

视觉 token 的 height position 会覆盖到：

```text
cur_idx + 37
```

但如果只按宽度推进，下一个文本位置会变成：

```text
cur_idx + 8
```

这样后续文本 token 和 decode token 会落在视觉 token 已经使用过的 height
position 范围内，导致多模态位置编码重叠。

#### 官方实现对照

Hugging Face Qwen-VL 系列实现里，视觉段结束后不是按宽度推进，而是按最大
空间维度推进：

官方 GitHub 路径：

- Qwen3-VL 生成后的模型文件：
  `https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py`
- 源 modular 文件：
  `https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen3_vl/modular_qwen3_vl.py`

关键代码在 `Qwen3VLModel.get_rope_index()` 中。视觉 token 段会先根据当前
模态取对应的 `grid_thw`，然后生成三路视觉 position ids，最后按最大空间维度
推进 `current_pos`：

```python
grid_thw = next(grid_iters[modality_type])
vision_position_ids = self.get_vision_position_ids(
    current_pos, grid_thw, 1, spatial_merge_size, device=input_ids.device
)
llm_pos_ids_list.append(vision_position_ids)
current_pos += max(grid_thw[1], grid_thw[2]) // spatial_merge_size
```

其中 `get_vision_position_ids()` 会把原始 `grid_thw` 转成 LLM 侧的 merged
grid：

```python
llm_grid_t = grid_thw[0].item() // temp_merge_size
llm_grid_h = grid_thw[1].item() // spatial_merge_size
llm_grid_w = grid_thw[2].item() // spatial_merge_size
```

因此，官方推进逻辑的含义是：

```python
current_pos += max(grid_thw[1], grid_thw[2]) // spatial_merge_size
```

其中：

- `grid_thw[1]` 是 spatial merge 前的视觉 grid height
- `grid_thw[2]` 是 spatial merge 前的视觉 grid width
- `spatial_merge_size` 用于把原始视觉 grid 转成 LLM 侧使用的 merged grid

所以换算到 MNN runtime 里，已经传入 `addPositionIds(t, h, w)` 的 `h/w`
本身就是 merge 后的 LLM visual grid 尺寸，对应推进逻辑应该是：

```text
next position = current position + max(merged_grid_h, merged_grid_w)
```

也就是：

```cpp
cur_idx + max(h, w)
```

#### Runtime 调用链判断

`Omni::addPositionIds()` 有两类调用方式。

文本和音频使用一维 position id 路径：

```cpp
addPositionIds(txt_ids.size());
addPositionIds(embed_len);
```

这些调用只传入 `t`，所以会进入普通 text/audio 分支：

```cpp
if (h < 0 && w < 0) {
    // text position ids
}
```

真正进入视觉 MRoPE 分支的只有三参数调用：

```cpp
addPositionIds(grid_t, grid_h / merge_size, grid_w / merge_size);
```

这个调用只出现在 `qwen2VisionProcess()` 里。

runtime 的视觉模型分发逻辑如下：

```cpp
if (inputNames.size() >= 3 && inputNames[0] == "patches") {
    imgIds = qwen2VisionProcess(image);
} else if (inputNames[0] == "pixel_values") {
    ...
} else if (inputNames.size() >= 2 && inputNames[0] == "input_patches") {
    imgIds = gemma4VisionProcess(image);
} else {
    imgIds = defaultVisionProcess(image);
}
```

因此，C++ runtime 里的这次修复只影响 `inputNames[0] == "patches"` 的
Qwen-VL 风格视觉路径。SmolVLM、MiniCPM-V、Gemma4 以及 default vision
path 不会走三参数 `addPositionIds(t, h, w)`，所以不会受这个视觉 MRoPE
修复影响。

#### 修复内容

##### C++ Runtime

文件：

```text
transformers/llm/engine/src/omni.cpp
```

在 `Omni::addPositionIds(int t, int h, int w)` 中，视觉段结束位置改为显式
设置成 `cur_idx + max(h, w)`：

```cpp
int next_idx = cur_idx + std::max(h, w);
mPositionIds.push_back(next_idx, next_idx, next_idx);
```

这样 runtime 侧的 MRoPE continuation point 和官方 Qwen-VL 实现一致，可以避免
高图场景下后续文本位置和视觉 height position 重叠。

##### Python Export

文件：

```text
transformers/llm/export/utils/vision.py
```

在 `Qwen2Vision.get_position_ids()` 中，把 cursor 更新从只按宽度推进：

```python
cur_idx += w
```

改为按 merge 后最大空间维度推进：

```python
cur_idx += max(h, w)
```

这样 export 侧生成的 Qwen-VL position ids 与 runtime 和官方实现保持一致。

#### 影响范围

Python 侧修复位于 `Qwen2Vision`，因此会影响复用这套 Qwen-VL 视觉 position
id 逻辑的模型，包括：

- Qwen2-VL
- Qwen2.5-VL
- Qwen2.5-Omni 的视觉部分
- Qwen3-VL
- Qwen3-VL-MoE

C++ runtime 侧修复只影响由 `inputNames[0] == "patches"` 选择的 Qwen-VL
视觉路径。

不会影响：

- text-only position ids
- audio position ids
- `pixel_values` 路径，例如 SmolVLM、MiniCPM-V
- `input_patches` 路径，例如 Gemma4
- default vision path

原因是这些路径不会进入三参数视觉 MRoPE `addPositionIds(t, h, w)` 分支。

#### 验证

可以用高图验证这个问题，例如 merge 后视觉 grid 为：

```text
grid = (1, 38, 8)
```

修复前，视觉段结束后只按宽度 `8` 推进，后续文本位置可能落在视觉 height
position 范围内。

修复后，视觉段结束位置变成：

```text
cur_idx + max(38, 8)
```

后续文本和 decode token 会从完整视觉空间范围之后继续。

本地已完成的基础验证：

```bash
python -m py_compile transformers/llm/export/utils/vision.py
git diff --check
```

并完成 Qwen3-VL-2B-Instruct 的 export、编译和 runtime demo：

```bash
conda run -n mnn python transformers/llm/export/llmexport.py \
  --path /tmp/models/Qwen3-VL-2B-Instruct \
  --export mnn \
  --quant_bit 16 \
  --lm_quant_bit 16 \
  --visual_quant_bit 16 \
  --dst_path /tmp/qwen3vl_mnn

cmake -S . -B build-qwen3vl \
  -DMNN_BUILD_LLM=ON \
  -DMNN_BUILD_LLM_OMNI=ON \
  -DMNN_LOW_MEMORY=ON

cmake --build build-qwen3vl --target llm_demo -j16

./build-qwen3vl/llm_demo /tmp/qwen3vl_mnn/config.json /tmp/qwen3vl_prompt.txt 64
```

demo 输出：

```text
An elderly man in a navy uniform stands in front of an American flag.
```

运行统计：

```text
prompt tokens num = 187
decode tokens num = 16
vision time = 19.20 s
pixels_mp = 0.17 MP
prefill time = 34.31 s
decode time = 21.79 s
prefill speed = 5.45 tok/s
decode speed = 0.73 tok/s
vision speed = 0.009 MP/s
```


### 其他验证步骤

#### 端到端验证
准备公开图片和 prompt：

```bash
curl -L \
  "https://raw.githubusercontent.com/python-pillow/Pillow/main/Tests/images/hopper.jpg" \
  -o /tmp/qwen3vl_public_source.jpg

python - <<'PY'
from PIL import Image

img = Image.open("/tmp/qwen3vl_public_source.jpg").convert("RGB")
img = img.resize((720, 324), Image.Resampling.BICUBIC)
img.save("/tmp/qwen3vl_review_720x324.jpg")
print(img.size)
PY

cat >/tmp/qwen3vl_prompt.txt <<'EOF'
<img>/tmp/qwen3vl_review_720x324.jpg</img> Describe the image in one short sentence.
EOF
```

构建 MNN runtime：

```bash
cmake -S . -B build-qwen3vl \
  -DMNN_BUILD_LLM=ON \
  -DMNN_BUILD_LLM_OMNI=ON \
  -DMNN_LOW_MEMORY=ON 

cmake --build build-qwen3vl --target llm_demo -j16

```

导出 fp16 MNN 模型：

```bash
conda run -n mnn python transformers/llm/export/llmexport.py \
  --path /tmp/models/Qwen3-VL-2B-Instruct \
  --export mnn \
  --quant_bit 16 \
  --lm_quant_bit 16 \
  --visual_quant_bit 16 \
  --dst_path /tmp/qwen3vl_mnn
```

检查 patch 后导出的配置：

```bash
conda run -n mnn python - <<'PY'
import json

c = json.load(open("/tmp/qwen3vl_mnn/llm_config.json"))
print("image_size_unit =", c.get("image_size_unit"))
print("image_min_pixels =", c.get("image_min_pixels"))
print("image_max_pixels =", c.get("image_max_pixels"))
PY
```

期望输出：

```text
image_size_unit=32
image_min_pixels=65536
image_max_pixels=16777216
```

设置 greedy 采样：

```bash
conda run -n mnn python - <<'PY'
import json

p = "/tmp/qwen3vl_mnn/config.json"
c = json.load(open(p))
c["sampler_type"] = "greedy"
c["temperature"] = 1.0
json.dump(c, open(p, "w"), ensure_ascii=False, indent=4)
PY
```

Torch/HF greedy 参考输出：

```bash
conda run -n mnn python - <<'PY'
import torch
from PIL import Image
from transformers import AutoProcessor, AutoModelForImageTextToText

model_path = "/tmp/models/Qwen3-VL-2B-Instruct"
image = Image.open("/tmp/qwen3vl_review_720x324.jpg").convert("RGB")
prompt = "Describe the image in one short sentence."

processor = AutoProcessor.from_pretrained(model_path, trust_remote_code=True)
model = AutoModelForImageTextToText.from_pretrained(
    model_path,
    dtype=torch.float16,
    low_cpu_mem_usage=True,
    trust_remote_code=True,
)
model.eval()

messages = [{
    "role": "user",
    "content": [{"type": "image", "image": image}, {"type": "text", "text": prompt}],
}]
text = processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
inputs = processor(text=[text], images=[image], return_tensors="pt")

with torch.no_grad():
    out = model.generate(**inputs, do_sample=False, max_new_tokens=32)

new_tokens = out[:, inputs["input_ids"].shape[1]:]
print(processor.batch_decode(new_tokens, skip_special_tokens=True)[0])
PY
```

MNN greedy 输出验证：

```bash
./build-qwen3vl/llm_demo /tmp/qwen3vl_mnn/config.json /tmp/qwen3vl_prompt.txt 64 
```

同图同 prompt 的端到端 greedy smoke test：

```text
before: 重复 token 异常，例如 AnAnAn...
after:  可理解的图像描述输出，语义上与 Torch/HF greedy 对齐
```

#### vision部分验证
与 HF/AutoProcessor 的 tensor 对比：
验证方式是使用同一张图片和同一份 Qwen3-VL processor 配置：

1. 用 HF `AutoProcessor` 导出参考 tensor：
   - `pixel_values`
   - `image_grid_thw`
2. 在 MNN runtime 中临时 dump 对应的中间结果：
   - image preprocessing 后、进入 vision encoder 前的 image patches
   - vision encoder 输出 `image_embeds`
   - Qwen3-VL 使用的 `deepstack_feature`
3. 将 HF 和 MNN 的 tensor reshape 到相同形状后计算 cosine similarity。



该对比用于验证 `smart_resize`、Pillow-like BICUBIC resize、归一化、patch layout 以及 vision feature 是否对齐；它比最终文本输出更适合作为数值正确性证据。

临时 dump 代码位置和示例：

1. HF 参考 tensor dump：

```python
import numpy as np
from PIL import Image
from transformers import AutoProcessor

model_path = "/tmp/models/Qwen3-VL-2B-Instruct"
image_path = "/tmp/qwen3vl_review_720x324.jpg"

processor = AutoProcessor.from_pretrained(model_path, trust_remote_code=True)
image = Image.open(image_path).convert("RGB")

inputs = processor(
    text=[
        "<|im_start|>user\n"
        "<|vision_start|><|image_pad|><|vision_end|>"
        "Describe the image in one short sentence.<|im_end|>\n"
        "<|im_start|>assistant\n"
    ],
    images=[image],
    return_tensors="pt",
)

np.save("/tmp/hf_pixel_values.npy", inputs["pixel_values"].cpu().float().numpy())
np.save("/tmp/hf_image_grid_thw.npy", inputs["image_grid_thw"].cpu().numpy())
print("pixel_values:", tuple(inputs["pixel_values"].shape))
print("image_grid_thw:", inputs["image_grid_thw"])
```

2. MNN runtime 临时 dump 插桩。

在 `transformers/llm/engine/src/omni.cpp` 中临时加入 helper：

```cpp
static void dumpFloatVar(const std::string& path, MNN::Express::VARP var) {
    auto info = var->getInfo();
    if (info == nullptr) {
        return;
    }
    const float* ptr = var->readMap<float>();
    if (ptr == nullptr) {
        return;
    }

    int size = 1;
    for (auto d : info->dim) {
        size *= d;
    }

    FILE* fp = fopen(path.c_str(), "wb");
    if (fp == nullptr) {
        return;
    }
    fwrite(ptr, sizeof(float), size, fp);
    fclose(fp);
}
```

在 `Omni::qwen2VisionProcess(VARP image)` 中，最终送入 vision encoder 的 image patches 变量就是 `patches`。在最后一次 reshape 之后、构造 `moduleInputs` 之前加入：

```cpp
patches =
    Express::_Reshape(patches, {grid_t * grid_h * grid_w, channel * temporal_patch_size * patch_size * patch_size});
dumpFloatVar("/tmp/mnn_pixel_values.f32", patches);
```

在 vision encoder 输出后，`outputs[0]` 是 `image_embeds`。在 `mVisionModule->onForward(moduleInputs)` 返回后加入：

```cpp
auto outputs = mVisionModule->onForward(moduleInputs);
auto imageEmbedding = outputs[0];
dumpFloatVar("/tmp/mnn_image_embeds.f32", imageEmbedding);
```

当前 Qwen3-VL runtime 会在 `outputs.size() == 2` 时把 `outputs[1]` 存入 `mDeepStackEmbeddings`，因此这里的 `outputs[1]` 就是后续 LLM 使用的 `deepstack_feature`。在现有 push 逻辑前加入：

```cpp
if (outputs.size() == 2) {
    dumpFloatVar("/tmp/mnn_deepstack_feature.f32", outputs[1]);
    mDeepStackEmbeddings.push_back(outputs[1]);
}
```

3. cosine similarity 计算：

```python
import numpy as np

def cosine(a, b):
    a = a.reshape(-1).astype(np.float64)
    b = b.reshape(-1).astype(np.float64)
    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)))

hf_pixel = np.load("/tmp/hf_pixel_values.npy")
mnn_pixel = np.fromfile("/tmp/mnn_pixel_values.f32", dtype=np.float32).reshape(hf_pixel.shape)

print("pixel_values cosine:", cosine(hf_pixel, mnn_pixel))
print("pixel_values max abs diff:", np.max(np.abs(hf_pixel - mnn_pixel)))
print("pixel_values mean abs diff:", np.mean(np.abs(hf_pixel - mnn_pixel)))

# image_embeds / deepstack_feature 同理：
# hf = np.load("/tmp/hf_image_embeds.npy")
# mnn = np.fromfile("/tmp/mnn_image_embeds.f32", dtype=np.float32).reshape(hf.shape)
# print(cosine(hf, mnn))
```


| Tensor | Before | After |
| --- | ---: | ---: |
| image patches / pixel values | 0.9920087 | 0.9999987 |
| vision encoder `image_embeds` | 0.9024969 | 0.9999431 |
| `deepstack_feature` | 0.9583789 | 0.9999789 |




## Module

LLM

## Type

- [ ] Feature
- [x] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [x] Tested on relevant platform(s)
- [x] No unrelated format or style changes included
