### PR TITLE
[LLM:Feature] Add HunyuanOCR 1.5 support

### DIFF
--- a/transformers/llm/engine/src/llm.cpp
+++ b/transformers/llm/engine/src/llm.cpp
@@ -419,7 +419,7 @@ bool Llm::load() {
         }
 
         if (mConfig->is_mrope()) {
-            mPositionIdsVarVec[i] = _Input({3, index}, NCHW, halide_type_of<int>());
+            mPositionIdsVarVec[i] = _Input({mConfig->mrope_axes(), index}, NCHW, halide_type_of<int>());
         } else {
             mPositionIdsVarVec[i] = _Input({1, index}, NCHW, halide_type_of<int>());
         }
@@ -1571,8 +1571,9 @@ VARP Llm::gen_position_ids(int seq_len) {
             auto ptr = mPositionIdsVarVec[0]->writeMap<int>();
             ptr[0] = is_glm2 ? mContext->gen_seq_len : mContext->all_seq_len;
             if (mConfig->is_mrope()) {
-                ptr[1] = ptr[0];
-                ptr[2] = ptr[0];
+                for (int axis = 1; axis < mConfig->mrope_axes(); axis++) {
+                    ptr[axis] = ptr[0];
+                }
             }
             return mPositionIdsVarVec[0];
         }
@@ -1581,16 +1582,21 @@ VARP Llm::gen_position_ids(int seq_len) {
             for (int i = 0; i < seq_len; i++) {
                 ptr[i] = i + mContext->all_seq_len;
             }
+            if (mConfig->is_mrope()) {
+                for (int axis = 1; axis < mConfig->mrope_axes(); axis++) {
+                    ::memcpy(ptr + axis * seq_len, ptr, seq_len * sizeof(int));
+                }
+            }
             return mPositionIdsVarVec[1];
         }
 
         if (mConfig->is_mrope()) {
-            positionIds = _Input({3, seq_len}, NCHW, halide_type_of<int>());
+            positionIds = _Input({mConfig->mrope_axes(), seq_len}, NCHW, halide_type_of<int>());
             auto ptr = positionIds->writeMap<int>();
-            for (int i = 0; i < seq_len; i++) {
-                ptr[0 * seq_len + i] = i + mContext->all_seq_len;
-                ptr[1 * seq_len + i] = i + mContext->all_seq_len;
-                ptr[2 * seq_len + i] = i + mContext->all_seq_len;
+            for (int axis = 0; axis < mConfig->mrope_axes(); axis++) {
+                for (int i = 0; i < seq_len; i++) {
+                    ptr[axis * seq_len + i] = i + mContext->all_seq_len;
+                }
             }
             return positionIds;
         }

--- a/transformers/llm/engine/src/llmconfig.hpp
+++ b/transformers/llm/engine/src/llmconfig.hpp
@@ -269,6 +269,8 @@ public:
         return config_.value("is_mrope", false);
     }
 
+    int mrope_axes() const { return config_.value("mrope_axes", 3); }
+
     bool has_talker() const {
         return config_.value("has_talker", false);
     }

--- a/transformers/llm/engine/src/omni.cpp
+++ b/transformers/llm/engine/src/omni.cpp
@@ -11,6 +11,7 @@
 #endif
 #include <regex>
 #include <algorithm>
+#include <cmath>
 #include <random>
 #include <MNN/AutoTime.hpp>
 #include <MNN/expr/ExecutorScope.hpp>
@@ -502,6 +503,91 @@ std::vector<int> Omni::qwen2VisionProcess(VARP image) {
     return imgIds;
 }
 
+std::vector<int> Omni::hunyuanVisionProcess(VARP image) {
+    MNN::Express::ExecutorScope s(mExecutor);
+    int patchSize = mConfig->config_.value("hunyuan_patch_size", 16);
+    int mergeSize = mConfig->config_.value("hunyuan_spatial_merge_size", 2);
+    int temporalPatchSize = mConfig->config_.value("hunyuan_temporal_patch_size", 1);
+    if (patchSize <= 0 || mergeSize <= 0 || temporalPatchSize <= 0) {
+        MNN_ERROR("Invalid Hunyuan vision config: patch=%d merge=%d temporal=%d\n", patchSize, mergeSize,
+                  temporalPatchSize);
+        return std::vector<int>(0);
+    }
+    if (temporalPatchSize != 1) {
+        MNN_ERROR("Hunyuan temporal_patch_size=%d is not supported by Omni image preprocessing\n", temporalPatchSize);
+        return std::vector<int>(0);
+    }
+    if (!mVisionSizeOverridden) {
+        auto imageInfo = image->getInfo();
+        if (imageInfo != nullptr && imageInfo->dim.size() >= 2) {
+            auto dims = imageInfo->dim;
+            int imageHeight = dims[0];
+            int imageWidth = dims[1];
+            if (dims.size() >= 3 && dims[dims.size() - 1] <= 4) {
+                imageHeight = dims[dims.size() - 3];
+                imageWidth = dims[dims.size() - 2];
+            }
+            if (imageHeight > 0 && imageWidth > 0) {
+                mVisionHeight = imageHeight;
+                mVisionWidth = imageWidth;
+            }
+        }
+    }
+    const int factor = patchSize * mergeSize;
+    int minPixels = mConfig->config_.value("image_min_pixels", mVisionHeight * mVisionWidth);
+    int maxPixels = mConfig->config_.value("image_max_pixels", mVisionMaxSize * mVisionMaxSize);
+    int resizedHeight =
+        std::max(factor, static_cast<int>(std::round(static_cast<float>(mVisionHeight) / factor)) * factor);
+    int resizedWidth =
+        std::max(factor, static_cast<int>(std::round(static_cast<float>(mVisionWidth) / factor)) * factor);
+    if (resizedHeight * resizedWidth > maxPixels) {
+        float beta = std::sqrt(static_cast<float>(mVisionHeight * mVisionWidth) / maxPixels);
+        resizedHeight = std::max(factor, static_cast<int>(std::floor(mVisionHeight / beta / factor)) * factor);
+        resizedWidth = std::max(factor, static_cast<int>(std::floor(mVisionWidth / beta / factor)) * factor);
+    } else if (resizedHeight * resizedWidth < minPixels) {
+        float beta = std::sqrt(static_cast<float>(minPixels) / (mVisionHeight * mVisionWidth));
+        resizedHeight = std::max(factor, static_cast<int>(std::ceil(mVisionHeight * beta / factor)) * factor);
+        resizedWidth = std::max(factor, static_cast<int>(std::ceil(mVisionWidth * beta / factor)) * factor);
+    }
+    mVisionHeight = resizedHeight;
+    mVisionWidth = resizedWidth;
+    image = MNN::CV::resize(image, {mVisionWidth, mVisionHeight}, 0, 0, MNN::CV::INTER_CUBIC, MNN::CV::COLOR_BGR2RGB,
+                            mVisionMean, mVisionNorm);
+    image = Express::_Unsqueeze(image, {0});
+    image = Express::_Convert(image, NCHW);
+    int gridH = mVisionHeight / patchSize;
+    int gridW = mVisionWidth / patchSize;
+    auto patches = Express::_Reshape(
+        image, {1, 3, gridH / mergeSize, mergeSize, patchSize, gridW / mergeSize, mergeSize, patchSize});
+    patches = Express::_Permute(patches, {0, 2, 5, 3, 6, 1, 4, 7});
+    patches = Express::_Reshape(patches, {gridH * gridW, 3 * temporalPatchSize * patchSize * patchSize});
+    auto imageGridThw = Express::_Input({1, 3}, NCHW, halide_type_of<int>());
+    auto gridPtr = imageGridThw->writeMap<int>();
+    gridPtr[0] = 1;
+    gridPtr[1] = gridH;
+    gridPtr[2] = gridW;
+    auto outputs = mVisionModule->onForward({patches, imageGridThw});
+    if (outputs.empty() || outputs[0] == nullptr || outputs[0]->getInfo() == nullptr) {
+        MNN_ERROR("Hunyuan vision forward failed: resized=%dx%d grid=%dx%d patch=%d merge=%d\n", mVisionHeight,
+                  mVisionWidth, gridH, gridW, patchSize, mergeSize);
+        return std::vector<int>(0);
+    }
+    auto imageEmbedding = outputs[0];
+    int visionLen = imageEmbedding->getInfo()->dim[0];
+    int gridTokens = (gridH / mergeSize) * (gridW / mergeSize + 1);
+    int extraTokens = visionLen - gridTokens;
+    if (extraTokens != 0 && extraTokens != 2) {
+        MNN_ERROR("Hunyuan image token count mismatch: tokens=%d grid=%d\n", visionLen, gridTokens);
+        return std::vector<int>(0);
+    }
+    mVisionEmbeddings.push_back(imageEmbedding);
+    addPositionIds(visionLen, gridH / mergeSize, gridW / mergeSize);
+    std::vector<int> imgIds(visionLen, mVisionPad);
+    imgIds.insert(imgIds.begin(), mVisionStart);
+    imgIds.push_back(mVisionEnd);
+    return imgIds;
+}
+
 std::vector<int> Omni::smolvlmVisionProcess(VARP image) {
     MNN::Express::ExecutorScope s(mExecutor);
     // SmolVLM / LFM2-VL: compute visionLen from global image forward
@@ -796,13 +882,21 @@ std::vector<int> Omni::visionProcess(VARP image) {
 #ifdef LLM_SUPPORT_VISION
     if (image == nullptr) {
         MNN_PRINT("Omni Can't open image\n");
+        mVisionSizeOverridden = false;
         return std::vector<int>(0);
     }
     Timer _t;
     std::vector<int> imgIds;
     const auto inputNames = mVisionModule->getInfo()->inputNames;
+    const auto visionType = mConfig->config_.value("vision_type", "");
     if (inputNames.size() >= 3 && inputNames[0] == "patches") {
         imgIds = qwen2VisionProcess(image);
+    } else if (visionType == "hunyuan_vl") {
+        if (inputNames.size() == 2 && inputNames[0] == "pixel_values" && inputNames[1] == "image_grid_thw") {
+            imgIds = hunyuanVisionProcess(image);
+        } else {
+            MNN_ERROR("Hunyuan vision expects inputs pixel_values,image_grid_thw\n");
+        }
     } else if (inputNames[0] == "pixel_values") {
         if (inputNames.size() == 1) {
             imgIds = smolvlmVisionProcess(image);
@@ -822,6 +916,7 @@ std::vector<int> Omni::visionProcess(VARP image) {
     }
     mContext->vision_us += _t.durationInUs();
     mContext->pixels_mp += (mVisionWidth / 1000.0f) * (mVisionHeight / 1000.0f);
+    mVisionSizeOverridden = false;
     // set vision number for image idx
     mVisionNum += 1;
     return imgIds;
@@ -957,7 +1052,12 @@ std::vector<int> Omni::multimodeProcess(const std::string& mode, std::string inf
 
             std::stringstream hw_ss(match.str(1));
             char comma;
-            hw_ss >> mVisionHeight >> comma >> mVisionWidth;
+            int parsedHeight = 0, parsedWidth = 0;
+            if (hw_ss >> parsedHeight >> comma >> parsedWidth && parsedHeight > 0 && parsedWidth > 0) {
+                mVisionHeight = parsedHeight;
+                mVisionWidth = parsedWidth;
+                mVisionSizeOverridden = true;
+            }
             currentPosition = matchPosition + match.length();
         }
         if (currentPosition < info.length()) {
@@ -1003,6 +1103,29 @@ std::vector<int> Omni::multimodeProcess(const std::string& mode, std::string inf
 }
 
 void Omni::addPositionIds(int t, int h, int w) {
+    if (mConfig->config_.value("vision_type", "") == "hunyuan_vl" && h >= 0 && w >= 0) {
+        int cur_idx = mPositionIds.mT.empty() ? 0 : mPositionIds.mT.back() + 1;
+        int gridTokens = h * (w + 1);
+        int extraTokens = t - gridTokens;
+        if (extraTokens != 0 && extraTokens != 2) {
+            MNN_ERROR("Hunyuan image token count mismatch: tokens=%d grid=%d\n", t, gridTokens);
+            return;
+        }
+        mPositionIds.push_back(cur_idx++);
+        if (extraTokens == 2) {
+            mPositionIds.push_back(cur_idx++);
+        }
+        for (int h_i = 0; h_i < h; h_i++) {
+            for (int w_i = 0; w_i <= w; w_i++) {
+                mPositionIds.push_back(cur_idx++, w_i, h_i, mVisionNum);
+            }
+        }
+        if (extraTokens == 2) {
+            mPositionIds.push_back(cur_idx++);
+        }
+        mPositionIds.push_back(cur_idx++);
+        return;
+    }
     int cur_idx = mPositionIds.currentIdx();
     if (h < 0 && w < 0) { // text position ids
         for (int i = 0; i < t; i++) {
@@ -1071,6 +1194,7 @@ std::vector<int> Omni::processImageContent(const std::string& content, const std
         if (it->second.height > 0 && it->second.width > 0) {
             mVisionHeight = it->second.height;
             mVisionWidth = it->second.width;
+            mVisionSizeOverridden = true;
         }
         // MNN_PRINT("processImageContent: using placeholder '%s' with size %dx%d", content.c_str(), mVisionWidth, mVisionHeight);
         return visionProcess(it->second.image_data);
@@ -1229,26 +1353,42 @@ VARP Omni::gen_position_ids(int seq_len) {
         return Llm::gen_position_ids(seq_len);
     }
     // mrope
-    if (needNewVar(positionIds, 1, seq_len)) {
-        positionIds = _Input({3, seq_len}, NCHW, halide_type_of<int>());
+    int axes = mConfig->mrope_axes();
+    if (positionIds == nullptr || positionIds->getInfo()->dim[0] != axes || needNewVar(positionIds, 1, seq_len)) {
+        positionIds = _Input({axes, seq_len}, NCHW, halide_type_of<int>());
     }
     auto ptr = positionIds->writeMap<int>();
     if (mContext->gen_seq_len > 0) {
-        for (int i=0; i<seq_len; ++i) {
+        for (int i = 0; i < seq_len; ++i) {
             // auto pos = mContext->gen_seq_len + mPositionIds.back() + i;
             auto pos = mContext->all_seq_len + i;
-            ptr[i + 0] = pos;
-            ptr[i + seq_len] = pos;
-            ptr[i + seq_len * 2] = pos;
+            for (int axis = 0; axis < axes; axis++) {
+                ptr[i + seq_len * axis] = pos;
+            }
         }
     } else {
+        bool hunyuan = mConfig->config_.value("vision_type", "") == "hunyuan_vl";
+        auto axisValue = [this](int axis, int i) {
+            const std::vector<int>* values = nullptr;
+            if (axis == 0) {
+                values = &mPositionIds.mT;
+            } else if (axis == 1) {
+                values = &mPositionIds.mH;
+            } else if (axis == 2) {
+                values = &mPositionIds.mW;
+            } else if (axis == 3) {
+                values = &mPositionIds.mX;
+            }
+            if (values != nullptr && i < static_cast<int>(values->size())) {
+                return (*values)[i];
+            }
+            return i;
+        };
         for (int i = 0; i < seq_len; i++) {
-            int mT_val = i < mPositionIds.mT.size() ? mPositionIds.mT[i] : i;
-            int mH_val = i < mPositionIds.mH.size() ? mPositionIds.mH[i] : i;
-            int mW_val = i < mPositionIds.mW.size() ? mPositionIds.mW[i] : i;
-            ptr[i] = mT_val + mContext->all_seq_len;
-            ptr[i + seq_len] = mH_val + mContext->all_seq_len;
-            ptr[i + seq_len * 2] = mW_val + mContext->all_seq_len;
+            for (int axis = 0; axis < axes; axis++) {
+                int offset = (hunyuan && axis > 0) ? 0 : mContext->all_seq_len;
+                ptr[i + seq_len * axis] = axisValue(axis, i) + offset;
+            }
         }
         if (mTalker) {
             mTalker->setPostionIds(mPositionIds);

--- a/transformers/llm/engine/src/omni.cpp
+++ b/transformers/llm/engine/src/omni.cpp
@@ -559,7 +559,7 @@ std::vector<int> Omni::hunyuanVisionProcess(VARP image) {
     int gridW = mVisionWidth / patchSize;
     auto patches = Express::_Reshape(
         image, {1, 3, gridH / mergeSize, mergeSize, patchSize, gridW / mergeSize, mergeSize, patchSize});
-    patches = Express::_Permute(patches, {0, 2, 5, 3, 6, 1, 4, 7});
+    patches = Express::_Permute(patches, {0, 2, 3, 5, 6, 1, 4, 7});
     patches = Express::_Reshape(patches, {gridH * gridW, 3 * temporalPatchSize * patchSize * patchSize});
     auto imageGridThw = Express::_Input({1, 3}, NCHW, halide_type_of<int>());
     auto gridPtr = imageGridThw->writeMap<int>();
@@ -1155,6 +1155,7 @@ std::vector<int> Omni::tokenizer_encode(const MultimodalPrompt& multimodal_input
     std::smatch match;
     std::vector<int> ids{};
     mPositionIds.clear();
+    mVisionNum = 0;
 
     while (std::regex_search(searchStart, prompt.cend(), match, multimode_regex)) {
         auto txt_ids = mTokenizer->encode(match.prefix().str());

--- a/transformers/llm/engine/src/omni.hpp
+++ b/transformers/llm/engine/src/omni.hpp
@@ -27,6 +27,7 @@ public:
         mT = info.mT;
         mH = info.mH;
         mW = info.mW;
+        mX = info.mX;
     }
     int back() {
         if (mW.empty()) {
@@ -40,10 +41,12 @@ public:
         }
         return back() + 1;
     }
-    void push_back(int t, int h, int w) {
+    void push_back(int t, int h, int w) { push_back(t, h, w, w); }
+    void push_back(int t, int h, int w, int x) {
         mT.push_back(t);
         mH.push_back(h);
         mW.push_back(w);
+        mX.push_back(x);
     }
     void push_back(int t) {
         push_back(t, t, t);
@@ -56,8 +59,9 @@ public:
         mT.clear();
         mH.clear();
         mW.clear();
+        mX.clear();
     }
-    std::vector<int> mT, mH, mW;
+    std::vector<int> mT, mH, mW, mX;
 };
 
 struct WavChunk {
@@ -165,6 +169,7 @@ public:
     std::vector<int> qwen2VisionProcess(VARP image);
     std::vector<int> smolvlmVisionProcess(VARP image);
     std::vector<int> minicpmVisionProcess(VARP image);
+    std::vector<int> hunyuanVisionProcess(VARP image);
     std::vector<int> gemma4VisionProcess(VARP image);
 private:
     int mVisionHeight = 448, mVisionWidth = 448, mVisionStart = 151857,
@@ -173,6 +178,7 @@ private:
     int mVisionGlobal = 49152;
     int mVisionSizeUnit = 1, mVisionMaxSize = 2048;
     int mVisionNum = 0;
+    bool mVisionSizeOverridden = false;
     std::vector<float> mVisionMean{122.7709383, 116.7460125, 104.09373615};
     std::vector<float> mVisionNorm{0.01459843, 0.01500777, 0.01422007};
     std::vector<int> multimodeProcess(const std::string& mode, std::string info);

--- a/transformers/llm/export/llmexport.py
+++ b/transformers/llm/export/llmexport.py
@@ -86,6 +86,8 @@ class LlmExporter(torch.nn.Module):
             'attention_type': self.config.attention_type,
             'is_mrope': self.model.rotary.is_mrope
         }
+        if self.model.rotary.is_mrope:
+            self.llm_config['mrope_axes'] = self.model.rotary.mrope_axes
         self.llm_config.update(self.model.get_config())
         # Attention scaling (gemma4 uses 1.0 instead of 1/sqrt(head_dim))
         if hasattr(self.model, 'blocks') and len(self.model.blocks) > 0:
@@ -116,6 +118,13 @@ class LlmExporter(torch.nn.Module):
             self.llm_config['jinja'] = {
                 'chat_template': "[gMASK]<sop>{% for message in messages %}{% if message.role == \"user\" %}<|user|>\n{{ message.content }}{% elif message.role == \"assistant\" %}<|assistant|>\n{{ message.content }}{% elif message.role == \"system\" %}<|system|>\n{{ message.content }}{% endif %}{% endfor %}{% if add_generation_prompt %}<|assistant|>\n{% endif %}",
                 'eos': '<|endoftext|>'
+            }
+        # HunyuanVL's HF template uses syntax unsupported by the C++ minja parser.
+        if self.model_type == 'hunyuan_vl':
+            self.llm_config['jinja'] = {
+                'chat_template': "<｜hy_begin▁of▁sentence｜>{% for message in messages %}{% if message.role == \"system\" %}{{ message.content }}<｜hy_place▁holder▁no▁3｜>{% elif message.role == \"user\" %}{{ message.content }}<｜hy_User｜>{% elif message.role == \"assistant\" %}{{ message.content }}<｜hy_Assistant｜>{% endif %}{% endfor %}",
+                'bos': '<｜hy_begin▁of▁sentence｜>',
+                'eos': '<｜hy_Assistant｜>'
             }
 
         # tie word embeddings

--- a/transformers/llm/export/llmexport.py
+++ b/transformers/llm/export/llmexport.py
@@ -419,6 +419,8 @@ class LlmExporter(torch.nn.Module):
             for i in range(len(self.model.blocks)):
                 # different kv cache shape in different layers
                 # if isinstance(self.config.num_attention_heads, list):
+                # Keep custom Attention in the exported LLM graph so runtime decode uses KV cache.
+                # HunyuanVL still disables MNNConvert transformerFuse separately.
                 self.model.blocks[i].self_attn.export_fused_attn = True
                 is_moe = hasattr(self.model.blocks[i].mlp, 'is_moe') and self.model.blocks[i].mlp.is_moe
                 if is_moe:
@@ -681,7 +683,8 @@ class LlmExporter(torch.nn.Module):
         if self.args.onnx_slim:
             self.slim_onnx(onnx_model)
         if self.mnn_converter:
-            tie_embeddings_info = MNNConverter(self, self.unloaded_ops).export(onnx_model)
+            fuse_transformer = self.model_type != 'hunyuan_vl'
+            tie_embeddings_info = MNNConverter(self, self.unloaded_ops).export(onnx_model, transformer_fuse=fuse_transformer)
             if tie_embeddings_info is not None:
                 self.llm_config['tie_embeddings'] = tie_embeddings_info
         else:

--- a/transformers/llm/export/utils/custom_op.py
+++ b/transformers/llm/export/utils/custom_op.py
@@ -45,8 +45,7 @@ class FusedAttentionOp(torch.autograd.Function):
             "kv_shared_layer_index_i": kv_shared_layer_index,
         }
         from torch.onnx.symbolic_helper import _get_tensor_sizes
-        out_sizes = _get_tensor_sizes(query)
-        out_sizes[-1] = output_dim
+        out_sizes = _get_tensor_sizes(query)[:2] + [output_dim]
         output_type = query.type().with_sizes(out_sizes)
         return g.op("LlmExporter::FusedAttention", query, key, value, attention_mask, **kwargs).setType(output_type)
 

--- a/transformers/llm/export/utils/mnn_converter.py
+++ b/transformers/llm/export/utils/mnn_converter.py
@@ -156,7 +156,10 @@ class MNNConverter:
             self.mnn2json(self.mnn_model_path, mnn_json)
             self.rebuild(mnn_json)
             self.json2mnn(mnn_json, self.mnn_model_path)
-            self.removeDupOps(self.mnn_model_path)
+            # HunyuanVL needs the explicit q/k/v reshape boundary before Attention.
+            # The extra optimize pass can bypass v_proj's post_reshape into Attention.
+            if self.exporter.model_type != 'hunyuan_vl':
+                self.removeDupOps(self.mnn_model_path)
             self.mnn2json(self.mnn_model_path, mnn_json)
             if self.args.gptq_path is not None:
                 self.apply_gptq(mnn_json)

--- a/transformers/llm/export/utils/model.py
+++ b/transformers/llm/export/utils/model.py
@@ -1,5 +1,7 @@
 import torch
 import importlib
+import json
+import os
 from packaging.version import Version
 from transformers import PreTrainedModel, AutoConfig, AutoModel, AutoModelForCausalLM
 from typing import Optional, List
@@ -8,6 +10,61 @@ from utils.config import LlmConfig
 from utils.tokenizer import LlmTokenizer
 from utils.model_mapper import ModelMapper
 from utils.transformers import Embedding, Rotary, Decoder, Lm
+
+
+def remap_hunyuan_vl_state_dict(state_dict):
+    remapped = {}
+    prefixes = (
+        ('model.embed_tokens.', 'model.language_model.embed_tokens.'),
+        ('model.layers.', 'model.language_model.layers.'),
+        ('model.norm.', 'model.language_model.norm.'),
+        ('vit.embeddings.', 'model.vision_tower.embeddings.'),
+        ('vit.layers.', 'model.vision_tower.layers.'),
+        ('vit.perceive.before_rms.', 'model.vision_tower.patch_merger.before_rms.'),
+        ('vit.perceive.after_rms.', 'model.vision_tower.patch_merger.after_rms.'),
+        ('vit.perceive.image_begin', 'model.vision_tower.patch_merger.image_begin'),
+        ('vit.perceive.image_end', 'model.vision_tower.patch_merger.image_end'),
+        ('vit.perceive.image_newline', 'model.vision_tower.patch_merger.image_newline'),
+        ('vit.perceive.image_sep', 'model.vision_tower.patch_merger.image_sep'),
+        ('vit.perceive.mlp.', 'model.vision_tower.patch_merger.mlp.'),
+        ('vit.perceive.proj.0.', 'model.vision_tower.patch_merger.proj_conv.'),
+        ('vit.perceive.proj.2.', 'model.vision_tower.patch_merger.proj_out.'),
+    )
+    for key, value in state_dict.items():
+        new_key = key
+        for old_prefix, new_prefix in prefixes:
+            if key.startswith(old_prefix):
+                new_key = new_prefix + key[len(old_prefix):]
+                break
+        if new_key.startswith('model.vision_tower.layers.'):
+            new_key = new_key.replace('.input_layernorm.', '.layer_norm1.')
+            new_key = new_key.replace('.post_attention_layernorm.', '.layer_norm2.')
+            new_key = new_key.replace('.mlp.dense_h_to_4h.', '.mlp.fc1.')
+            new_key = new_key.replace('.mlp.dense_4h_to_h.', '.mlp.fc2.')
+        remapped[new_key] = value
+    return remapped
+
+
+def load_hunyuan_vl_state_dict(model_path):
+    from safetensors.torch import load_file
+    index_path = os.path.join(model_path, 'model.safetensors.index.json')
+    if os.path.exists(index_path):
+        with open(index_path, 'r', encoding='utf-8') as f:
+            index = json.load(f)
+        shard_files = sorted(set(index.get('weight_map', {}).values()))
+        if not shard_files:
+            raise ValueError(f"HunyuanVL safetensors index has no weight_map entries: {index_path}")
+    else:
+        safetensors_path = os.path.join(model_path, 'model.safetensors')
+        if not os.path.exists(safetensors_path):
+            raise FileNotFoundError(f"HunyuanVL weights not found: {safetensors_path}")
+        shard_files = [os.path.basename(safetensors_path)]
+    state_dict = {}
+    for shard_file in shard_files:
+        shard_path = shard_file if os.path.isabs(shard_file) else os.path.join(model_path, shard_file)
+        state_dict.update(load_file(shard_path, device='cpu'))
+    return state_dict
+
 
 class LlmModel(PreTrainedModel):
     config_class = LlmConfig
@@ -54,6 +111,7 @@ class LlmModel(PreTrainedModel):
             'glm_ocr': 'GlmOcrForConditionalGeneration',
             'lfm2_vl': 'Lfm2VlForConditionalGeneration',
             'gemma4': 'Gemma4ForConditionalGeneration',
+            'hunyuan_vl': 'HunYuanVLForConditionalGeneration',
         }
         if model_type is None or model_type not in MODEL_CLASS_MAPPING:
             return AutoModelForCausalLM
@@ -104,6 +162,22 @@ class LlmModel(PreTrainedModel):
             )
             # Force sdpa attention on CPU (flash_attention_2 requires GPU)
             original_model.lfm.set_attn_implementation('sdpa')
+        elif model_type == 'hunyuan_vl':
+            try:
+                original_model = model_class.from_pretrained(pretrained_model_name_or_path, **load_kwargs)
+            except Exception as load_error:
+                original_config = AutoConfig.from_pretrained(pretrained_model_name_or_path, trust_remote_code=True)
+                if hasattr(model_class, '_from_config'):
+                    original_model = model_class._from_config(original_config)
+                else:
+                    original_model = model_class(original_config)
+                state_dict = remap_hunyuan_vl_state_dict(load_hunyuan_vl_state_dict(pretrained_model_name_or_path))
+                missing, unexpected = original_model.load_state_dict(state_dict, strict=False)
+                if missing or unexpected:
+                    raise RuntimeError(
+                        "HunyuanVL fallback weight load mismatch: "
+                        f"missing={missing}, unexpected={unexpected}"
+                    ) from load_error
         else:
             # Normal loading with weights
             try:
@@ -463,7 +537,7 @@ class LlmModel(PreTrainedModel):
             position_ids = torch.arange(seq_len, dtype=torch.int)
 
         if self.rotary.is_mrope:
-            position_ids = torch.stack([position_ids] * 3)
+            position_ids = torch.stack([position_ids] * self.rotary.mrope_axes)
         else:
             position_ids = position_ids.unsqueeze(0)
         return position_ids

--- a/transformers/llm/export/utils/model_mapper.py
+++ b/transformers/llm/export/utils/model_mapper.py
@@ -699,6 +699,40 @@ class ModelMapper:
         }
         self.regist('hunyuan_v1_dense', hunyuan_map)
 
+    def regist_hunyuan_vl(self):
+        hunyuan_vl_config = {
+            'hidden_size': 'text_config.hidden_size',
+            'head_dim': 'text_config.head_dim',
+            'num_attention_heads': 'text_config.num_attention_heads',
+            'num_hidden_layers': 'text_config.num_hidden_layers',
+            'num_key_value_heads': 'text_config.num_key_value_heads',
+            'rope_theta': 'text_config.rope_theta',
+            'rope_scaling': 'text_config.rope_scaling',
+            'max_position_embeddings': 'text_config.max_position_embeddings'
+        }
+        hunyuan_vl_model = {
+            'lm': 'lm_head',
+            'embed': 'model.language_model.embed_tokens',
+            'blocks': 'model.language_model.layers',
+            'final_layernorm': 'model.language_model.norm',
+            'visual': 'model.vision_tower'
+        }
+        hunyuan_attention = {
+            'q_proj': 'q_proj',
+            'k_proj': 'k_proj',
+            'v_proj': 'v_proj',
+            'o_proj': 'o_proj',
+            'q_norm': 'query_layernorm',
+            'k_norm': 'key_layernorm'
+        }
+        hunyuan_vl_map = {
+            'config': hunyuan_vl_config,
+            'model': hunyuan_vl_model,
+            'decoder': self.default_decoder,
+            'attention': hunyuan_attention
+        }
+        self.regist('hunyuan_vl', hunyuan_vl_map)
+
     def regist_gpt_oss(self):
         gpt_oss_config = {
             'hidden_size': 'hidden_size',

--- a/transformers/llm/export/utils/transformers.py
+++ b/transformers/llm/export/utils/transformers.py
@@ -841,6 +841,7 @@ class Rotary(torch.nn.Module):
         self.attention_scaling = 1.0
         self.is_scaled = False
         self.mrope_interleaved = False
+        self.mrope_axes = 3
 
         def get_theta():
             return 1.0 / (self.rope_theta ** (torch.arange(0, self.rotary_dim, 2, dtype=torch.float32) / self.rotary_dim))
@@ -848,17 +849,21 @@ class Rotary(torch.nn.Module):
         self.theta = get_theta()
         # other type
         if hasattr(config, 'rope_scaling') and config.rope_scaling is not None:
-            scaling_config = config.rope_scaling
+            scaling_config = dict(config.rope_scaling)
+            if 'xdrope_section' in scaling_config and 'mrope_section' not in scaling_config:
+                scaling_config['mrope_section'] = scaling_config['xdrope_section']
             # get rope_type
             rope_type = 'default'
-            if 'type' in config.rope_scaling:
-                rope_type = config.rope_scaling['type']
-            elif 'rope_type' in config.rope_scaling:
-                rope_type = config.rope_scaling['rope_type']
+            if 'type' in scaling_config:
+                rope_type = scaling_config['type']
+            elif 'rope_type' in scaling_config:
+                rope_type = scaling_config['rope_type']
+            if rope_type == 'xdrope':
+                rope_type = 'dynamic'
             # gen theta for rope_type
             if rope_type == 'dynamic': # NTK
-                if 'alpha' in config.rope_scaling: # NTKAlpha in Hunyuan
-                    self.rope_theta *= (config.rope_scaling['alpha'] ** (self.rotary_dim / (self.rotary_dim - 2)))
+                if 'alpha' in scaling_config: # NTKAlpha in Hunyuan
+                    self.rope_theta *= (scaling_config['alpha'] ** (self.rotary_dim / (self.rotary_dim - 2)))
                 else: # NTKScaling
                     pass
                 self.theta = get_theta()
@@ -883,6 +888,7 @@ class Rotary(torch.nn.Module):
             if 'mrope_section' in scaling_config:
                 self.mrope_interleaved = scaling_config.get('mrope_interleaved', False)
                 self.mrope_section = scaling_config['mrope_section']
+                self.mrope_axes = len(self.mrope_section)
                 self.theta = get_theta().unsqueeze(0)
                 self.theta_sections = self.theta.split(self.mrope_section, dim=-1)
                 def apply_interleaved_mrope(freqs, mrope_section):
@@ -922,17 +928,26 @@ class Rotary(torch.nn.Module):
             idx_theta = position_ids * self.theta.to(position_ids.device)
             idx_theta = idx_theta.transpose(1, 0).reshape(-1, 3 * self.rotary_dim // 2)
             idx_theta = idx_theta[:, self.mrope_reindex]
+        elif self.model_type == 'hunyuan_vl':
+            axis_theta = position_ids * self.theta.to(position_ids.device)
+            axis_theta = torch.cat((axis_theta, axis_theta), dim=-1)
+            full_sections = [section * 2 for axis, section in enumerate(self.mrope_section)]
+            axis_chunks = [axis_theta[axis].split(full_sections, dim=-1) for axis in range(self.mrope_axes)]
+            idx_theta = torch.cat([
+                axis_chunks[axis % self.mrope_axes][axis] for axis, section in enumerate(full_sections)
+            ], dim=-1)
         else:
             idx_theta = torch.concat([
-                position_ids[0] * self.theta_sections[0],
-                position_ids[1] * self.theta_sections[1],
-                position_ids[2] * self.theta_sections[2]
+                position_ids[axis] * self.theta_sections[axis]
+                for axis, section in enumerate(self.mrope_section)
             ], dim=-1)
         rotary_pos_emb = torch.stack([torch.cos(idx_theta), torch.sin(idx_theta)])
         if self.model_type in ['glm_ocr']:
             # interleaved doubling: [c0,c0,c1,c1,...,cn,cn]
             rotary_pos_emb = torch.stack((rotary_pos_emb, rotary_pos_emb), dim=-1)
             rotary_pos_emb = rotary_pos_emb.reshape(*rotary_pos_emb.shape[:-2], -1)
+        elif self.model_type == 'hunyuan_vl':
+            pass
         else:
             rotary_pos_emb = torch.cat((rotary_pos_emb, rotary_pos_emb), dim=-1)
         rotary_pos_emb = rotary_pos_emb.unsqueeze(2).unsqueeze(1)

--- a/transformers/llm/export/utils/vision.py
+++ b/transformers/llm/export/utils/vision.py
@@ -1,4 +1,6 @@
+import json
 import math
+import os
 import torch
 import torch.nn.functional as F
 import numpy as np
@@ -52,6 +54,7 @@ class Vision(torch.nn.Module):
             'minicpmv': MiniCPMVision,
             'glm_ocr': GlmOcrVision,
             'lfm2_vl': Lfm2VlVision,
+            'hunyuan_vl': HunyuanVLVision,
         }
         if model_type in visual_models:
             return visual_models[model_type]
@@ -1464,6 +1467,248 @@ class Idefics3Vision(Vision):
                     output_names=['image_embeds'],
                     dynamic_axes={
                         "pixel_values": { 0: "size" },
+                    })
+        return onnx_model
+
+
+class HunyuanVLVision(Vision):
+    def __init__(self, visual, base):
+        self.image_embeds = []
+        self.image_grid_thw = []
+        self.image_height = 512
+        self.image_width = 512
+        self.model_path = getattr(getattr(base, 'args', None), 'path', None)
+        self.is_mrope = getattr(getattr(base, 'rotary', None), 'is_mrope', False)
+        self.mrope_axes = getattr(getattr(base, 'rotary', None), 'mrope_axes', 3)
+        super().__init__(visual, base)
+        self.quant_bit = 4
+        self.transformer_fuse = False
+
+    def load(self):
+        vconfig = self.visual.config
+        self.vision_start_id = self.config.image_start_token_id
+        self.vision_end_id = self.config.image_end_token_id
+        self.image_pad_id = self.config.image_token_id
+        self.patch_size = vconfig.patch_size
+        self.merge_size = vconfig.spatial_merge_size
+        self.temporal_patch_size = vconfig.temporal_patch_size
+        self.min_pixels = vconfig.min_image_size * vconfig.min_image_size
+        self.max_pixels = vconfig.max_image_size * vconfig.max_image_size
+        if self.model_path is not None:
+            preprocessor_config = os.path.join(self.model_path, 'preprocessor_config.json')
+            if os.path.exists(preprocessor_config):
+                with open(preprocessor_config, 'r', encoding='utf-8') as f:
+                    processor_config = json.load(f)
+                self.min_pixels = int(processor_config.get('min_pixels', self.min_pixels))
+                self.max_pixels = int(processor_config.get('max_pixels', self.max_pixels))
+        self.image_height = vconfig.min_image_size
+        self.image_width = vconfig.min_image_size
+        self.llm_config['vision_type'] = 'hunyuan_vl'
+        self.llm_config['image_size'] = self.image_height
+        self.llm_config['image_size_unit'] = self.patch_size * self.merge_size
+        self.llm_config['hunyuan_patch_size'] = self.patch_size
+        self.llm_config['hunyuan_spatial_merge_size'] = self.merge_size
+        self.llm_config['hunyuan_temporal_patch_size'] = self.temporal_patch_size
+        self.llm_config['image_max_size'] = vconfig.max_image_size
+        self.llm_config['image_min_pixels'] = self.min_pixels
+        self.llm_config['image_max_pixels'] = self.max_pixels
+        self.llm_config['vision_start'] = self.vision_start_id
+        self.llm_config['vision_end'] = self.vision_end_id
+        self.llm_config['image_pad'] = self.image_pad_id
+        self.vision_start_token = self.tokenizer.id_to_str(self.vision_start_id)
+        self.vision_end_token = self.tokenizer.id_to_str(self.vision_end_id)
+        self.image_pad_token = self.tokenizer.id_to_str(self.image_pad_id)
+
+    def get_position_ids(self, input_ids, seq_len, new_tokens):
+        if not self.is_mrope:
+            return None
+        axes = self.mrope_axes
+        if new_tokens:
+            return torch.stack([torch.tensor([seq_len - 1], dtype=torch.int)] * axes)
+        position_ids = torch.arange(seq_len, dtype=torch.int)
+        position_ids = torch.stack([position_ids] * axes)
+        if input_ids is None or len(self.image_grid_thw) == 0:
+            return position_ids
+        image_token_id = getattr(self.config, 'image_token_id', None)
+        if image_token_id is None:
+            return position_ids
+        flat_input_ids = input_ids.reshape(-1).to(torch.int64)
+        image_mask = (flat_input_ids == int(image_token_id)).tolist()
+        spans = []
+        start = None
+        for index, is_image in enumerate(image_mask):
+            if is_image and start is None:
+                start = index
+            elif not is_image and start is not None:
+                spans.append((start, index))
+                start = None
+        if start is not None:
+            spans.append((start, len(image_mask)))
+        if len(spans) != len(self.image_grid_thw):
+            raise ValueError(
+                f"HunyuanVL image spans do not match image_grid_thw: spans={len(spans)}, "
+                f"grids={len(self.image_grid_thw)}"
+            )
+        merge_size = int(getattr(self, 'merge_size', 1))
+        axis_offset = max(0, axes - 3)
+        for image_index, ((span_start, span_end), grid_thw) in enumerate(zip(spans, self.image_grid_thw)):
+            _, grid_h, grid_w = [int(x) for x in grid_thw]
+            merged_h = grid_h // merge_size
+            merged_w = grid_w // merge_size
+            grid_tokens = merged_h * (merged_w + 1)
+            span_len = span_end - span_start
+            if span_len == grid_tokens + 2:
+                grid_start = span_start + 1
+            elif span_len == grid_tokens:
+                grid_start = span_start
+            else:
+                raise ValueError(
+                    "HunyuanVL image token span length does not match image_grid_thw: "
+                    f"span_length={span_len}, expected {grid_tokens} or {grid_tokens + 2}"
+                )
+            grid_end = grid_start + grid_tokens
+            width = torch.arange(merged_w + 1, dtype=torch.int).repeat(merged_h)
+            height = torch.arange(merged_h, dtype=torch.int).repeat_interleave(merged_w + 1)
+            position_ids[axis_offset, grid_start:grid_end] = width
+            position_ids[axis_offset + 1, grid_start:grid_end] = height
+            position_ids[axis_offset + 2, grid_start:grid_end] = image_index
+        return position_ids
+
+    def str_to_ids(self, prompt):
+        self.image_embeds = []
+        self.image_grid_thw = []
+        if '<img>' not in prompt or '</img>' not in prompt:
+            return self.tokenizer(prompt, return_tensors="pt")['input_ids']
+        import re
+        import requests
+        from PIL import Image
+        pattern = r'(<img>.*?</img>)'
+        parts = re.split(pattern, prompt)
+        txt_prompt = ''
+        for part in parts:
+            if re.match(pattern, part):
+                img_content = re.search(r'<img>(.*?)</img>', part).group(1)
+                image_hw = None
+                match = re.search(r'<hw>(.*?)</hw>', img_content)
+                if match:
+                    img_content = img_content[:match.start()] + img_content[match.end():]
+                    hw = match.group(1).split(',')
+                    image_hw = (int(hw[0]), int(hw[1]))
+                if img_content.startswith('http://') or img_content.startswith('https://'):
+                    image_obj = Image.open(requests.get(img_content, stream=True).raw)
+                else:
+                    image_obj = Image.open(img_content)
+                img_pad_len = self.img_process(image_obj, image_hw)
+                txt_prompt += self.vision_start_token
+                txt_prompt += self.image_pad_token * img_pad_len
+                txt_prompt += self.vision_end_token
+            else:
+                txt_prompt += part
+        return self.tokenizer(txt_prompt, return_tensors="pt")['input_ids']
+
+    def smart_resize(self, height: int, width: int):
+        factor = self.patch_size * self.merge_size
+        if max(height, width) / min(height, width) > 200:
+            raise ValueError("absolute aspect ratio must be smaller than 200")
+        h_bar = round(height / factor) * factor
+        w_bar = round(width / factor) * factor
+        if h_bar * w_bar > self.max_pixels:
+            beta = math.sqrt((height * width) / self.max_pixels)
+            h_bar = max(factor, math.floor(height / beta / factor) * factor)
+            w_bar = max(factor, math.floor(width / beta / factor) * factor)
+        elif h_bar * w_bar < self.min_pixels:
+            beta = math.sqrt(self.min_pixels / (height * width))
+            h_bar = math.ceil(height * beta / factor) * factor
+            w_bar = math.ceil(width * beta / factor) * factor
+        return h_bar, w_bar
+
+    def vision_reshape(self, images):
+        batch, channel, height, width = images.shape
+        grid_h, grid_w = height // self.patch_size, width // self.patch_size
+        patches = images.reshape(
+            batch,
+            channel,
+            grid_h // self.merge_size,
+            self.merge_size,
+            self.patch_size,
+            grid_w // self.merge_size,
+            self.merge_size,
+            self.patch_size,
+        )
+        patches = patches.permute(0, 2, 5, 3, 6, 1, 4, 7)
+        flatten_patches = patches.unsqueeze(6).expand(
+            -1, -1, -1, -1, -1, -1, self.temporal_patch_size, -1, -1
+        ).reshape(
+            batch,
+            grid_h * grid_w,
+            channel * self.temporal_patch_size * self.patch_size * self.patch_size,
+        )
+        grid_thw = torch.tensor([[1, grid_h, grid_w]], dtype=torch.long)
+        self.image_grid_thw.append([1, grid_h, grid_w])
+        return flatten_patches.reshape(-1, flatten_patches.shape[-1]), grid_thw
+
+    def images_forward(self, images):
+        pixel_values, image_grid_thw = self.vision_reshape(images)
+        return self.forward(pixel_values, image_grid_thw)
+
+    def forward(self, pixel_values, image_grid_thw):
+        output = self.visual(pixel_values, grid_thw=image_grid_thw).pooler_output
+        return output.squeeze(0).unsqueeze(1)
+
+    def img_process(self, image, image_hw=None):
+        from transformers.image_transforms import (
+            convert_to_rgb,
+            resize,
+            rescale,
+            normalize
+        )
+        from transformers.image_utils import (
+            PILImageResampling,
+            infer_channel_dimension_format,
+            to_numpy_array
+        )
+        image_width, image_height = image.size
+        if image_hw is not None:
+            image_height, image_width = image_hw
+        image = convert_to_rgb(image)
+        image = to_numpy_array(image)
+        resized_height, resized_width = self.smart_resize(image_height, image_width)
+        image_format = infer_channel_dimension_format(image)
+        image = resize(
+            image,
+            size=(resized_height, resized_width),
+            resample=PILImageResampling.BICUBIC,
+            input_data_format=image_format
+        )
+        image = rescale(image, scale=1 / 255.0, input_data_format=image_format)
+        image = normalize(image=image, mean=self.norm_mean, std=self.norm_std, input_data_format=image_format)
+        image = np.expand_dims(image, [0])
+        image = image.transpose(0, 3, 1, 2)
+        image_embed = self.images_forward(torch.from_numpy(image))
+        self.image_embeds.append(image_embed.to(dtype=self.embed_.embed.weight.dtype))
+        return image_embed.shape[0]
+
+    def embed(self, input_ids, images=None, videos=None):
+        input_embeds = self.embed_(input_ids)
+        if self.image_embeds:
+            image_mask = (input_ids == self.image_pad_id).squeeze()
+            input_embeds[image_mask] = torch.concat(self.image_embeds, dim=0).to(input_embeds.dtype)
+            self.image_embeds = []
+        return input_embeds
+
+    @spinner_run(f'export visual to ')
+    def export(self, onnx_path):
+        grid = self.image_height // self.patch_size
+        pixel_values = torch.randn([grid * grid, 3 * self.temporal_patch_size * self.patch_size * self.patch_size])
+        image_grid_thw = torch.tensor([[1, grid, grid]], dtype=torch.long)
+        onnx_model = f'{onnx_path}/visual.onnx'
+        onnx_export(self, (pixel_values, image_grid_thw),
+                    onnx_model,
+                    input_names=['pixel_values', 'image_grid_thw'],
+                    output_names=['image_embeds'],
+                    dynamic_axes={
+                        "pixel_values": { 0: "num_patches" },
+                        "image_grid_thw": { 0: "num_images" },
                     })
         return onnx_model
 

--- a/transformers/llm/export/utils/vision.py
+++ b/transformers/llm/export/utils/vision.py
@@ -1635,7 +1635,7 @@ class HunyuanVLVision(Vision):
             self.merge_size,
             self.patch_size,
         )
-        patches = patches.permute(0, 2, 5, 3, 6, 1, 4, 7)
+        patches = patches.permute(0, 2, 3, 5, 6, 1, 4, 7)
         flatten_patches = patches.unsqueeze(6).expand(
             -1, -1, -1, -1, -1, -1, self.temporal_patch_size, -1, -1
         ).reshape(
@@ -1652,7 +1652,30 @@ class HunyuanVLVision(Vision):
         return self.forward(pixel_values, image_grid_thw)
 
     def forward(self, pixel_values, image_grid_thw):
-        output = self.visual(pixel_values, grid_thw=image_grid_thw).pooler_output
+        hidden_states = self.visual.embeddings(pixel_values, image_grid_thw)
+        for layer in self.visual.layers:
+            residual = hidden_states
+            hidden_states = layer.layer_norm1(hidden_states)
+            attn = layer.self_attn
+            batch_size, seq_len, _ = hidden_states.shape
+            query = attn.q_proj(hidden_states)
+            key = attn.k_proj(hidden_states)
+            value = attn.v_proj(hidden_states)
+            query = query.view(batch_size, seq_len, attn.num_heads, attn.head_dim).transpose(1, 2)
+            key = key.view(batch_size, seq_len, attn.num_heads, attn.head_dim).transpose(1, 2)
+            value = value.view(batch_size, seq_len, attn.num_heads, attn.head_dim).transpose(1, 2)
+            attn_weights = torch.matmul(query, key.transpose(2, 3)) * attn.scaling
+            attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+            hidden_states = torch.matmul(attn_weights, value)
+            hidden_states = hidden_states.transpose(1, 2).reshape(batch_size, seq_len, -1).contiguous()
+            hidden_states = attn.o_proj(hidden_states)
+            hidden_states = residual + hidden_states
+
+            residual = hidden_states
+            hidden_states = layer.layer_norm2(hidden_states)
+            hidden_states = layer.mlp(hidden_states)
+            hidden_states = residual + hidden_states
+        output = self.visual.patch_merger(hidden_states, size=(image_grid_thw[0, 1], image_grid_thw[0, 2]))
         return output.squeeze(0).unsqueeze(1)
 
     def img_process(self, image, image_hw=None):


### PR DESCRIPTION
## Summary

This PR adds HunyuanOCR-1.5 1B support to the MNN LLM export and Omni runtime path.

It covers the HunyuanVL text mapper, Hunyuan vision export, 4-axis MRoPE / XD-RoPE position IDs, and C++ Omni image preprocessing/runtime dispatch needed for base autoregressive single-image OCR.

## Key Changes

- Add `hunyuan_vl` model mapping for nested text config and HunyuanOCR weight layout.
- Add HunyuanVL vision export for `pixel_values` and `image_grid_thw`.
- Support HunyuanOCR 4-axis MRoPE while preserving existing 3-axis behavior for other Omni models.
- Add Hunyuan-specific Omni runtime image preprocessing and visual module dispatch through `vision_type == "hunyuan_vl"`.
- Read Hunyuan vision patch/merge/temporal settings from exported config instead of hardcoding them in C++.
- Pin the exporter env to `transformers==5.13.0` so upstream HuggingFace HunyuanVL support is available.
- Remove the temporary local Hunyuan weight-loading fallback and rely on the upstream loader.
- Keep one-off alignment tooling, OpenSpec records, skill notes, and non-portable tests out of the framework patch.

## Scope Notes

- This PR targets base AR single-image OCR.
- It does not add new FlatBuffers ops.
- It does not include `dflash/` speculative decoding or video support.
- Existing non-Hunyuan MRoPE cursor semantics are preserved.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile transformers/llm/export/llmexport.py transformers/llm/export/utils/model.py transformers/llm/export/utils/model_mapper.py transformers/llm/export/utils/transformers.py transformers/llm/export/utils/vision.py`
- `cmake --build build_hunyuan_omni --target llm_demo -j$(nproc)`
- `PYTHONPATH=/tmp/hf513.aF0q9j:$PWD /data1/lyxu18/miniconda3/envs/lightx2v/bin/python transformers/llm/export/llmexport.py --path /data1/models/HunyuanOCR --export mnn --dst_path /tmp/hunyuan_ocr_e2e_mnn --mnnconvert build/MNNConvert --hqq`
- `./build_hunyuan_omni_align/hunyuan_ocr_align /tmp/hunyuan_ocr_e2e_mnn/llm_config.json /tmp/hunyuan_prompt.txt /tmp/hunyuan_align_out`
- HF reference `generate(max_new_tokens=2)` on the same OCR prompt/image matched the MNN dump tokens: first token `12858`, second token `1843`.
