### PR TITLE
[CPU:Bugfix] Fix ConvInt8 SIGSEGV when Conv lacks quantized weight

### DIFF
--- a/source/backend/cpu/CPUBackend.cpp
+++ b/source/backend/cpu/CPUBackend.cpp
@@ -654,6 +654,31 @@ static OpType _getRealOpType(OpType opType) {
             return opType;
     }
 }
+
+// A Conv / DepthwiseConv may be promoted to Int8 execution purely based on the
+// int8 quantAttr of its input/output tensors. Guard against promoting an op that
+// carries no quantized weight data (e.g. a Conv listed in skip_quant_op_names but
+// still surrounded by int8 tensors): the ConvInt8 executor would later dereference
+// a missing quan weight (null symmetricQuan) and crash. Non-conv ops are unaffected.
+static bool _convHasQuantWeight(const MNN::Op* op) {
+    auto opType = op->type();
+    if (opType != OpType_Convolution && opType != OpType_ConvolutionDepthwise) {
+        return true;
+    }
+    auto conv2d = op->main_as_Convolution2D();
+    if (nullptr == conv2d) {
+        return false;
+    }
+    auto quan = conv2d->quanParameter();
+    if (nullptr != quan && (nullptr != quan->buffer() || nullptr != conv2d->external())) {
+        return true;
+    }
+    auto symmetric = conv2d->symmetricQuan();
+    if (nullptr != symmetric && nullptr != symmetric->weight()) {
+        return true;
+    }
+    return false;
+}
 void* CPUBackend::onMapTensor(Tensor::MapType mtype, Tensor::DimensionType dtype, const Tensor* srcTensor) {
     if (static_cast<int>(getBytes(this, srcTensor)) != srcTensor->getType().bytes()) {
         return nullptr;
@@ -732,7 +757,7 @@ Execution* CPUBackend::onCreate(const std::vector<Tensor*>& inputs, const std::v
     if (outputs.size() > 0 && inputs.size() > 0) {
         bool outputQuant = TensorUtils::getDescribe(outputs[0])->quantAttr != nullptr && TensorUtils::getDescribe(outputs[0])->quantAttr->type == DataType_DT_INT8;
         bool inputQuant = TensorUtils::getDescribe(inputs[0])->quantAttr != nullptr && TensorUtils::getDescribe(inputs[0])->quantAttr->type == DataType_DT_INT8;
-        if (inputQuant && outputQuant) {
+        if (inputQuant && outputQuant && _convHasQuantWeight(op)) {
             opType = _getRealOpType(opType);
         }
     }

--- a/source/backend/cpu/CPUConvolution.cpp
+++ b/source/backend/cpu/CPUConvolution.cpp
@@ -342,6 +342,16 @@ public:
             quanCommon = ConvolutionCommon::load(op, backend, false, true);
 
         }
+        // A ConvInt8 op must carry quantized weight data, either as quanCommon
+        // (from quanParameter / external) or as an inline symmetricQuan weight.
+        // Without either, DenseConvInt8TiledExecutor would dereference a null
+        // weight pointer and crash. Reject explicitly instead.
+        if (nullptr == quanCommon &&
+            (nullptr == convOp->symmetricQuan() || nullptr == convOp->symmetricQuan()->weight())) {
+            MNN_ERROR("CPUConvInt8Creator: op '%s' has no quantized weight data for ConvInt8 execution\n",
+                      op->name() ? op->name()->c_str() : "unknown");
+            return nullptr;
+        }
         // auto res = CPUConvolution::makeResourceInt8(backend, op, core->pack);
         // return new DenseConvInt8TiledExecutor(backend, op, res);
 


### PR DESCRIPTION
在 `CPUConvolution.cpp` 和 `CPUBackend.cpp` 中添加了检查，确保在执行 `ConvInt8` 操作时具有量化权重数据，以防止因缺少量化权重而导致的空指针解引用崩溃。 

## Description

<!-- Brief description of the changes -->

## Module

<!-- Which module does this PR affect? e.g. LLM, CPU, Metal, CUDA, OpenCL, Core, Infra -->

## Type

- [ ] Feature
- [ ] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [ ] Commit message follows `[Module:Type] Description` format
- [ ] Code compiles without errors
- [ ] Tested on relevant platform(s)
- [ ] No unrelated format or style changes included
