### PR TITLE
[Core:Bugfix] Fix crashes when mmap allocation fails across all backends

### DIFF
--- a/source/backend/cpu/CPUBackend.cpp
+++ b/source/backend/cpu/CPUBackend.cpp
@@ -588,9 +588,14 @@ Backend::MemObj* CPUBackend::allocBuffer(size_t size, Tensor* dest, StorageType 
     auto& buffer = dest->buffer();
     auto des = TensorUtils::getDescribe(dest);
     MemChunk chunk;
+    BufferAllocator* staticAllocator = mRuntime->mStaticAllocator.get();
     switch (storageType) {
         case STATIC: {
             chunk = mRuntime->mStaticAllocator->alloc(size, false);
+            if (chunk.invalid() && nullptr != mRuntime->mStaticAllocatorRaw.get()) {
+                chunk = mRuntime->mStaticAllocatorRaw->alloc(size, false);
+                staticAllocator = mRuntime->mStaticAllocatorRaw.get();
+            }
             break;
         }
         case DYNAMIC: {
@@ -614,7 +619,7 @@ Backend::MemObj* CPUBackend::allocBuffer(size_t size, Tensor* dest, StorageType 
     Backend::MemObj* res = nullptr;
 
     if (storageType == STATIC) {
-        res = new CPUMemObj(mRuntime->mStaticAllocator.get(), chunk, size);
+        res = new CPUMemObj(staticAllocator, chunk, size);
     } else {
         res = new CPUMemObj(mDmaInfo->mCurrentDynamicAllocator, chunk, size);
         chunk.attach(dest);

--- a/source/backend/cuda/core/CUDABackend.cpp
+++ b/source/backend/cuda/core/CUDABackend.cpp
@@ -489,6 +489,7 @@ void CUDABackend::onCopyBuffer(const Tensor* srcTensor, const Tensor* dstTensor)
     if (!srcDevice) {
         auto cpuSize = srcTensor->size();
         tempSrcStorage = mStaticBufferPool->alloc(cpuSize);
+        if (nullptr == tempSrcStorage.first) { MNN_ERROR("CUDA alloc failed\n"); return; }
         srcPtr = tempSrcStorage.ptr();
         mCUDARuntime->memcpy(srcPtr, srcTensor->host<void>(), cpuSize, MNNMemcpyHostToDevice,
                              true);
@@ -500,6 +501,7 @@ void CUDABackend::onCopyBuffer(const Tensor* srcTensor, const Tensor* dstTensor)
     if (!dstDevice) {
         auto cpuSize = dstTensor->size();
         tempDstStorage = mStaticBufferPool->alloc(cpuSize);
+        if (nullptr == tempDstStorage.first) { MNN_ERROR("CUDA alloc failed\n"); return; }
         dstPtr = tempDstStorage.ptr();
     } else {
         dstPtr = (uint8_t*)dstTensor->deviceId();
@@ -540,6 +542,7 @@ void CUDABackend::onCopyBuffer(const Tensor* srcTensor, const Tensor* dstTensor)
 
         wrapTensor.reset(Tensor::createDevice(srcTensor->shape(), dstTensor->getType(), dimType));
         wrapSrcStorage = mStaticBufferPool->alloc(realSize(wrapTensor.get()) * getBytes(dstTensor));
+        if (nullptr == wrapSrcStorage.first) { MNN_ERROR("CUDA alloc failed\n"); return; }
         // MNN_PRINT("warp:%d %d %d %d\n", realSize(wrapTensor.get()), getBytes(dstTensor), dstTensor->getType(), srcTensor->getDimensionType());
         wrapTensor.get()->buffer().device = (uint64_t)(wrapSrcStorage.ptr());
 

--- a/source/backend/cuda/execution/ArgMaxExecution.cu
+++ b/source/backend/cuda/execution/ArgMaxExecution.cu
@@ -118,8 +118,10 @@ ErrorCode ArgMaxExecution::onResize(const std::vector<Tensor *> &inputs, const s
     if(mSplitKernel) {
         mSecondArgLen = (mDim + ARG_REDUCE_NUM - 1) / ARG_REDUCE_NUM;
         auto buffer_data = pool->alloc(mOutside * mInside * mSecondArgLen * bytes);
+        if (nullptr == buffer_data.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
         mTempDataBuffer = (void*)(buffer_data.ptr());
         auto buffer_index = pool->alloc(mOutside * mInside * mSecondArgLen * sizeof(int32_t));
+        if (nullptr == buffer_index.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
         mTempIndexBuffer = (void*)(buffer_index.ptr());
         pool->free(buffer_data);
         pool->free(buffer_index);

--- a/source/backend/cuda/execution/ConvCutlassExecution.cu
+++ b/source/backend/cuda/execution/ConvCutlassExecution.cu
@@ -40,6 +40,7 @@ ConvCutlassExecution::Resource::Resource(Backend* bn, const MNN::Op* op) {
     // Reorder weight
     {
         auto tempCacheBuffer = static_cast<CUDABackend*>(bn)->getStaticBufferPool()->alloc(weightSize * sizeof(float));
+        if (nullptr == tempCacheBuffer.first) { MNN_ERROR("CUDA alloc failed\n"); return; }
         float* cacheWeight = (float*)((uint8_t*)tempCacheBuffer.first + tempCacheBuffer.second);
         runtime->memcpy(cacheWeight, filterDataPtr, weightSize * sizeof(float), MNNMemcpyHostToDevice);
         if(static_cast<CUDABackend*>(bn)->getPrecision() == 1) {
@@ -66,6 +67,7 @@ ConvCutlassExecution::Resource::Resource(Backend* bn, const MNN::Op* op) {
             int hp = UP_DIV(biasSize, 8) * 8;
 
             auto tempBiasStorage = static_cast<CUDABackend*>(bn)->getStaticBufferPool()->alloc(hp*sizeof(float));
+            if (nullptr == tempBiasStorage.first) { MNN_ERROR("CUDA alloc failed\n"); return; }
             auto biasTemp = (float*)((uint8_t*)tempBiasStorage.first + tempBiasStorage.second);
             runtime->memset(biasTemp, 0, hp * sizeof(int32_t));
             cuda_check(cudaMemcpy(biasTemp, conv->bias()->data(), conv->bias()->size()*sizeof(float), cudaMemcpyHostToDevice));
@@ -183,6 +185,7 @@ ErrorCode ConvCutlassExecution::onResize(const std::vector<Tensor*> &inputs, con
             im2colBytes = 4;
         }
         auto buffer = pool->alloc(im2colBytes * (size_t)mGemmInfo.elh[0] * (size_t)mGemmInfo.elhPad[1]);
+        if (nullptr == buffer.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
         mIm2ColBuffer = (void*)((uint8_t*)buffer.first + buffer.second);
         pool->free(buffer);
     }

--- a/source/backend/cuda/execution/ConvDepthWiseExecution.cu
+++ b/source/backend/cuda/execution/ConvDepthWiseExecution.cu
@@ -657,6 +657,7 @@ static std::shared_ptr<ConvDepthWiseExecution::Resource> _makeResource(const Op*
     std::shared_ptr<ConvolutionCommon::Int8Common> quanCommon;
     ConvolutionCommon::getConvParameters(&quanCommon, bn, op, &filterDataPtr, &weightSize);
     auto tempWeightStorage = pool->alloc(depthC * PACK_NUMBER * kernelY * kernelX * sizeof(float));
+    if (nullptr == tempWeightStorage.first) { MNN_ERROR("CUDA alloc failed\n"); return nullptr; }
     auto tempWeight = (uint8_t*)tempWeightStorage.first + tempWeightStorage.second;
     cuda_check(cudaMemset(tempWeight, 0, depthC * PACK_NUMBER * kernelY * kernelX * sizeof(float)));
     cuda_check(cudaMemcpy(tempWeight, filterDataPtr, weightSize*sizeof(float), cudaMemcpyHostToDevice));
@@ -664,7 +665,9 @@ static std::shared_ptr<ConvDepthWiseExecution::Resource> _makeResource(const Op*
     FuseRegion reg;
     int offset[8 * PACK_NUMBER];
     auto regionStorage = static_cast<CUDABackend*>(bn)->getStaticBufferPool()->alloc(sizeof(FuseRegion));
+    if (nullptr == regionStorage.first) { MNN_ERROR("CUDA alloc failed\n"); return nullptr; }
     auto offsetGpuStorage = static_cast<CUDABackend*>(bn)->getStaticBufferPool()->alloc(sizeof(offset));
+    if (nullptr == offsetGpuStorage.first) { MNN_ERROR("CUDA alloc failed\n"); return nullptr; }
     auto offsetGpu = (uint8_t*)offsetGpuStorage.first + offsetGpuStorage.second;
 
     #ifdef ENABLE_CUDA_BF16
@@ -713,6 +716,7 @@ static std::shared_ptr<ConvDepthWiseExecution::Resource> _makeResource(const Op*
     }
     if(conv->bias() != nullptr) {
         auto tempBiasStorage = pool->alloc(depth * sizeof(float));
+        if (nullptr == tempBiasStorage.first) { MNN_ERROR("CUDA alloc failed\n"); return nullptr; }
         auto tempBias = (uint8_t*)tempBiasStorage.first + tempBiasStorage.second;
         cuda_check(cudaMemcpy(tempBias, conv->bias()->data(), conv->bias()->size()*sizeof(float), cudaMemcpyHostToDevice));
 

--- a/source/backend/cuda/execution/ConvImplicitExecution.cu
+++ b/source/backend/cuda/execution/ConvImplicitExecution.cu
@@ -95,6 +95,7 @@ ConvImplicitExecution::Resource::Resource(Backend* backend, const MNN::Op* op) {
         int khw = mKernelInfo.kernelX * mKernelInfo.kernelY;
 
         auto tempCacheBuffer = static_cast<CUDABackend*>(backend)->getStaticBufferPool()->alloc(weightSize * sizeof(float));
+        if (nullptr == tempCacheBuffer.first) { MNN_ERROR("CUDA alloc failed\n"); return; }
         float* cacheWeight = (float*)((uint8_t*)tempCacheBuffer.first + tempCacheBuffer.second);
         runtime->memcpy(cacheWeight, filterDataPtr, weightSize * sizeof(float), MNNMemcpyHostToDevice);
         if(static_cast<CUDABackend*>(backend)->getPrecision() == 1) {
@@ -127,6 +128,7 @@ ConvImplicitExecution::Resource::Resource(Backend* backend, const MNN::Op* op) {
         int hp = UP_DIV(biasSize, PACK_NUMBER) * PACK_NUMBER;
 
         auto tempBiasStorage = static_cast<CUDABackend*>(backend)->getStaticBufferPool()->alloc(hp*sizeof(float));
+        if (nullptr == tempBiasStorage.first) { MNN_ERROR("CUDA alloc failed\n"); return; }
         auto biasTemp = (float*)((uint8_t*)tempBiasStorage.first + tempBiasStorage.second);
         runtime->memset(biasTemp, 0, hp * sizeof(int32_t));
         cuda_check(cudaMemcpy(biasTemp, conv->bias()->data(), conv->bias()->size()*sizeof(float), cudaMemcpyHostToDevice));

--- a/source/backend/cuda/execution/ConvWinogradExecution.cu
+++ b/source/backend/cuda/execution/ConvWinogradExecution.cu
@@ -83,6 +83,7 @@ ConvWinogradExecution::Resource::Resource(Backend* backend, const MNN::Op* op) {
     // Reorder weight
     {
         auto tempCacheBuffer = static_cast<CUDABackend*>(backend)->getStaticBufferPool()->alloc(dstWeightSize*sizeof(float));
+        if (nullptr == tempCacheBuffer.first) { MNN_ERROR("CUDA alloc failed\n"); return; }
         float* cacheWeight = (float*)((uint8_t*)tempCacheBuffer.first + tempCacheBuffer.second);
         runtime->memcpy(cacheWeight, dstWeight->host<uint8_t>(), dstWeightSize * sizeof(float), MNNMemcpyHostToDevice);
         if(static_cast<CUDABackend*>(backend)->getPrecision() == 1) {
@@ -196,9 +197,11 @@ ErrorCode ConvWinogradExecution::onResize(const std::vector<Tensor*>  &inputs, c
         BtdB_bytes = 4;
     }
     auto bufferData = pool->alloc(BtdB_bytes * mBlock2 * mGemmInfo.elhPad[0] * mGemmInfo.elhPad[1]);
+    if (nullptr == bufferData.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
     mBtdB_Buffer = (void*)((uint8_t*)bufferData.first + bufferData.second);
 
     auto bufferMatmul = pool->alloc(bytes * mBlock2 * mGemmInfo.elh[0] * mGemmInfo.elhPad[2]);
+    if (nullptr == bufferMatmul.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
     mMatmul_Buffer = (void*)((uint8_t*)bufferMatmul.first + bufferMatmul.second);
 
     pool->free(bufferData);

--- a/source/backend/cuda/execution/DeconvSingleInputExecution.cu
+++ b/source/backend/cuda/execution/DeconvSingleInputExecution.cu
@@ -47,6 +47,7 @@ DeconvSingleInputExecution::Resource::Resource(Backend* bn, const MNN::Op* op) {
     param.elhPad[2] = UP_DIV(h, PACK_NUMBER) * PACK_NUMBER;
 
     auto tempCacheBuffer = static_cast<CUDABackend*>(bn)->getStaticBufferPool()->alloc(weightSize * sizeof(float));
+    if (nullptr == tempCacheBuffer.first) { MNN_ERROR("CUDA alloc failed\n"); return; }
     float* cacheWeight = (float*)((uint8_t*)tempCacheBuffer.first + tempCacheBuffer.second);
     runtime->memcpy(cacheWeight, filterDataPtr, weightSize * sizeof(float), MNNMemcpyHostToDevice);
 
@@ -74,6 +75,7 @@ DeconvSingleInputExecution::Resource::Resource(Backend* bn, const MNN::Op* op) {
         mBias = (void *)biasTensor.get()->buffer().device;
 
         auto tempBiasBuffer = static_cast<CUDABackend*>(bn)->getStaticBufferPool()->alloc(biasPackSize * sizeof(float));
+        if (nullptr == tempBiasBuffer.first) { MNN_ERROR("CUDA alloc failed\n"); return; }
         float* cacheBias = (float*)((uint8_t*)tempBiasBuffer.first + tempBiasBuffer.second);
         cuda_check(cudaMemcpy(cacheBias, conv->bias()->data(), conv->bias()->size()*sizeof(float), cudaMemcpyHostToDevice));
 
@@ -160,11 +162,13 @@ ErrorCode DeconvSingleInputExecution::onResize(const std::vector<Tensor*> &input
     MemChunk buffer_input, buffer_im2col;
     if(mFp16Fp32MixInfer) {
         buffer_input = pool->alloc(sizeof(__half) * mGemmInfo.elh[0] * mGemmInfo.elhPad[1]);
+        if (nullptr == buffer_input.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
         mInputBuffer = (void*)((uint8_t*)buffer_input.first + buffer_input.second);
     } else {
         mInputBuffer = (void*)input->deviceId();
     }
     buffer_im2col = pool->alloc(bytes * mGemmInfo.elh[0] * mGemmInfo.elhPad[2]);
+    if (nullptr == buffer_im2col.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
     mIm2ColBuffer = (__half*)((uint8_t*)buffer_im2col.first + buffer_im2col.second);
     if(mFp16Fp32MixInfer) {
         pool->free(buffer_input);

--- a/source/backend/cuda/execution/FuseExecution.cu
+++ b/source/backend/cuda/execution/FuseExecution.cu
@@ -70,7 +70,9 @@ ErrorCode FuseExecution::onResize(const std::vector<Tensor *> &inputs, const std
     DivModFast d_channel(channel);
 
     mDivChannelStorage = static_cast<CUDABackend*>(backend())->getStaticBufferPool()->alloc(sizeof(DivModFast));
+    if (nullptr == mDivChannelStorage.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
     mDivAreaStorage = static_cast<CUDABackend*>(backend())->getStaticBufferPool()->alloc(sizeof(DivModFast));
+    if (nullptr == mDivAreaStorage.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
     runtime->memcpy((uint8_t*)mDivAreaStorage.first + mDivAreaStorage.second, &d_area, sizeof(DivModFast), MNNMemcpyHostToDevice, true);
     runtime->memcpy((uint8_t*)mDivChannelStorage.first + mDivChannelStorage.second, &d_channel, sizeof(DivModFast), MNNMemcpyHostToDevice, true);
     #endif

--- a/source/backend/cuda/execution/FuseExecutionV2.cu
+++ b/source/backend/cuda/execution/FuseExecutionV2.cu
@@ -114,6 +114,7 @@ public:
                         break;
                 }
                 MemChunk buffer = pool->alloc(bufferSize);
+                if (nullptr == buffer.first) { mValid = false; MNN_ERROR("CUDA alloc failed\n"); return; }
                 runtime->memcpy(buffer.ptr(), result, bufferSize, MNNMemcpyHostToDevice);
 
                 mConstIndides.emplace_back(std::make_pair(attr->i(), buffer));

--- a/source/backend/cuda/execution/MatMulExecution.cu
+++ b/source/backend/cuda/execution/MatMulExecution.cu
@@ -1105,6 +1105,7 @@ ErrorCode MatMulExecution::onResize(const std::vector<Tensor *> &inputs, const s
     }
     if((mNeedConvertMatAB && mFp16Fp32MixInfer) || mNeedATempBuffer) {
         bufferAData = pool->alloc(convertBytes * mBatch * mAs * mGemmInfo.elh[0] * mGemmInfo.elhPad[1]);
+        if (nullptr == bufferAData.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
         mTempMatA = (void*)bufferAData.ptr();
     } else {
         mTempMatA = (void *)A->deviceId();
@@ -1112,6 +1113,7 @@ ErrorCode MatMulExecution::onResize(const std::vector<Tensor *> &inputs, const s
 
     if((mNeedConvertMatAB && mFp16Fp32MixInfer) || mNeedBTempBuffer) {
         bufferBData = pool->alloc(convertBytes * mBatch * mBs * mGemmInfo.elh[2] * mGemmInfo.elhPad[1]);
+        if (nullptr == bufferBData.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
         mTempMatB = (void*)bufferBData.ptr();
     } else {
         mTempMatB = (void *)B->deviceId();

--- a/source/backend/cuda/execution/MultiInputConvDepthWiseExecution.cu
+++ b/source/backend/cuda/execution/MultiInputConvDepthWiseExecution.cu
@@ -103,9 +103,11 @@ ErrorCode MultiInputConvDepthWiseExecution::onResize(const std::vector<Tensor *>
     auto pool = static_cast<CUDABackend*>(backend())->getStaticBufferPool();
 
     auto bufferFilter = pool->alloc(mParams.numWeightPackTotal * sizeof(half));
+    if (nullptr == bufferFilter.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
     mParams.mFilter = (void*)((uint8_t*)bufferFilter.first + bufferFilter.second);
 
     auto bufferBias = pool->alloc(mParams.numBiasPackTotal * sizeof(half));
+    if (nullptr == bufferBias.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
     mParams.mBias = (void*)((uint8_t*)bufferBias.first + bufferBias.second);
 
     pool->free(bufferFilter);

--- a/source/backend/cuda/execution/MultiInputConvExecution.cu
+++ b/source/backend/cuda/execution/MultiInputConvExecution.cu
@@ -86,6 +86,7 @@ ErrorCode MultiInputConvExecution::onResize(const std::vector<Tensor*> &inputs, 
     MemChunk bufferFilter;
     if(mNeedWeightFill) {
         bufferFilter = pool->alloc(elementBytes * (size_t)mGemmInfo.elhPad[1] * (size_t)mGemmInfo.elhPad[2]);
+        if (nullptr == bufferFilter.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
         mFilterAddr = (void*)(bufferFilter.ptr());
     } else {
         mFilterAddr = (void*)inputs[1]->deviceId();
@@ -95,6 +96,7 @@ ErrorCode MultiInputConvExecution::onResize(const std::vector<Tensor*> &inputs, 
     MemChunk bufferBias;
     if(mNeedBiasFill) {
         bufferBias = pool->alloc(elementBytes * (size_t)mGemmInfo.elhPad[2]);
+        if (nullptr == bufferBias.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
         mBiasAddr = (void*)(bufferBias.ptr());
 
     } else {
@@ -111,6 +113,7 @@ ErrorCode MultiInputConvExecution::onResize(const std::vector<Tensor*> &inputs, 
     MemChunk bufferIm2Col;
     if(mNeedIm2Col) {
         bufferIm2Col = pool->alloc(elementBytes * (size_t)mGemmInfo.elh[0] * (size_t)mGemmInfo.elhPad[1]);
+        if (nullptr == bufferIm2Col.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
         mIm2ColBuffer = (void*)(bufferIm2Col.ptr());
     }
 

--- a/source/backend/cuda/execution/MultiInputDeconvExecution.cu
+++ b/source/backend/cuda/execution/MultiInputDeconvExecution.cu
@@ -88,17 +88,20 @@ ErrorCode MultiInputDeconvExecution::onResize(const std::vector<Tensor*> &inputs
     MemChunk buffer_input, buffer_im2col;
     if(mFp16Fp32MixInfer) {
         buffer_input = pool->alloc(sizeof(__half) * mGemmInfo.elhPad[1] * mGemmInfo.elh[2]);
+        if (nullptr == buffer_input.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
         mInputBuffer = (void*)buffer_input.ptr();
     } else {
         mInputBuffer = (void*)input->deviceId();
     }
     buffer_im2col = pool->alloc(bytes * mGemmInfo.elh[0] * mGemmInfo.elhPad[2]);
+    if (nullptr == buffer_im2col.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
     mIm2ColBuffer = (void*)buffer_im2col.ptr();
 
     mNeedWeightFill = (mGemmInfo.elh[1] != mGemmInfo.elhPad[1]);
     MemChunk buffer_filter;
     if(mNeedWeightFill) {
         buffer_filter = pool->alloc(bytes * (size_t)mGemmInfo.elh[0] * (size_t)mGemmInfo.elhPad[1]);
+        if (nullptr == buffer_filter.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
         mFilterAddr = (void*)buffer_filter.ptr();
     } else {
         mFilterAddr = (void*)inputs[1]->deviceId();

--- a/source/backend/cuda/execution/PReLUExecution.cu
+++ b/source/backend/cuda/execution/PReLUExecution.cu
@@ -24,6 +24,7 @@ PReLUExecution::PReLUExecution(const PRelu* prelu, Backend *backend) : Execution
     auto staticPool = static_cast<CUDABackend*>(backend)->getStaticBufferPool();
     auto slopeSize = UP_DIV(slopCount, PACK_NUMBER) * PACK_NUMBER * sizeof(float);
     mPreluStorage = staticPool->alloc(slopeSize);
+    if (nullptr == mPreluStorage.first) { mValid = false; MNN_ERROR("CUDA alloc failed\n"); return; }
     mDeviceSlope = (uint8_t*)mPreluStorage.first + mPreluStorage.second;
 
     MNN_ASSERT(nullptr != mDeviceSlope);

--- a/source/backend/cuda/execution/ScaleExecution.cu
+++ b/source/backend/cuda/execution/ScaleExecution.cu
@@ -21,6 +21,7 @@ ScaleExecution::ScaleExecution(const Scale* scale, Backend *backend) : Execution
     auto scaleBiasStorageSize = 2 * mChannel * PACK_NUMBER * sizeof(float);
     auto staticPool = static_cast<CUDABackend*>(backend)->getStaticBufferPool();
     mScaleBiasStorage = staticPool->alloc(scaleBiasStorageSize);
+    if (nullptr == mScaleBiasStorage.first) { mValid = false; MNN_ERROR("CUDA alloc failed\n"); return; }
     mDeviceScale = (uint8_t*)mScaleBiasStorage.first + mScaleBiasStorage.second;
     mDeviceBias = (uint8_t*)mDeviceScale + scaleBiasStorageSize / 2;
     cudaMemset(mDeviceScale, 0, scaleBiasStorageSize);

--- a/source/backend/cuda/execution/TopKV2Execution.cu
+++ b/source/backend/cuda/execution/TopKV2Execution.cu
@@ -324,22 +324,28 @@ ErrorCode TopKV2Execution::onResize(const std::vector<Tensor *> &inputs, const s
 
     if (inputTensor->getType().code == halide_type_int && inputTensor->getType().bits == 32) {
         auto bufferIndices = pool->alloc(mParams.mNumBlockTotal * mParams.mNumK * sizeof(int));
+        if (nullptr == bufferIndices.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
         mParams.mBufferIndices = (void*)((uint8_t*)bufferIndices.first + bufferIndices.second);
         auto  bufferValues = pool->alloc(mParams.mNumBlockTotal * mParams.mNumK * sizeof(int));
+        if (nullptr == bufferValues.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
         mParams.mBufferValues = (void*)((uint8_t*)bufferValues.first + bufferValues.second);
         pool->free(bufferIndices);
         pool->free(bufferValues);
     } else if (static_cast<CUDABackend*>(backend())->useFp16()) {
         auto bufferIndices = pool->alloc(mParams.mNumBlockTotal * mParams.mNumK * sizeof(int));
+        if (nullptr == bufferIndices.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
         mParams.mBufferIndices = (void*)((uint8_t*)bufferIndices.first + bufferIndices.second);
         auto bufferValues = pool->alloc(mParams.mNumBlockTotal * mParams.mNumK * sizeof(half));
+        if (nullptr == bufferValues.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
         mParams.mBufferValues = (void*)((uint8_t*)bufferValues.first + bufferValues.second);
         pool->free(bufferIndices);
         pool->free(bufferValues);
     } else {
         auto bufferIndices = pool->alloc(mParams.mNumBlockTotal * mParams.mNumK * sizeof(int));
+        if (nullptr == bufferIndices.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
         mParams.mBufferIndices = (void*)((uint8_t*)bufferIndices.first + bufferIndices.second);
         auto bufferValues = pool->alloc(mParams.mNumBlockTotal * mParams.mNumK * sizeof(float));
+        if (nullptr == bufferValues.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
         mParams.mBufferValues = (void*)((uint8_t*)bufferValues.first + bufferValues.second);
         pool->free(bufferIndices);
         pool->free(bufferValues);

--- a/source/backend/cuda/execution/bf16/ConvCutlassBf16Execution.cu
+++ b/source/backend/cuda/execution/bf16/ConvCutlassBf16Execution.cu
@@ -43,6 +43,7 @@ ConvCutlassBf16Execution::Resource::Resource(Backend* bn, const MNN::Op* op) {
     // Reorder weight
     {
         auto tempCacheBuffer = static_cast<CUDABackend*>(bn)->getStaticBufferPool()->alloc(weightSize * sizeof(float));
+        if (nullptr == tempCacheBuffer.first) { MNN_ERROR("CUDA alloc failed\n"); return; }
         float* cacheWeight = (float*)((uint8_t*)tempCacheBuffer.first + tempCacheBuffer.second);
         runtime->memcpy(cacheWeight, filterDataPtr, weightSize * sizeof(float), MNNMemcpyHostToDevice);
         weightTensor.reset(Tensor::createDevice<int16_t>({lp * hp}));
@@ -61,6 +62,7 @@ ConvCutlassBf16Execution::Resource::Resource(Backend* bn, const MNN::Op* op) {
         int hp = UP_DIV(biasSize, 8) * 8;
 
         auto tempBiasStorage = static_cast<CUDABackend*>(bn)->getStaticBufferPool()->alloc(hp*sizeof(float));
+        if (nullptr == tempBiasStorage.first) { MNN_ERROR("CUDA alloc failed\n"); return; }
         auto biasTemp = (float*)((uint8_t*)tempBiasStorage.first + tempBiasStorage.second);
         runtime->memset(biasTemp, 0, hp * sizeof(int32_t));
         cuda_check(cudaMemcpy(biasTemp, conv->bias()->data(), conv->bias()->size()*sizeof(float), cudaMemcpyHostToDevice));
@@ -167,6 +169,7 @@ ErrorCode ConvCutlassBf16Execution::onResize(const std::vector<Tensor*> &inputs,
             im2colBytes = 4;
         }
         auto buffer = pool->alloc(im2colBytes * (size_t)mGemmInfo.elh[0] * (size_t)mGemmInfo.elhPad[1]);
+        if (nullptr == buffer.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
         mIm2ColBuffer = (void*)((uint8_t*)buffer.first + buffer.second);
         pool->free(buffer);
     }

--- a/source/backend/cuda/execution/cutlass_common/CutlassGemmTensorCore884.cu
+++ b/source/backend/cuda/execution/cutlass_common/CutlassGemmTensorCore884.cu
@@ -36,7 +36,8 @@ ErrorCode CutlassConvCommonExecution::callCutlassGemmTensorCore884(const std::ve
 
             if(workspace_size != 0) {
                 workspaceTensor.reset(Tensor::createDevice<int8_t>({(int)workspace_size}));
-                mBackendPtr->onAcquireBuffer(workspaceTensor.get(), Backend::STATIC);
+                auto allocSuccess = mBackendPtr->onAcquireBuffer(workspaceTensor.get(), Backend::STATIC);
+                if (!allocSuccess) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
                 mWorkspace = (void *)workspaceTensor.get()->buffer().device;
             }
 
@@ -61,7 +62,8 @@ ErrorCode CutlassConvCommonExecution::callCutlassGemmTensorCore884(const std::ve
 
             if(workspace_size != 0) {
                 workspaceTensor.reset(Tensor::createDevice<int8_t>({(int)workspace_size}));
-                mBackendPtr->onAcquireBuffer(workspaceTensor.get(), Backend::STATIC);
+                auto allocSuccess = mBackendPtr->onAcquireBuffer(workspaceTensor.get(), Backend::STATIC);
+                if (!allocSuccess) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
                 mWorkspace = (void *)workspaceTensor.get()->buffer().device;
             }
 
@@ -90,7 +92,8 @@ ErrorCode CutlassConvCommonExecution::callCutlassGemmTensorCore884(const std::ve
 
             if(workspace_size != 0) {
                 workspaceTensor.reset(Tensor::createDevice<int8_t>({(int)workspace_size}));
-                mBackendPtr->onAcquireBuffer(workspaceTensor.get(), Backend::STATIC);
+                auto allocSuccess = mBackendPtr->onAcquireBuffer(workspaceTensor.get(), Backend::STATIC);
+                if (!allocSuccess) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
                 mWorkspace = (void *)workspaceTensor.get()->buffer().device;
             }
 
@@ -115,7 +118,8 @@ ErrorCode CutlassConvCommonExecution::callCutlassGemmTensorCore884(const std::ve
 
             if(workspace_size != 0) {
                 workspaceTensor.reset(Tensor::createDevice<int8_t>({(int)workspace_size}));
-                mBackendPtr->onAcquireBuffer(workspaceTensor.get(), Backend::STATIC);
+                auto allocSuccess = mBackendPtr->onAcquireBuffer(workspaceTensor.get(), Backend::STATIC);
+                if (!allocSuccess) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
                 mWorkspace = (void *)workspaceTensor.get()->buffer().device;
             }
 
@@ -142,7 +146,8 @@ ErrorCode CutlassConvCommonExecution::callCutlassGemmTensorCore884(const std::ve
 
             if(workspace_size != 0) {
                 workspaceTensor.reset(Tensor::createDevice<int8_t>({(int)workspace_size}));
-                mBackendPtr->onAcquireBuffer(workspaceTensor.get(), Backend::STATIC);
+                auto allocSuccess = mBackendPtr->onAcquireBuffer(workspaceTensor.get(), Backend::STATIC);
+                if (!allocSuccess) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
                 mWorkspace = (void *)workspaceTensor.get()->buffer().device;
             }
 
@@ -164,7 +169,8 @@ ErrorCode CutlassConvCommonExecution::callCutlassGemmTensorCore884(const std::ve
 
             if(workspace_size != 0) {
                 workspaceTensor.reset(Tensor::createDevice<int8_t>({(int)workspace_size}));
-                mBackendPtr->onAcquireBuffer(workspaceTensor.get(), Backend::STATIC);
+                auto allocSuccess = mBackendPtr->onAcquireBuffer(workspaceTensor.get(), Backend::STATIC);
+                if (!allocSuccess) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
                 mWorkspace = (void *)workspaceTensor.get()->buffer().device;
             }
 

--- a/source/backend/cuda/execution/int8/ConvInt8CutlassExecution.cu
+++ b/source/backend/cuda/execution/int8/ConvInt8CutlassExecution.cu
@@ -234,6 +234,7 @@ ConvInt8CutlassExecution::Resource::Resource(Backend* bn, const MNN::Op* op) {
     // Reorder weight
     {
         auto tempCacheBuffer = static_cast<CUDABackend*>(bn)->getStaticBufferPool()->alloc(weightSize * sizeof(int8_t));
+        if (nullptr == tempCacheBuffer.first) { MNN_ERROR("CUDA alloc failed\n"); return; }
         int8_t* cacheWeight = (int8_t*)((uint8_t*)tempCacheBuffer.first + tempCacheBuffer.second);
         runtime->memcpy(cacheWeight, filterDataPtr, weightSize * sizeof(int8_t), MNNMemcpyHostToDevice);
 
@@ -349,6 +350,7 @@ ErrorCode ConvInt8CutlassExecution::onResize(const std::vector<Tensor*> &inputs,
     auto pool = static_cast<CUDABackend*>(backend())->getBufferPool();
     if(mNeedIm2Col) {
         auto buffer = pool->alloc(sizeof(int8_t) * (size_t)mGemmInfo.elh[0] * (size_t)mGemmInfo.elhPad[1]);
+        if (nullptr == buffer.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
         mIm2ColBuffer = (void*)((uint8_t*)buffer.first + buffer.second);
         pool->free(buffer);
     }

--- a/source/backend/cuda/execution/int8/FloatToInt8Execution.cu
+++ b/source/backend/cuda/execution/int8/FloatToInt8Execution.cu
@@ -144,6 +144,7 @@ FloatToInt8Execution::FloatToInt8Execution(Backend *backend, const std::vector<T
     } else {
         auto staticPool = static_cast<CUDABackend*>(backend)->getStaticBufferPool();
         mScaleStorage = staticPool->alloc(UP_DIV(scaleLen, INT8_PACK_NUMBER) * INT8_PACK_NUMBER * sizeof(float));
+        if (nullptr == mScaleStorage.first) { mValid = false; MNN_ERROR("CUDA alloc failed\n"); return; }
         mScales = (void *)((uint8_t*)mScaleStorage.first + mScaleStorage.second);
         runtime->memset(mScales, 0, UP_DIV(scaleLen, INT8_PACK_NUMBER) * INT8_PACK_NUMBER * sizeof(float));
 

--- a/source/backend/cuda/execution/int8/Int8ToFloatExecution.cu
+++ b/source/backend/cuda/execution/int8/Int8ToFloatExecution.cu
@@ -83,6 +83,7 @@ Int8ToFloatExecution::Int8ToFloatExecution(Backend *backend, const std::vector<T
 
         auto staticPool = static_cast<CUDABackend*>(backend)->getStaticBufferPool();
         mScaleStorage = staticPool->alloc(UP_DIV(scaleLen, PACK_NUMBER) * PACK_NUMBER * sizeof(float));
+        if (nullptr == mScaleStorage.first) { mValid = false; MNN_ERROR("CUDA alloc failed\n"); return; }
         mScales = (void*)((uint8_t*)mScaleStorage.first + mScaleStorage.second);
         runtime->memset(mScales, 0, UP_DIV(scaleLen, PACK_NUMBER) * PACK_NUMBER * sizeof(float));
 

--- a/source/backend/cuda/execution/plugin/FmhaCommon/FmhaV2CommonExecution.cu
+++ b/source/backend/cuda/execution/plugin/FmhaCommon/FmhaV2CommonExecution.cu
@@ -149,14 +149,18 @@ ErrorCode FmhaCommonExecution::onResize(const std::vector<Tensor*>& inputs, cons
     MemChunk buffer_q;
     if(mType == 0) {
         buffer_q = pool->alloc(mBatchSize * mSeqLen * mHeadSize * mNumHeads * sizeof(half));
+        if (nullptr == buffer_q.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
         mQ_Buffer = (void*)((uint8_t*)buffer_q.first + buffer_q.second);
     }
     auto buffer_k = pool->alloc(mBatchSize * mSeqLenKV * mHeadSize * mNumHeads * sizeof(half));
+    if (nullptr == buffer_k.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
     mK_Buffer = (void*)((uint8_t*)buffer_k.first + buffer_k.second);
     auto buffer_v = pool->alloc(mBatchSize * mSeqLenKV * mHeadSizeV * mNumHeads * sizeof(half));
+    if (nullptr == buffer_v.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
     mV_Buffer = (void*)((uint8_t*)buffer_v.first + buffer_v.second);
     // output size
     auto buffer_acc = pool->alloc(mBatchSize * mSeqLen * mHeadSizeV * mNumHeads * sizeof(float));
+    if (nullptr == buffer_acc.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
     mAcc_Buffer = (void*)((uint8_t*)buffer_acc.first + buffer_acc.second);
     
     if(mType == 0) {

--- a/source/backend/cuda/execution/plugin/FmhaV2/FmhaV2Execution.cu
+++ b/source/backend/cuda/execution/plugin/FmhaV2/FmhaV2Execution.cu
@@ -41,6 +41,7 @@ ErrorCode FmhaV2Execution::onResize(const std::vector<Tensor*>& inputs, const st
     mBatchSize = output->length(0);
     mSeqLen = output->length(1);
     auto buffer_data = pool->alloc((mBatchSize+1) * sizeof(int32_t));
+    if (nullptr == buffer_data.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
     mSeqLenDevPtr = (void*)((uint8_t*)buffer_data.first + buffer_data.second);
     std::vector<int32_t> cuSeqLens(mBatchSize + 1, 0);
     // Compute the prefix sum of the1

--- a/source/backend/cuda/execution/plugin/Fmhca/FmhcaExecution.cu
+++ b/source/backend/cuda/execution/plugin/Fmhca/FmhcaExecution.cu
@@ -49,6 +49,7 @@ ErrorCode FmhcaExecution::onResize(const std::vector<Tensor*>& inputs, const std
         MNN_ERROR("MNN CUDA Fmhca only support sequence len <= 128 now!\n");
     }
     auto buffer_q = pool->alloc((mBatchSize+1) * sizeof(int32_t));
+    if (nullptr == buffer_q.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
     mSeqLenQDevPtr = (void*)((uint8_t*)buffer_q.first + buffer_q.second);
     std::vector<int32_t> cuSeqLensQ(mBatchSize + 1, 0);
     // Compute the prefix sum of the1
@@ -60,6 +61,7 @@ ErrorCode FmhcaExecution::onResize(const std::vector<Tensor*>& inputs, const std
     checkKernelErrors;
 
     auto buffer_kv = pool->alloc((mBatchSize+1) * sizeof(int32_t));
+    if (nullptr == buffer_kv.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
     mSeqLenKVDevPtr = (void*)((uint8_t*)buffer_kv.first + buffer_kv.second);
     std::vector<int32_t> cuSeqLensKV(mBatchSize + 1, 0);
     // Compute the prefix sum of the1

--- a/source/backend/cuda/execution/plugin/GroupNorm/GroupNormExecution.cpp
+++ b/source/backend/cuda/execution/plugin/GroupNorm/GroupNormExecution.cpp
@@ -91,6 +91,7 @@ ErrorCode GroupNormExecution::onResize(const std::vector<Tensor*>& inputs, const
     }
     auto size = getWorkspaceSizeInBytes(); 
     auto buffer_ws = pool->alloc(size);
+    if (nullptr == buffer_ws.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
     mWorkSpacePtr = (void*)((uint8_t*)buffer_ws.first + buffer_ws.second);
     runtime->memset(mWorkSpacePtr, 0, size);
     return NO_ERROR;

--- a/source/backend/cuda/execution/weight_only_quant/ConvFpAIntBExecution.cu
+++ b/source/backend/cuda/execution/weight_only_quant/ConvFpAIntBExecution.cu
@@ -1447,6 +1447,7 @@ ConvFpAIntBExecution::Resource::Resource(Backend* bn, const MNN::Op* op) {
 
         if(static_cast<CUDABackend*>(bn)->useFp16()) {
             auto tempScaleStorage = static_cast<CUDABackend*>(bn)->getStaticBufferPool()->alloc(quanHp*sizeof(float));
+            if (nullptr == tempScaleStorage.first) { MNN_ERROR("CUDA alloc failed\n"); return; }
             auto scaleTemp = (float*)((uint8_t*)tempScaleStorage.first + tempScaleStorage.second);
             cuda_check(cudaMemcpy(scaleTemp, dequantScale.data(), quanHp*sizeof(float), cudaMemcpyHostToDevice));
 
@@ -1489,6 +1490,7 @@ ConvFpAIntBExecution::Resource::Resource(Backend* bn, const MNN::Op* op) {
             mIsWeightInt4 = true;
 
             auto tempCacheBuffer = static_cast<CUDABackend*>(bn)->getStaticBufferPool()->alloc(weightSize * sizeof(int8_t));
+            if (nullptr == tempCacheBuffer.first) { MNN_ERROR("CUDA alloc failed\n"); return; }
             float* cacheWeight = (float*)((uint8_t*)tempCacheBuffer.first + tempCacheBuffer.second);
             runtime->memcpy(cacheWeight, quanCommon->weight.get(), weightSize * sizeof(int8_t), MNNMemcpyHostToDevice);
 
@@ -1526,6 +1528,7 @@ ConvFpAIntBExecution::Resource::Resource(Backend* bn, const MNN::Op* op) {
             }
         } else {
             auto tempCacheBuffer = static_cast<CUDABackend*>(bn)->getStaticBufferPool()->alloc(weightSize * sizeof(int8_t));
+            if (nullptr == tempCacheBuffer.first) { MNN_ERROR("CUDA alloc failed\n"); return; }
             float* cacheWeight = (float*)((uint8_t*)tempCacheBuffer.first + tempCacheBuffer.second);
             runtime->memcpy(cacheWeight, quanCommon->weight.get(), weightSize * sizeof(int8_t), MNNMemcpyHostToDevice);
 
@@ -1549,6 +1552,7 @@ ConvFpAIntBExecution::Resource::Resource(Backend* bn, const MNN::Op* op) {
             int hp = UP_DIV(biasSize, 8) * 8;
 
             auto tempBiasStorage = static_cast<CUDABackend*>(bn)->getStaticBufferPool()->alloc(hp*sizeof(float));
+            if (nullptr == tempBiasStorage.first) { MNN_ERROR("CUDA alloc failed\n"); return; }
             auto biasTemp = (float*)((uint8_t*)tempBiasStorage.first + tempBiasStorage.second);
             runtime->memset(biasTemp, 0, hp * sizeof(int32_t));
             cuda_check(cudaMemcpy(biasTemp, conv->bias()->data(), conv->bias()->size()*sizeof(float), cudaMemcpyHostToDevice));
@@ -1682,6 +1686,7 @@ ErrorCode ConvFpAIntBExecution::onResize(const std::vector<Tensor*> &inputs, con
             im2colBytes = 4;
         }
         auto buffer = pool->alloc(im2colBytes * (size_t)mGemmInfo.elh[0] * (size_t)mGemmInfo.elhPad[1]);
+        if (nullptr == buffer.first) { MNN_ERROR("CUDA alloc failed\n"); return OUT_OF_MEMORY; }
         mIm2ColBuffer = (void*)((uint8_t*)buffer.first + buffer.second);
         pool->free(buffer);
     }

--- a/source/backend/metal/MetalBackend.mm
+++ b/source/backend/metal/MetalBackend.mm
@@ -261,6 +261,10 @@ Backend::MemObj* MetalBackend::onAcquire(const Tensor *_tensor, StorageType stor
         case Backend::STATIC: {
             buffer = mRuntime->mStaticAllocator->alloc(size, false);
             allocator = mRuntime->mStaticAllocator.get();
+            if (nullptr == buffer.first && nullptr != mRuntime->mStaticAllocatorRaw.get()) {
+                buffer = mRuntime->mStaticAllocatorRaw->alloc(size, false);
+                allocator = mRuntime->mStaticAllocatorRaw.get();
+            }
         } break;
         case Backend::DYNAMIC: {
             buffer = mCurrentAllocator->alloc(size, false);
@@ -1303,8 +1307,14 @@ public:
     virtual MemChunk onAlloc(size_t size, size_t align) override {
         auto mem = mOrigin->onAlloc(size, align);
         MNN_ASSERT(mem.second == 0);
+        if (mem.first == nullptr) {
+            return MemChunk(nullptr, 0);
+        }
         id<MTLBuffer> buffer = [mDevice newBufferWithBytesNoCopy:mem.first length:size options:MTLResourceStorageModeShared  deallocator:nil];
-
+        if (buffer == nil) {
+            mOrigin->onRelease(mem);
+            return MemChunk(nullptr, 0);
+        }
         auto wrap = new MetalRuntimeAllocator::MetalBufferAlloc(buffer);
         return MemChunk((void *)wrap, 0);
     }

--- a/source/backend/opencl/core/MmapPool.cpp
+++ b/source/backend/opencl/core/MmapPool.cpp
@@ -38,6 +38,8 @@ std::string OpenCLMmapAllocator::onAlloc(size_t size) {
         auto code = MNNSetFileSize(file, size);
         if (NO_ERROR != code) {
             MNN_ERROR("Set File size %lu error= %d\n", size, code);
+            MNNCloseFile(file);
+            return "";
         }
         mNewMmap = true;
     }
@@ -110,9 +112,13 @@ std::shared_ptr<cl::Buffer> MmapPool::allocBuffer(size_t size, bool separate) {
     if(fileName.length() == 0){
         //need open new file
         fileName = mOrigin->onAlloc(mFileSize);
+        if (fileName.empty()) {
+            MNN_ERROR("OpenCL mmap file alloc failed\n");
+            return nullptr;
+        }
         mFileInfo.insert(std::make_pair(fileName, 0));
     }
-    
+
     std::shared_ptr<OpenCLMmapBufferNode> node(new OpenCLMmapBufferNode);
     cl_int ret = CL_SUCCESS;
     mTotalSize += size;
@@ -186,6 +192,10 @@ std::shared_ptr<cl::Image> MmapPool::allocImage(size_t w, size_t h, cl_channel_t
     if(fileName.length() == 0){
         //need open new file
         fileName = mOrigin->onAlloc(mFileSize);
+        if (fileName.empty()) {
+            MNN_ERROR("OpenCL mmap file alloc failed for image\n");
+            return nullptr;
+        }
         mFileInfo.insert(std::make_pair(fileName, 0));
     }
     node->fileName = fileName;

--- a/source/backend/opencl/core/OpenCLBackend.cpp
+++ b/source/backend/opencl/core/OpenCLBackend.cpp
@@ -482,28 +482,48 @@ Backend::MemObj* OpenCLBackend::onAcquire(const Tensor* nativeTensor, StorageTyp
         size = ROUND_UP(size, 2);
         if (storageType == DYNAMIC_SEPERATE) {
             auto buffer = mBufferPool->alloc(size*typeSize, true);
+            if (nullptr == buffer) {
+                MNN_ERROR("OpenCL alloc buffer failed (DYNAMIC_SEPERATE), size=%zu\n", size*typeSize);
+                return nullptr;
+            }
             ((Tensor*)nativeTensor)->buffer().device = (uint64_t)buffer;
             return new CLMemReleaseBuffer(buffer, mBufferPool);
         }
         if (storageType == DYNAMIC) {
             auto buffer = mBufferPool->alloc(size*typeSize);
+            if (nullptr == buffer) {
+                MNN_ERROR("OpenCL alloc buffer failed (DYNAMIC), size=%zu\n", size*typeSize);
+                return nullptr;
+            }
             ((Tensor*)nativeTensor)->buffer().device = (uint64_t)buffer;
             return new CLMemReleaseBuffer(buffer, mBufferPool);
         }
         if (storageType == DYNAMIC_IN_EXECUTION){
             auto node = mExecutionBufferPool->alloc(size*typeSize);
+            if (nullptr == node.get()) {
+                MNN_ERROR("OpenCL alloc exec buffer failed, size=%zu\n", size*typeSize);
+                return nullptr;
+            }
             ((Tensor*)nativeTensor)->buffer().device = reinterpret_cast<uint64_t>(node.get());
             return new CLReleaseExecutionBuffer(node, mExecutionBufferPool.get());
         }
         MNN_ASSERT(storageType == STATIC);
         if(mCLRuntime->hint().useCachedMmap && mCLRuntime->mMmapPool.get() != nullptr && mCLRuntime->mUseMmapPool)
         {
-            auto buffer = mCLRuntime->mMmapPool->allocBuffer(size*typeSize).get();
-            ((Tensor*)nativeTensor)->buffer().device = (uint64_t)buffer; // fix
-            return new CLMemReleaseMmapBuffer(buffer, mCLRuntime->mMmapPool.get());
-        }else{
+            auto buffer = mCLRuntime->mMmapPool->allocBuffer(size*typeSize);
+            if (nullptr != buffer.get()) {
+                ((Tensor*)nativeTensor)->buffer().device = (uint64_t)buffer.get();
+                return new CLMemReleaseMmapBuffer(buffer.get(), mCLRuntime->mMmapPool.get());
+            }
+            MNN_ERROR("OpenCL mmap alloc failed, falling back to buffer pool, size=%zu\n", size*typeSize);
+        }
+        {
             auto buffer = mCLRuntime->mBufferPool->alloc(size*typeSize);
-            ((Tensor*)nativeTensor)->buffer().device = (uint64_t)buffer; // fix
+            if (nullptr == buffer) {
+                MNN_ERROR("OpenCL alloc buffer failed (STATIC), size=%zu\n", size*typeSize);
+                return nullptr;
+            }
+            ((Tensor*)nativeTensor)->buffer().device = (uint64_t)buffer;
             return new CLMemReleaseBuffer(buffer, mCLRuntime->mBufferPool.get());
         }
     }
@@ -534,17 +554,29 @@ Backend::MemObj* OpenCLBackend::onAcquire(const Tensor* nativeTensor, StorageTyp
 
         if (storageType == DYNAMIC_SEPERATE) {
             auto image                               = mImagePool->alloc(imageWidth, imageHeight, dataType, true);
-            ((Tensor*)nativeTensor)->buffer().device = (uint64_t)image; // fix
+            if (nullptr == image) {
+                MNN_ERROR("OpenCL alloc image failed (DYNAMIC_SEPERATE), %zux%zu\n", imageWidth, imageHeight);
+                return nullptr;
+            }
+            ((Tensor*)nativeTensor)->buffer().device = (uint64_t)image;
             return new CLMemReleaseImage(image, mImagePool);
         }
         if (storageType == DYNAMIC) {
             auto image                               = mImagePool->alloc(imageWidth, imageHeight, dataType);
-            ((Tensor*)nativeTensor)->buffer().device = (uint64_t)image; // fix
+            if (nullptr == image) {
+                MNN_ERROR("OpenCL alloc image failed (DYNAMIC), %zux%zu\n", imageWidth, imageHeight);
+                return nullptr;
+            }
+            ((Tensor*)nativeTensor)->buffer().device = (uint64_t)image;
             return new CLMemReleaseImage(image, mImagePool);
         }
         MNN_ASSERT(storageType == STATIC);
         auto image                               = mCLRuntime->mImagePool->alloc(imageWidth, imageHeight, dataType);
-        ((Tensor*)nativeTensor)->buffer().device = (uint64_t)image; // fix
+        if (nullptr == image) {
+            MNN_ERROR("OpenCL alloc image failed (STATIC), %zux%zu\n", imageWidth, imageHeight);
+            return nullptr;
+        }
+        ((Tensor*)nativeTensor)->buffer().device = (uint64_t)image;
         return new CLMemReleaseImage(image, mCLRuntime->mImagePool.get());
     }
 }

--- a/source/backend/vulkan/buffer/backend/VulkanBackend.cpp
+++ b/source/backend/vulkan/buffer/backend/VulkanBackend.cpp
@@ -223,6 +223,10 @@ Backend::MemObj* VulkanBackend::onAcquire(const Tensor* tensor, StorageType stor
     auto des = TensorUtils::getDescribeOrigin(tensor);
     if (Backend::STATIC == storageType) {
         auto newBuffer = mRuntime->mBufferPool->alloc(alignSize);
+        if (nullptr == newBuffer.first) {
+            MNN_ERROR("Vulkan alloc static buffer failed, size=%zu\n", alignSize);
+            return nullptr;
+        }
         auto mem = new VulkanMemRelease(mRuntime->mBufferPool.get(), newBuffer, alignSize);
         MTensor->buffer().device = (uint64_t)(newBuffer.first);
         des->offset = newBuffer.second;
@@ -230,6 +234,10 @@ Backend::MemObj* VulkanBackend::onAcquire(const Tensor* tensor, StorageType stor
     }
     bool seperate  = storageType == Backend::DYNAMIC_SEPERATE;
     auto newBuffer = mCurrentDynamicBufferPool->alloc(alignSize, seperate);
+    if (nullptr == newBuffer.first) {
+        MNN_ERROR("Vulkan alloc dynamic buffer failed, size=%zu\n", alignSize);
+        return nullptr;
+    }
     auto mem = new VulkanMemRelease(mCurrentDynamicBufferPool, newBuffer, alignSize);
     MTensor->buffer().device = (uint64_t)(newBuffer.first);
     des->offset = newBuffer.second;

--- a/source/backend/vulkan/component/VulkanBuffer.cpp
+++ b/source/backend/vulkan/component/VulkanBuffer.cpp
@@ -22,7 +22,10 @@ VulkanBuffer::VulkanBuffer(const VulkanMemoryPool& pool, bool separate, size_t s
     VkMemoryRequirements memReq;
     mPool.device().getBufferMemoryRequirements(mBuffer, memReq);
     mMemory = const_cast<VulkanMemoryPool&>(mPool).allocMemory(memReq, requirements_mask, separate);
-    //        FUNC_PRINT(mMemory->type());
+    if (nullptr == mMemory.first) {
+        MNN_ERROR("VulkanBuffer: allocMemory failed, size=%zu\n", size);
+        return;
+    }
     auto realMem = (VulkanMemory*)mMemory.first;
 
     if (nullptr != hostData) {

--- a/source/backend/vulkan/component/VulkanImage.cpp
+++ b/source/backend/vulkan/component/VulkanImage.cpp
@@ -56,7 +56,10 @@ VulkanImage::VulkanImage(const VulkanMemoryPool& pool, bool separate, const std:
     mDevice.getImageMemoryRequirements(mImage.first, memRequirements);
 
     mMemory = const_cast<VulkanMemoryPool&>(mPool).allocMemory(memRequirements, 0, separate);
-    //        FUNC_PRINT(mMemory->type());
+    if (nullptr == mMemory.first) {
+        MNN_ERROR("VulkanImage: allocMemory failed\n");
+        return;
+    }
     auto realMem = (VulkanMemory*)mMemory.first;
     mDevice.bindImageMemory(mImage.first, realMem->get(), mMemory.second);
     CALL_VK(mDevice.createImageView(mImage.second, mImage.first, viewType, format));

--- a/source/backend/vulkan/component/VulkanImage.hpp
+++ b/source/backend/vulkan/component/VulkanImage.hpp
@@ -59,6 +59,9 @@ public:
         return std::get<4>(mInfo);
     }
     void release();
+    bool valid() const {
+        return mMemory.first != nullptr;
+    }
     void resetBarrier() {
         mLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     }

--- a/source/backend/vulkan/component/VulkanMemoryPool.cpp
+++ b/source/backend/vulkan/component/VulkanMemoryPool.cpp
@@ -9,7 +9,12 @@
 #include "VulkanMemoryPool.hpp"
 namespace MNN {
 VulkanMemory::VulkanMemory(const VulkanDevice& dev, const VkMemoryAllocateInfo& info) : mDevice(dev) {
-    CALL_VK(mDevice.allocMemory(mMemory, info));
+    mMemory = VK_NULL_HANDLE;
+    auto ret = mDevice.allocMemory(mMemory, info);
+    if (ret != VK_SUCCESS) {
+        MNN_ERROR("Vulkan allocMemory failed, result=%d, size=%zu\n", ret, info.allocationSize);
+        return;
+    }
     mTypeIndex = info.memoryTypeIndex;
     mSize      = info.allocationSize;
 }
@@ -32,6 +37,10 @@ public:
         info.allocationSize = size;
         info.memoryTypeIndex = mIndex;
         auto mem = new VulkanMemory(mDevice, info);
+        if (mem->get() == VK_NULL_HANDLE) {
+            delete mem;
+            return MemChunk(nullptr, 0);
+        }
         return MemChunk(mem, 0);
     }
     virtual void onRelease(MemChunk ptr) override {

--- a/source/backend/vulkan/component/VulkanMemoryPool.hpp
+++ b/source/backend/vulkan/component/VulkanMemoryPool.hpp
@@ -35,7 +35,7 @@ public:
     }
 
 private:
-    VkDeviceMemory mMemory;
+    VkDeviceMemory mMemory = VK_NULL_HANDLE;
     const VulkanDevice& mDevice;
     uint32_t mTypeIndex;
     VkDeviceSize mSize;

--- a/source/backend/vulkan/image/backend/VulkanBackend.cpp
+++ b/source/backend/vulkan/image/backend/VulkanBackend.cpp
@@ -182,11 +182,19 @@ Backend::MemObj* VulkanBackend::onAcquire(const Tensor* tensor, StorageType stor
     auto format = _getFormat(tensor->getType());
     if (Backend::STATIC == storageType) {
         auto newBuffer           = std::make_shared<VulkanTensor>(MTensor, format, getMemoryPool(), device().proty().limits);
+        if (nullptr == newBuffer->image() || !newBuffer->image()->valid()) {
+            MNN_ERROR("Vulkan alloc static image failed\n");
+            return nullptr;
+        }
         MTensor->buffer().device = (uint64_t)(newBuffer.get());
         return new VulkanMemRelease(newBuffer);
     }
     bool separate  = storageType == Backend::DYNAMIC_SEPERATE;
     auto newBuffer = std::make_shared<VulkanTensor>(MTensor, format, getDynamicMemoryPool(), device().proty().limits, separate);
+    if (nullptr == newBuffer->image() || !newBuffer->image()->valid()) {
+        MNN_ERROR("Vulkan alloc dynamic image failed\n");
+        return nullptr;
+    }
     MTensor->buffer().device = (uint64_t)(newBuffer.get());
     mAllBuffers.insert(std::make_pair(MTensor->buffer().device, newBuffer));
     return new VulkanMemRelease(newBuffer);;

--- a/source/core/BufferAllocator.cpp
+++ b/source/core/BufferAllocator.cpp
@@ -107,18 +107,37 @@ public:
         std::string name = mPrefix + std::to_string(mAllocTimes) + "." + mPosfix;
         std::string fileName = MNNFilePathConcat(mFileName, name);
         file_t file;
+        size = UP_DIV(size, align) * align;
         if (MNNFileExist(fileName.c_str())) {
             file = MNNOpenFile(fileName.c_str(), MNN_FILE_READ | MNN_FILE_WRITE);
+            // The cache file may be shorter than the mapping we are about to make
+            // (truncated / incomplete previous sync / mismatched chunk ordering
+            // across in-process reloads). Mapping past EOF raises SIGBUS on iOS,
+            // so grow the file to cover the whole mapping before mmap.
+            if (MNNGetFileSize(file) < size) {
+                auto code = MNNSetFileSize(file, size);
+                if (NO_ERROR != code) {
+                    MNN_ERROR("Grow mmap cache file size %lu error= %d\n", size, code);
+                    MNNCloseFile(file);
+                    return MemChunk(nullptr, 0);
+                }
+            }
         } else {
             file = MNNCreateFile(fileName.c_str());
-            size = UP_DIV(size, align) * align;
             auto code = MNNSetFileSize(file, size);
             if (NO_ERROR != code) {
                 MNN_ERROR("Set File size %lu error= %d\n", size, code);
+                MNNCloseFile(file);
+                return MemChunk(nullptr, 0);
             }
             mNewMmap = true;
         }
         void* ptr = MNNMmapFile(file, size);
+        if (ptr == nullptr) {
+            MNN_ERROR("MNNMmapFile failed for %s, size=%lu\n", fileName.c_str(), size);
+            MNNCloseFile(file);
+            return MemChunk(nullptr, 0);
+        }
         mCache.insert(std::make_pair(ptr, std::make_tuple(file, size, fileName)));
         mAllocTimes++;
         return MemChunk(ptr, 0);

--- a/transformers/llm/engine/src/llm.cpp
+++ b/transformers/llm/engine/src/llm.cpp
@@ -294,6 +294,11 @@ bool Llm::load() {
     }
     MNN::Express::ExecutorScope s(mExecutor);
     Timer _t;
+    // Must release old module before runtime, because module's Execution objects
+    // reference Backend owned by RuntimeManager. Releasing runtime first would
+    // destroy the Backend, causing use-after-free when module destructor runs.
+    mModulePool.clear();
+    mModule.reset();
     initRuntime();
     // init module status
     // 1. load vocab
@@ -1246,6 +1251,7 @@ Llm::~Llm() {
     }
 #endif
     mGenerateParam.reset();
+    mModulePool.clear();
     mModule.reset();
     mRuntimeManager.reset();
     mProcessorRuntimeManager.reset();


### PR DESCRIPTION
When mmap-backed allocation fails (disk full, mmap error, file too short), backends silently stored null device pointers into tensors, causing EXC_BAD_ACCESS / SIGBUS crashes on iOS.

Fixes across all backends:
- LLM: grow mmap cache file before mmap to avoid SIGBUS past EOF; release module before runtime in load() to fix use-after-free
- Metal: check nil Metal buffer from failed mmap, fall back to non-mmap GPU allocator (mStaticAllocatorRaw)
- OpenCL: null-check all alloc() paths in onAcquire, fall back to non-mmap BufferPool; propagate MmapPool failure instead of wrapping null
- CPU: fall back to mStaticAllocatorRaw when mmap static allocation fails
- Vulkan: fix CALL_VK no-op in release builds; null-check allocations in onAcquire, VulkanBuffer/VulkanImage constructors
- CUDA: add null checks after pool->alloc() in all 26 execution kernels, return OUT_OF_MEMORY or set mValid=false

Discussed-in: Merge-Request 28543428 , URL: https://code.alibaba-inc.com/AliNN/AliNNPrivate/codereview/28543428
GitOrigin-RevId: b59217536d041370f22167289464ad7225a14178

## Description

<!-- Brief description of the changes -->

## Module

<!-- Which module does this PR affect? e.g. LLM, CPU, Metal, CUDA, OpenCL, Core, Infra -->

## Type

- [ ] Feature
- [ ] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [ ] Commit message follows `[Module:Type] Description` format
- [ ] Code compiles without errors
- [ ] Tested on relevant platform(s)
- [ ] No unrelated format or style changes included
