### PR TITLE
[LLM:Bugfix] Honor --chunk_size when generating QNN prefill IO

### DIFF
--- a/source/backend/qnn/npu_convert.py
+++ b/source/backend/qnn/npu_convert.py
@@ -83,7 +83,7 @@ def process_src(task):
         "-t", "x86_64-linux-clang",
         "-o", workdir,
     ]
-    compile_result = run_subprocess(compile_cmd, retries=3)
+    compile_result = run_subprocess(compile_cmd, cwd=workdir, retries=3)
     if compile_result.returncode != 0:
         raise RuntimeError(f"Compile failed for src={src}: {' '.join(compile_cmd)}")
 

--- a/transformers/llm/export/llmexport.py
+++ b/transformers/llm/export/llmexport.py
@@ -20,6 +20,7 @@ from utils.mnn_converter import MNNConverter
 from utils.awq_quantizer import AwqQuantizer
 from utils.smooth_quantizer import SmoothQuantizer
 from utils.omni_quantizer import OmniQuantizer
+from utils.seqmse_quantizer import SeqMSEQuantizer
 from utils.torch_utils import onnx_export
 
 class LlmExporter(torch.nn.Module):
@@ -584,6 +585,27 @@ class LlmExporter(torch.nn.Module):
         self.smooth_quantizer = SmoothQuantizer(model = self.model, max_calib_samples = calib_samples, act_bit=self.args.act_bit, act_sym=self.args.act_sym, generate_for_npu=self.args.generate_for_npu)
         self.smooth_quantizer.quantize()
 
+    def seqmse_quant(self):
+        total_lines = 8
+        if self.args.calib_data:
+            print(f"检测到 calib_data: {self.args.calib_data}，开始读取...")
+            self.model.args.calib_data = self.args.calib_data
+            if os.path.exists(self.args.calib_data):
+                with open(self.args.calib_data, 'r', encoding='utf-8') as f:
+                    total_lines = sum(1 for _ in f)
+            else:
+                print(f"错误：找不到文件 {self.args.calib_data}")
+
+        calib_samples = min(total_lines, self.args.seqmse_samples)
+        self.seqmse_quantizer = SeqMSEQuantizer(
+            model=self.model,
+            max_calib_samples=calib_samples,
+            max_calib_seq_len=self.args.seqmse_seq_len,
+            num_candidates=self.args.seqmse_candidates,
+            max_tokens_per_linear=self.args.seqmse_tokens,
+        )
+        self.seqmse_quantizer.quantize()
+
     def export_vision(self):
         if self.visual is None:
             return
@@ -686,6 +708,8 @@ class LlmExporter(torch.nn.Module):
                 self.awq_quant()
             if self.args.smooth:
                 self.smooth_quant()
+            if self.args.seqmse:
+                self.seqmse_quant()
         export_mnn = export_type == 'mnn'
         self.mnn_converter = MNNConverter(self) if export_mnn else None
         self.export_talker()
@@ -861,6 +885,11 @@ def build_args(parser):
     parser.add_argument('--ppl', action='store_true', help='Whether or not to get all logits of input tokens.')
     parser.add_argument('--awq', action='store_true', help='Whether or not to use awq quant.')
     parser.add_argument('--hqq', action='store_true', help='Whether or not to use hqq quant.')
+    parser.add_argument('--seqmse', action='store_true', help='Whether or not to use SeqMSE weight encoding search.')
+    parser.add_argument('--seqmse_candidates', type=int, default=20, help='Number of SeqMSE clipping candidates, default is 20.')
+    parser.add_argument('--seqmse_samples', type=int, default=8, help='Number of calibration samples for SeqMSE, default is 8.')
+    parser.add_argument('--seqmse_seq_len', type=int, default=256, help='Max calibration sequence length for SeqMSE, default is 256.')
+    parser.add_argument('--seqmse_tokens', type=int, default=512, help='Max tokens kept per Linear during SeqMSE search, default is 512.')
     parser.add_argument('--omni', action='store_true', help='Whether or not to use omni quant.')
     parser.add_argument('--transformer_fuse', action='store_true', help='Whether or not to fuse vision transformer op.')
     parser.add_argument('--group_conv_native', action='store_true', help='Whether or not to keep native group_conv.')

--- a/transformers/llm/export/npu/generate_llm_qnn.py
+++ b/transformers/llm/export/npu/generate_llm_qnn.py
@@ -14,7 +14,11 @@ def makeIO(args, model_name, inputjson, external_file = None):
     cache = os.path.join(os.getcwd(), args.cache_path)
     output = os.path.join(cache, 'testdir')
     os.makedirs(output, exist_ok=True)
-    print(os.popen(exe + " " + model + " " + inputjson + " " + output + " " + external_file).read())
+    process = subprocess.Popen(exe + " " + model + " " + inputjson + " " + output + " " + external_file, bufsize=1, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd = cache, text=True, shell=True)
+    for line in process.stdout:
+        print(line, end='')
+    process.wait()
+    return process.returncode
 
 def makeIOJson(args, seq_len, hidden_size, mask_type):
     config = {
@@ -261,17 +265,20 @@ def output_qnn(args):
 def convert_qnn(args, model_name, inputjson, external_file, ids):
     sta = time.time()
     print("Step1: Make IO")
-    makeIO(args, model_name, inputjson, external_file)
+    if makeIO(args, model_name, inputjson, external_file) != 0:
+        raise RuntimeError("generateIO failed")
     end = time.time()
     print("Cost: ", end - sta, ' s')
     sta = end
     print("Step2: Seperate Model")
-    seperate(args, model_name, ids)
+    if seperate(args, model_name, ids) != 0:
+        raise RuntimeError("compilefornpu failed")
     end = time.time()
     print("Cost: ", end - sta, ' s')
     sta = end
     print("Step3: Compile to QNN")
-    compile_qnn(args)
+    if compile_qnn(args) != 0:
+        raise RuntimeError("npu_convert.py failed")
     end = time.time()
     print("Cost: ", end - sta, ' s')
     print("Step4: Move result file to ", args.model)
@@ -328,7 +335,7 @@ def convert_llm(args):
     
     ids = [0, 1]
     external_file = os.path.join(os.getcwd(), args.model, 'llm.mnn.weight')
-    makeIOJson(args, 128, hidden_size, mask_type)
+    makeIOJson(args, args.chunk_size, hidden_size, mask_type)
     inputjson = os.path.join(cache, 'input.json')
     convert_qnn(args, 'llm.mnn', inputjson, external_file, ids)
 

--- a/transformers/llm/export/utils/mnn_converter.py
+++ b/transformers/llm/export/utils/mnn_converter.py
@@ -6,6 +6,7 @@ import torch
 import numpy as np
 
 from .torch_utils import quant as torch_quant
+from .torch_utils import quant_from_encoding
 from .torch_utils import onnx_export
 from tqdm import tqdm
 from .spinner import spinner_run
@@ -289,7 +290,7 @@ class MNNConverter:
             json.dump(mnn_graph, file, ensure_ascii=False, indent=4)
         return self.mnn_weight_path
 
-    def quant(self, weight, quant_bit, quant_block, symmetric):
+    def quant(self, weight, quant_bit, quant_block, symmetric, name=None):
         if self.exporter.args.skip_weight:
             # Skip expensive quantization when skip_weight is enabled
             oc, ic = weight.shape
@@ -306,6 +307,21 @@ class MNNConverter:
             q_weight_num = (oc * ic * quant_bit + 7) // 8
             q_weight = torch.zeros(q_weight_num, dtype=torch.uint8)
             return q_weight, alpha
+
+        encodings = getattr(self.exporter.model, 'seqmse_encodings', None)
+        if encodings is not None and name in encodings:
+            encoding = encodings[name]
+            if (encoding["quant_bit"] == quant_bit and
+                    encoding["quant_block"] == quant_block and
+                    encoding["symmetric"] == symmetric):
+                return quant_from_encoding(
+                    weight.cpu(),
+                    quant_bit,
+                    quant_block,
+                    symmetric,
+                    encoding["scale"],
+                    encoding["zero"],
+                )
 
         q_weight, alpha = torch_quant(weight.cpu(), quant_bit, quant_block, symmetric, self.args.awq, self.args.hqq)
         return q_weight, alpha
@@ -333,7 +349,7 @@ class MNNConverter:
         header_length = dim_num + dim_length + map_length
         return header_length, shape_dtype == np.int32
 
-    def build_weight(self, linear, quant_bit, quant_block, symmetric):
+    def build_weight(self, linear, quant_bit, quant_block, symmetric, name=None):
         ic, oc = linear.in_features, linear.out_features
         if quant_bit == 16:
             if self.exporter.args.skip_weight:
@@ -347,7 +363,7 @@ class MNNConverter:
         else:
             q_min = 1
             assert(quant_bit in (1, 2, 3, 4, 8))
-            q_weight, alpha = self.quant(linear.weight.data, quant_bit, quant_block, symmetric)
+            q_weight, alpha = self.quant(linear.weight.data, quant_bit, quant_block, symmetric, name)
             header_len, shape_int32 = self.write_header(ic, oc, quant_bit)
             scale_fp16 = (self.args.scale_bit == 16)
             alpha_dtype_size = 2 if scale_fp16 else 4
@@ -549,7 +565,7 @@ class MNNConverter:
         if is_lm and self.lm_weight is not None:
             external, q_min, shape_int32, header_len = self.lm_weight
         else:
-            external, q_min, shape_int32, header_len = self.build_weight(linear, quant_bit, quant_block, quant_sym)
+            external, q_min, shape_int32, header_len = self.build_weight(linear, quant_bit, quant_block, quant_sym, name)
         if is_lm and self.lm_weight is None:
             self.lm_weight = [external, q_min, shape_int32, header_len]
         if is_lm and self.args.tie_word_embeddings:

--- a/transformers/llm/export/utils/seqmse_quantizer.py
+++ b/transformers/llm/export/utils/seqmse_quantizer.py
@@ -1,0 +1,291 @@
+import functools
+import inspect
+import gc
+from collections import defaultdict
+
+import torch
+import torch.nn.functional as F
+from tqdm import tqdm
+
+from .smooth_quantizer import SmoothQuantizer
+from .torch_utils import _get_quant_block_size
+
+
+class SeqMSEQuantizer:
+    def __init__(
+        self,
+        model,
+        max_calib_samples=8,
+        max_calib_seq_len=256,
+        num_candidates=20,
+        max_tokens_per_linear=512,
+    ):
+        self.model = model
+        self.tokenizer = model.tokenizer
+        self.quant_bit = model.args.quant_bit
+        self.quant_block = model.args.quant_block
+        self.symmetric = model.args.sym
+        self.calib_data = 'wikitext' if model.args.calib_data is None else model.args.calib_data
+        self.max_calib_samples = max_calib_samples
+        self.max_calib_seq_len = max_calib_seq_len
+        self.num_candidates = num_candidates
+        self.max_tokens_per_linear = max_tokens_per_linear
+        self.best_device = SmoothQuantizer.get_best_device()
+        self.modules = self.model.blocks
+        self.samples = SmoothQuantizer.get_calib_dataset(
+            data=self.calib_data,
+            tokenizer=self.tokenizer,
+            n_samples=max_calib_samples,
+            max_seq_len=max_calib_seq_len,
+            split='train',
+        )
+        self.encodings = {}
+        self.float_inputs = defaultdict(list)
+        self.quant_inputs = defaultdict(list)
+        self.stats = {}
+
+    @staticmethod
+    def _sanitize_kwargs(inputs_kwargs, module):
+        module_signature = inspect.signature(module.forward).parameters
+        return {k: v for k, v in inputs_kwargs.items() if k in module_signature}
+
+    @staticmethod
+    def _module_forward(x, module, module_kwargs):
+        SmoothQuantizer.clear_block_cache(module)
+        output = module(x, **module_kwargs)
+        if isinstance(output, tuple):
+            output = output[0]
+        SmoothQuantizer.clear_block_cache(module)
+        return output
+
+    @staticmethod
+    def _get_named_linears(module):
+        return {name: m for name, m in module.named_modules() if isinstance(m, torch.nn.Linear)}
+
+    @staticmethod
+    def _module_dtype(module):
+        for submodule in module.modules():
+            if isinstance(submodule, torch.nn.Linear):
+                return submodule.weight.dtype
+        for param in module.parameters():
+            return param.dtype
+        return torch.float32
+
+    def _make_full_name(self, layer_idx, name):
+        return f'/layers.{layer_idx}/{name.replace(".", "/")}/Linear'
+
+    def _get_first_input(self, samples):
+        if isinstance(samples, (list, tuple)):
+            sample = torch.cat(samples, dim=1)
+        else:
+            sample = samples
+        if sample.numel() > self.max_calib_seq_len:
+            sample = sample.reshape(1, -1)[:, :self.max_calib_seq_len]
+        seq_len = sample.numel()
+        new_tokens = 0
+        inps = self.model.embedding(sample).to(self.best_device)
+        position_ids = self.model.get_position_ids(seq_len, new_tokens, sample)
+        layer_kwargs = {
+            "rotary_pos_emb": self.model.rotary(position_ids).to(self.best_device),
+            "attention_mask": self.model.get_attention_mask(seq_len, new_tokens).to(self.best_device),
+        }
+        return layer_kwargs, inps
+
+    def _collect_float_inputs(self, layer_idx, layer, named_linears, inps, module_kwargs):
+
+        def cast_input_hook(module, x):
+            x = x[0] if isinstance(x, tuple) else x
+            return (x.to(module.weight.dtype),)
+
+        def cache_input_hook(module, x, y, name):
+            x = x[0] if isinstance(x, tuple) else x
+            x = x.detach().cpu()
+            hidden = x.shape[-1]
+            x = x.reshape(-1, hidden)
+            if x.shape[0] > self.max_tokens_per_linear:
+                x = x[:self.max_tokens_per_linear]
+            self.float_inputs[self._make_full_name(layer_idx, name)].append(x)
+
+        handles = []
+        for name, linear in named_linears.items():
+            handles.append(linear.register_forward_pre_hook(cast_input_hook))
+            handles.append(linear.register_forward_hook(functools.partial(cache_input_hook, name=name)))
+        out = self._module_forward(inps, layer, self._sanitize_kwargs(module_kwargs, layer))
+        for h in handles:
+            h.remove()
+        return out
+
+    def _run_quant_layer(self, layer_idx, layer, named_linears, inps, module_kwargs):
+
+        def cast_input_hook(module, x):
+            x = x[0] if isinstance(x, tuple) else x
+            return (x.to(module.weight.dtype),)
+
+        def quant_hook(module, x, y, name):
+            full_name = self._make_full_name(layer_idx, name)
+            q_in = x[0] if isinstance(x, tuple) else x
+            flat_q_in = q_in.detach().cpu().reshape(-1, q_in.shape[-1])
+            if flat_q_in.shape[0] > self.max_tokens_per_linear:
+                flat_q_in = flat_q_in[:self.max_tokens_per_linear]
+            self.quant_inputs[full_name].append(flat_q_in)
+
+            if full_name not in self.encodings:
+                if full_name not in self.float_inputs:
+                    return y
+                ref_inputs = torch.cat(self.float_inputs[full_name], dim=0)
+                quant_inputs = torch.cat(self.quant_inputs[full_name], dim=0)
+                self.encodings[full_name] = self._search_linear(module, ref_inputs, quant_inputs)
+                baseline_mse = self.encodings[full_name]["baseline_mse"]
+                best_mse = self.encodings[full_name]["best_mse"]
+                improvement = 0.0 if baseline_mse <= 0 else (baseline_mse - best_mse) / baseline_mse
+                self.stats[full_name] = {
+                    "baseline_mse": baseline_mse,
+                    "best_mse": best_mse,
+                    "improvement": improvement,
+                }
+
+            dq_weight = self._dequantize_weight_from_encoding(module, self.encodings[full_name]).to(q_in.device)
+            bias = None if module.bias is None else module.bias.to(q_in.device)
+            return F.linear(q_in, dq_weight, bias)
+
+        handles = []
+        for name, linear in named_linears.items():
+            handles.append(linear.register_forward_pre_hook(cast_input_hook))
+            handles.append(linear.register_forward_hook(functools.partial(quant_hook, name=name)))
+        out = self._module_forward(inps, layer, self._sanitize_kwargs(module_kwargs, layer))
+        for h in handles:
+            h.remove()
+        return out
+
+    def _candidate_dequant(self, weight_blocks, ratio):
+        offset = 1 << (self.quant_bit - 1)
+        clip_max = offset - 1
+        if self.symmetric:
+            abs_max = weight_blocks.abs().amax(dim=-1, keepdim=True) * ratio
+            scale = (abs_max / clip_max).clamp_min(1e-8)
+            q = torch.round(weight_blocks / scale).clamp(-clip_max, clip_max)
+            dq = q * scale
+            zero = None
+        else:
+            clip_min = -offset
+            w_min = weight_blocks.amin(dim=-1, keepdim=True) * ratio
+            w_max = weight_blocks.amax(dim=-1, keepdim=True) * ratio
+            scale = ((w_max - w_min) / (clip_max - clip_min)).clamp_min(1e-8)
+            q = torch.round((weight_blocks - w_min) / scale) + clip_min
+            dq = (q.clamp(clip_min, clip_max) - clip_min) * scale + w_min
+            zero = w_min
+        return dq, scale.squeeze(-1), None if zero is None else zero.squeeze(-1)
+
+    @torch.no_grad()
+    def _search_linear(self, linear, ref_inputs, quant_inputs):
+        weight = linear.weight.detach().float().cpu()
+        ref_inputs = ref_inputs.float()
+        quant_inputs = quant_inputs.float()
+        sample_count = min(ref_inputs.shape[0], quant_inputs.shape[0], self.max_tokens_per_linear)
+        ref_inputs = ref_inputs[:sample_count]
+        quant_inputs = quant_inputs[:sample_count]
+
+        oc, ic = weight.shape
+        block_size = _get_quant_block_size(ic, self.quant_block)
+        block_num = ic // block_size
+        weight_blocks = weight.reshape(oc, block_num, block_size)
+        ref_blocks = ref_inputs.reshape(ref_inputs.shape[0], block_num, block_size)
+        quant_blocks = quant_inputs.reshape(quant_inputs.shape[0], block_num, block_size)
+
+        ratios = torch.linspace(1.0 / self.num_candidates, 1.0, self.num_candidates)
+        best_loss = torch.full((oc, block_num), torch.inf)
+        best_scale = torch.empty((oc, block_num))
+        best_zero = None if self.symmetric else torch.empty((oc, block_num))
+        ref_out = torch.einsum('tbi,obi->tob', ref_blocks, weight_blocks)
+        baseline_loss = None
+
+        for ratio in ratios:
+            dq, scale, zero = self._candidate_dequant(weight_blocks, ratio)
+            quant_out = torch.einsum('tbi,obi->tob', quant_blocks, dq)
+            loss = (quant_out - ref_out).pow(2).mean(dim=0)
+            if torch.isclose(ratio, torch.tensor(1.0)):
+                baseline_loss = loss.detach().clone()
+            mask = loss < best_loss
+            best_loss[mask] = loss[mask]
+            best_scale[mask] = scale[mask]
+            if best_zero is not None:
+                best_zero[mask] = zero[mask]
+
+        return {
+            "scale": best_scale.cpu(),
+            "zero": None if best_zero is None else best_zero.cpu(),
+            "quant_bit": self.quant_bit,
+            "quant_block": self.quant_block,
+            "symmetric": self.symmetric,
+            "baseline_mse": float(best_loss.mean().item() if baseline_loss is None else baseline_loss.mean().item()),
+            "best_mse": float(best_loss.mean().item()),
+        }
+
+    def _dequantize_weight_from_encoding(self, linear, encoding):
+        weight = linear.weight.detach().float()
+        oc, ic = weight.shape
+        block_size = _get_quant_block_size(ic, self.quant_block)
+        block_num = ic // block_size
+        weight_blocks = weight.reshape(oc, block_num, block_size)
+        scale = encoding["scale"].to(weight.device, weight.dtype).reshape(oc, block_num, 1)
+        offset = 1 << (self.quant_bit - 1)
+        clip_max = offset - 1
+        if self.symmetric:
+            q = torch.round(weight_blocks / scale).clamp(-clip_max, clip_max)
+            dq = q * scale
+        else:
+            clip_min = -offset
+            zero = encoding["zero"].to(weight.device, weight.dtype).reshape(oc, block_num, 1)
+            q = torch.round((weight_blocks - zero) / scale) + clip_min
+            dq = (q.clamp(clip_min, clip_max) - clip_min) * scale + zero
+        return dq.reshape_as(weight).to(linear.weight.dtype)
+
+    def _set_layer_quantized_weights(self, layer_idx, named_linears):
+        originals = {}
+        for name, linear in named_linears.items():
+            full_name = self._make_full_name(layer_idx, name)
+            encoding = self.encodings.get(full_name)
+            if encoding is None:
+                continue
+            originals[linear] = linear.weight.data
+            linear.weight.data = self._dequantize_weight_from_encoding(linear, encoding).to(linear.weight.device)
+        return originals
+
+    @staticmethod
+    def _restore_weights(originals):
+        for linear, weight in originals.items():
+            linear.weight.data = weight
+
+    def quantize(self):
+        self.model.eval()
+        layer_kwargs, fp_inps = self._get_first_input(self.samples)
+        qt_inps = fp_inps.detach().clone()
+
+        with torch.no_grad():
+            for layer_idx, layer in enumerate(tqdm(self.modules, desc="SeqMSE")):
+                layer.to(self.best_device)
+                layer.float()
+                layer_dtype = self._module_dtype(layer)
+                fp_inps = fp_inps.to(device=self.best_device, dtype=layer_dtype)
+                qt_inps = qt_inps.to(device=self.best_device, dtype=layer_dtype)
+                named_linears = self._get_named_linears(layer)
+
+                fp_next = self._collect_float_inputs(layer_idx, layer, named_linears, fp_inps, layer_kwargs)
+                originals = self._set_layer_quantized_weights(layer_idx, named_linears)
+                qt_next = self._run_quant_layer(layer_idx, layer, named_linears, qt_inps, layer_kwargs)
+                self._restore_weights(originals)
+                fp_inps = fp_next.detach().cpu()
+                qt_inps = qt_next.detach().cpu()
+                layer.cpu()
+                gc.collect()
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+
+        self.model.seqmse_encodings = self.encodings
+        self.model.seqmse_stats = self.stats
+        if self.stats:
+            baseline = sum(item["baseline_mse"] for item in self.stats.values()) / len(self.stats)
+            best = sum(item["best_mse"] for item in self.stats.values()) / len(self.stats)
+            improvement = 0.0 if baseline <= 0 else (baseline - best) / baseline
+            print(f"SeqMSE reconstruction MSE: baseline={baseline:.6e}, best={best:.6e}, improvement={improvement * 100:.2f}%")
+        return self.encodings

--- a/transformers/llm/export/utils/torch_utils.py
+++ b/transformers/llm/export/utils/torch_utils.py
@@ -26,15 +26,61 @@ def repack_low_bits(x, iNeedBits, block_size):
             iOffset = 0
     return torch.cat(v, axis=1)
 
-def _quant_on_device(weight, quant_bit, quant_block, symmetric, awq, hqq):
-    oc, ic = weight.shape
+def _get_quant_block_size(ic, quant_block):
     if quant_block == 0:
         block_size = ic
     else:
         block_size = quant_block
     while ic % block_size != 0:
         block_size /= 2
-    block_size = int(block_size)
+    return int(block_size)
+
+
+def _pack_quant_weight(q_weight, quant_bit, block_num, oc, block_size):
+    if quant_bit < 8 and 8 % quant_bit == 0:
+        group_size = 8 // quant_bit
+        q_weight = q_weight.reshape(-1, group_size)
+        multipliers = [2 ** (quant_bit * (group_size - 1 - i)) for i in range(group_size)]
+        # Use uint8 multipliers to avoid uint8->int64 promotion (8x memory blowup)
+        multipliers = torch.tensor(multipliers, dtype=torch.uint8).to(q_weight.device)
+        q_weight = (q_weight * multipliers).sum(axis=1).to(torch.uint8)
+    elif quant_bit < 8:
+        q_weight = repack_low_bits(q_weight.reshape((block_num * oc, block_size)), quant_bit, block_size)
+    return q_weight
+
+
+def quant_from_encoding(weight, quant_bit, quant_block, symmetric, scale, zero=None):
+    device = weight.device
+    oc, ic = weight.shape
+    block_size = _get_quant_block_size(ic, quant_block)
+    block_num = ic // block_size
+    weight = weight.reshape(oc, block_num, block_size)
+    scale = scale.to(device=device, dtype=weight.dtype).reshape(oc, block_num, 1)
+
+    offset = 1 << (quant_bit - 1)
+    clip_max = offset - 1
+    if symmetric:
+        clip_min = -clip_max
+        q_weight = torch.round(weight / scale).clamp(clip_min, clip_max)
+        alpha = scale.flatten()
+    else:
+        clip_min = -offset
+        zero = zero.to(device=device, dtype=weight.dtype).reshape(oc, block_num, 1)
+        q_weight = torch.round((weight - zero) / scale) + clip_min
+        q_weight = q_weight.clamp(clip_min, clip_max)
+        dequant_zero = zero - scale * clip_min
+        alpha = torch.stack([dequant_zero.flatten(), scale.flatten()], axis=-1).flatten()
+
+    q_weight = (q_weight.flatten() + offset).to(torch.uint8)
+    q_weight = _pack_quant_weight(q_weight, quant_bit, block_num, oc, block_size)
+    if q_weight.device is not torch.device('cpu'):
+        return q_weight.cpu(), alpha.float().cpu()
+    return q_weight, alpha.float()
+
+
+def _quant_on_device(weight, quant_bit, quant_block, symmetric, awq, hqq):
+    oc, ic = weight.shape
+    block_size = _get_quant_block_size(ic, quant_block)
     block_num = ic // block_size
 
     offset = 1 << (quant_bit - 1)
@@ -77,15 +123,7 @@ def _quant_on_device(weight, quant_bit, quant_block, symmetric, awq, hqq):
             q_weight = (torch.clamp(q_weight.flatten(), clip_min, clip_max) + offset).to(torch.uint8)
             alpha = torch.stack([zeros.flatten(), scale.flatten()], axis=-1).flatten()
 
-    if quant_bit < 8 and 8 % quant_bit == 0:
-        group_size = 8 // quant_bit
-        q_weight = q_weight.reshape(-1, group_size)
-        multipliers = [2 ** (quant_bit * (group_size - 1 - i)) for i in range(group_size)]
-        # Use uint8 multipliers to avoid uint8->int64 promotion (8x memory blowup)
-        multipliers = torch.tensor(multipliers, dtype=torch.uint8).to(q_weight.device)
-        q_weight = (q_weight * multipliers).sum(axis=1).to(torch.uint8)
-    elif quant_bit < 8:
-        q_weight = repack_low_bits(q_weight.reshape((block_num * oc, block_size)), quant_bit, block_size)
+    q_weight = _pack_quant_weight(q_weight, quant_bit, block_num, oc, block_size)
 
     if q_weight.device is not torch.device('cpu'):
         return q_weight.cpu(), alpha.float().cpu()


### PR DESCRIPTION
## Description

This PR fixes a bug in `transformers/llm/export/npu/generate_llm_qnn.py` where the user-provided `--chunk_size` was not honored when generating prefill IO.

Before this change, `convert_llm()` always called:

```python
makeIOJson(args, 128, hidden_size, mask_type)
```

which meant the prefill QNN graph could still be generated against 128-token IO even when `--chunk_size 256/512` was requested.

This can make the generated QNN artifact inconsistent with runtime configuration and lead to misleading evaluation results, especially for `ppl_eval`.

## Module

LLM

## Type

- [ ] Feature
- [x] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [x] Tested on relevant platform(s)
- [x] No unrelated format or style changes included
