### PR TITLE
[LLM:Bugfix] Fix QNN export chunk-size and per-task workdir handling

### DIFF
--- a/source/backend/qnn/npu_convert.py
+++ b/source/backend/qnn/npu_convert.py
@@ -83,7 +83,7 @@ def process_src(task):
         "-t", "x86_64-linux-clang",
         "-o", workdir,
     ]
-    compile_result = run_subprocess(compile_cmd, retries=3)
+    compile_result = run_subprocess(compile_cmd, cwd=workdir, retries=3)
     if compile_result.returncode != 0:
         raise RuntimeError(f"Compile failed for src={src}: {' '.join(compile_cmd)}")
 

--- a/transformers/llm/export/npu/generate_llm_qnn.py
+++ b/transformers/llm/export/npu/generate_llm_qnn.py
@@ -14,7 +14,11 @@ def makeIO(args, model_name, inputjson, external_file = None):
     cache = os.path.join(os.getcwd(), args.cache_path)
     output = os.path.join(cache, 'testdir')
     os.makedirs(output, exist_ok=True)
-    print(os.popen(exe + " " + model + " " + inputjson + " " + output + " " + external_file).read())
+    process = subprocess.Popen(exe + " " + model + " " + inputjson + " " + output + " " + external_file, bufsize=1, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd = cache, text=True, shell=True)
+    for line in process.stdout:
+        print(line, end='')
+    process.wait()
+    return process.returncode
 
 def makeIOJson(args, seq_len, hidden_size, mask_type):
     config = {
@@ -261,17 +265,20 @@ def output_qnn(args):
 def convert_qnn(args, model_name, inputjson, external_file, ids):
     sta = time.time()
     print("Step1: Make IO")
-    makeIO(args, model_name, inputjson, external_file)
+    if makeIO(args, model_name, inputjson, external_file) != 0:
+        raise RuntimeError("generateIO failed")
     end = time.time()
     print("Cost: ", end - sta, ' s')
     sta = end
     print("Step2: Seperate Model")
-    seperate(args, model_name, ids)
+    if seperate(args, model_name, ids) != 0:
+        raise RuntimeError("compilefornpu failed")
     end = time.time()
     print("Cost: ", end - sta, ' s')
     sta = end
     print("Step3: Compile to QNN")
-    compile_qnn(args)
+    if compile_qnn(args) != 0:
+        raise RuntimeError("npu_convert.py failed")
     end = time.time()
     print("Cost: ", end - sta, ' s')
     print("Step4: Move result file to ", args.model)
@@ -328,7 +335,7 @@ def convert_llm(args):
     
     ids = [0, 1]
     external_file = os.path.join(os.getcwd(), args.model, 'llm.mnn.weight')
-    makeIOJson(args, 128, hidden_size, mask_type)
+    makeIOJson(args, args.chunk_size, hidden_size, mask_type)
     inputjson = os.path.join(cache, 'input.json')
     convert_qnn(args, 'llm.mnn', inputjson, external_file, ids)
 


### PR DESCRIPTION
## Description

This PR contains two small bug fixes in the LLM QNN export path.

### 1. Honor `--chunk_size` when generating prefill IO

`transformers/llm/export/npu/generate_llm_qnn.py` exposed `--chunk_size`, but `convert_llm()` always called:

```python
makeIOJson(args, 128, hidden_size, mask_type)
```

This meant the prefill QNN graph could still be generated against 128-token IO even when `--chunk_size 256/512` was requested.

### 2. Run QNN compile subprocesses inside the per-task workdir

`source/backend/qnn/npu_convert.py` invoked the compile subprocess without setting `cwd=workdir`.
For parallel conversions, this could make multiple tasks share the same process working directory assumptions and increase the chance of temporary/output path collisions.

## Why this matters

In the MNN QNN offline export path, these issues can make generated artifacts inconsistent with runtime expectations:

- prefill graph shape may not match the requested chunk size
- runtime `chunk_limits` and generated graphs may diverge
- `ppl_eval` results can become misleading
- parallel export jobs are more fragile than they need to be

## Module

LLM

## Type

- [ ] Feature
- [x] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [x] Tested on relevant platform(s)
- [x] No unrelated format or style changes included

## Fixed
https://github.com/alibaba/MNN/issues/4612