### PR TITLE
[Infra:Chore] Remove CoreML suffix from iOS release package

### DIFF
--- a/.github/workflows/mnn_release.yml
+++ b/.github/workflows/mnn_release.yml
@@ -182,7 +182,7 @@ jobs:
     needs: [setup]
     runs-on: macos-latest
     env:
-      PACKAGENAME: mnn_${{ needs.setup.outputs.VERSION }}_ios_armv82_cpu_metal_coreml
+      PACKAGENAME: mnn_${{ needs.setup.outputs.VERSION }}_ios_armv82_cpu_metal
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
## Summary

Remove the `coreml` suffix from the iOS artifact name produced by the `mnn_release` workflow.

## Why

The iOS release job currently builds through `package_scripts/ios/buildiOS.sh`, which enables Metal but does not pass `-DMNN_COREML=ON`. Since CoreML is not included in that package, the artifact suffix was misleading.

## Impact

Release artifacts now better match the actual backend configuration: iOS arm64 + ARM82 + CPU + Metal.

## Validation

- Checked the staged workflow diff.
- Ran `git diff --cached --check`.
- Commit hook checks passed during commit.
