### PR TITLE
[Express:Bugfix] Guard null runtime in RuntimeManager::setCache

### DIFF
--- a/express/Executor.cpp
+++ b/express/Executor.cpp
@@ -360,6 +360,11 @@ BackendConfig* Executor::RuntimeManager::getBnConfig() {
 void Executor::RuntimeManager::setCache(std::string cacheName) {
     std::lock_guard<std::mutex> _l(mLock);
 
+    if (nullptr == mInside->mInfo) {
+        // Runtime not created (e.g. requested backend unavailable on this device), skip setCache
+        MNN_ERROR("Runtime not created, skip setCache\n");
+        return;
+    }
     mInside->mCache.reset(new Cache);
     mInside->mCache->cacheFile = cacheName;
     mInside->mInfo->onSetCachePath(cacheName.c_str(), 0);


### PR DESCRIPTION
GitOrigin-RevId: e1d27551e71f9adf6c82a67479d91a3c4d65186d

## Description

<!-- Brief description of the changes -->

## Module

<!-- Which module does this PR affect? e.g. LLM, CPU, Metal, CUDA, OpenCL, Core, Infra -->

## Type

- [ ] Feature
- [ ] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [ ] Commit message follows `[Module:Type] Description` format
- [ ] Code compiles without errors
- [ ] Tested on relevant platform(s)
- [ ] No unrelated format or style changes included
