### PR TITLE
修复lora.py对 lora权重名称解析方式的缺陷

### DIFF
--- a/transformers/llm/export/utils/lora.py
+++ b/transformers/llm/export/utils/lora.py
@@ -36,7 +36,8 @@ class LoRA:
         with safe_open(path, framework="pt") as f:
             for k in f.keys():
                 names = k.split('.')
-                layer, key, name = names[4], names[6], names[7]
+                idx = names.index("layers")
+                layer, key, name = names[idx+1], names[idx+3], names[idx+4]
                 tag = layer + key
                 tensor = f.get_tensor(k).float()
                 self.lora_keys.add(key)

--- a/transformers/llm/export/utils/lora.py
+++ b/transformers/llm/export/utils/lora.py
@@ -36,7 +36,12 @@ class LoRA:
         with safe_open(path, framework="pt") as f:
             for k in f.keys():
                 names = k.split('.')
-                layer, key, name = names[4], names[6], names[7]
+                ni = next((i for i, n in enumerate(names) if n.startswith('lora_')), -1)
+                if ni < 1 or names[ni] not in ('lora_A', 'lora_B'):
+                    continue
+
+                name, key = names[ni], names[ni - 1]
+                layer = next(n for n in reversed(names[:ni - 1]) if n.isdigit())
                 tag = layer + key
                 tensor = f.get_tensor(k).float()
                 self.lora_keys.add(key)


### PR DESCRIPTION
我在单独转换lora权重时(--lora_split)发现存在一些lora权重无法转换的问题，经过排查发现是/MNN/transformers/llm/export/utils/lora.py里面对lora权重名称解析存在问题，此pr已经针对性修复并且适配通用lora权重