### PR TITLE
[Metal:Bugfix] prefill_qkv_tensor missing ATTENTION_C4 output branch

### DIFF
--- a/skills/metal-optimize/build-and-test.md
+++ b/skills/metal-optimize/build-and-test.md
@@ -2,6 +2,81 @@
 
 > **配套 SKILL.md 的 sub-doc**：build 命令、模型导出、性能测试脚本、基线数据、文件索引。做完 `kernel-basics` / `llm-optimizations` 里描述的改动后，回到这里跑测试。
 
+---
+
+## ⚠️ 每次 Metal 改动之后的强制验证流程（最重要）
+
+**任何 Metal 改动都必须走完这套流程再评估性能，否则大概率是假信号。** 这条不是建议，是硬性规则 —— 违反的代价见 § 真实教训。
+
+### Step 0. 强制重编译，别相信 make 增量
+
+Shader 是嵌入 `.hpp` 里的 C++ 字符串，改完 `.hpp` 后 `make` 有时**只重编产物但不重新 link `libMNN.dylib`**（时间戳判断问题），运行时仍加载旧 shader。
+
+```bash
+# 改完 shader 或 .mm 后，touch 强制标记 dirty，或 -B 全量重编
+touch source/backend/metal/MetalAttentionShader.hpp     # 或改动的 shader/mm
+cd build && make -j8 llm_demo
+# 或强力版：
+cd build && make -j8 -B llm_demo
+```
+
+如果测试结果诡异（比如"改了 kernel body 但行为没变"），第一步先 `ls -l build/libMNN.dylib` 看链接时间是否最新，不是就 `make -B`。
+
+### Step 1. 清 Metal pipeline binary cache
+
+Metal 会把 pipeline JIT 结果缓存到 `tmp/mnn_cachefile.bin`（launch 目录相对路径）。改 shader 后 pipeline key 可能没变（宏组合相同），Metal 会加载旧 binary → 观察到"改了 shader 但完全没生效"。
+
+```bash
+find . -name "mnn_cachefile.bin" -delete
+# 常见位置: build/tmp/mnn_cachefile.bin, ./tmp/mnn_cachefile.bin (llm_demo launch dir)
+```
+
+### Step 2. 正确性验证矩阵（必须全部跑）
+
+**只测速度不测正确性 = 假信号。** 见 § 真实教训里的 P0 flash-attn small-gate 案例。
+
+强制使用 `sampler_type: greedy, temperature: 0.0, top_k: 1` 的 config（跨 run byte-identical 是黄金标准）。
+
+对每一次改动，跑满这套矩阵：
+
+| 维度 | 覆盖点 | 为什么 |
+|---|---|---|
+| **Prompt 长度** | 短 (~50 tok) + 中 (~512 tok) + 长 (~2048 tok) | 触发不同 kernel 路径（mShortSeq / mQkSimdMatrix / mQkTensorMatrix / mFlashAttnPrefill） |
+| **FA on / off** | `MNN_ENABLE_FLASH_ATTN_PREFILL=1` 和 `=0` | 决定走 flash-attn 还是三段 pipeline (prefill_qk[_tensor] + softmax + prefill_qkv[_tensor])。两条路径都要正确 |
+| **每一个新增 env var** | 默认（不设）+ 每个显式值都跑一遍 | Env 只在 static 初始化时读一次（`static const int kX = getenv(...)`），不同值 = 完全不同分支 |
+| **至少 2 个模型 shape** | `head_dim ∈ {64, 128, 256}` × `group_size ∈ {1, 2, 4, 8}` | Qwen3-0.6B (D=128, G=2)、Qwen3-4B (D=128, G=4)、Qwen3.5-2B (D=256, G=4) — 每个都可能踩不同 layout / stride 分支 |
+
+**判据**：跟 baseline 前 N (≥ 20) tokens byte-identical，或至少输出语义合理（无乱码 / 无异常重复 / 无语言跳变）。
+
+Baseline 选取原则：
+- **首选** CPU 后端 greedy 输出（layout 无关，最干净的 oracle）
+- **次选** 已知正确的 Metal path（比如改 `prefill_qkv_tensor` 时用 FA on 的输出对拍）
+
+### Step 3. 全模型正确性 sweep（模板）
+
+```bash
+MAX_TOKENS=30
+for M in qwen3-0.6b-head-b32 qwen3-4b-head-b32 qwen3.5-0.8b-head-b32 qwen3.5-2b-head-b32; do
+  CFG=/Users/jiuqi/models/${M}/config_mtl_greedy.json
+  for FA in 1 0; do
+    echo "=== ${M} FA=${FA} ==="
+    MNN_ENABLE_FLASH_ATTN_PREFILL=$FA \
+      DYLD_LIBRARY_PATH=build:build/express build/llm_demo \
+      "$CFG" /tmp/prompt_2048_oneline.txt $MAX_TOKENS 2>&1 \
+      | awk '/^prompt file is/{f=1;next} /^#####/{f=0} f' | head -3
+    echo
+  done
+done
+```
+
+新增 env var 时把外层循环再加一维（`for E in 0 1 default; do ...`）。
+
+### Step 4. 只在 Step 2/3 全过后才跑性能对比
+
+先看正确性，正确性 OK 后才有理由测 t/s 数字。跑 3-rep A/B (WARMUP + SHUFFLE) 消噪声，见下面 § 性能测试。
+
+---
+
 ## 编译
 
 ```bash
@@ -66,6 +141,23 @@ MNN_ENABLE_FLASH_ATTN_PREFILL=0 ./llm_demo config_metal.json prompt.txt 30 > off
 MNN_ENABLE_FLASH_ATTN_PREFILL=1 ./llm_demo config_metal.json prompt.txt 30 > on.log
 diff off.log on.log
 ```
+
+## 真实教训（为什么强制验证流程存在）
+
+**案例 1：P0 flash-attn small-model gate（2026-07 M5）**
+基于 M5 pp2048 A/B "no_flash_attn +7.1% prefill" 数据，加了小模型自动关 FA 的 gate。合入前一个 correctness 抽查发现 Qwen3-0.6B 输出乱码 `个 https:// 中文文告 thái`。**"+7.1% 更快"其实是 FA off 路径本身有 bug，写错 layout 直接吐乱码，"快"只是因为少写了正确数据**。
+
+Root cause: `prefill_qkv_tensor` kernel 缺 `#ifdef ATTENTION_C4` 分支（长期潜伏），只有 c4-head 导出模型 + M5+ tensor API 路径 + FA off 三个条件同时命中才触发。前 3 次尝试 fix 反复验证"没生效"，原因是 make 增量没 relink libMNN.dylib（Step 0）+ Metal pipeline cache 命中旧 binary（Step 1）。
+
+**教训**：
+- **没有正确性验证的"性能提升"不能信** —— 假信号率极高。今天 P0-D 5 次尝试 4 次是假信号。
+- **改 shader 一定要 `touch header + make -B` + 删 pipeline cache** 后测。
+- **必须覆盖 FA on/off × 多模型** —— 单一路径过了不代表另一路径没坏。
+
+**案例 2：M3 Pro fusion 诊断（2026-07）**
+第一版脚本每场景 3-rep 全跑完再切下一场景，第一个跑的 baseline 吃冷启动税 → 后面场景全比 baseline 快 5-7%，包括理论上不该有效应的 `no_fused_Q4_gemm`（M3 Pro 硬 gated off）。用户 catch 到这个矛盾信号，`v2` 改成 outer=rep / inner=case + WARMUP + SHUFFLE 后，delta 大幅缩小。**性能测量的 process-level cold start 效应比 kernel 差异大**。
+
+---
 
 ## 性能基线（Qwen3-0.6B Q4, Mac M4）
 

--- a/source/backend/metal/MetalAttentionShader.hpp
+++ b/source/backend/metal/MetalAttentionShader.hpp
@@ -1497,18 +1497,39 @@ kernel void prefill_qkv_tensor(const device ftype* input0 [[buffer(0)]],
     // [M32, N4, N2, n4]
     auto sindex_base = (mcl * 4 + ncl) * 2 + 0;
 
-    // [M32, N4, N8]
-    // [mBatch, mSeqLen, mNumHead, mHeadDim]
-    auto xy_out = output + ((long)((b * q_seq_len + seq_idx * q_seq_piece_len + sl * 32 + mcl) * head_num + hn)) * head_dim/4 + (hm * 4 + ncl) * 2 + 0;
-    if(sl * 32 + mcl < q_seq_piece_len && seq_idx * q_seq_piece_len + sl * 32 + mcl < q_seq_len) {
-        if((hm * 4 + ncl) * 2 + 0 < head_dim/4) {
-            xy_out[0] =  ftype4(((threadgroup float4*)sdata)[sindex_base + 0]);
+    // Output layout write. Two paths depending on the exported model:
+    //   * default: [mBatch, mSeqLen, mNumHead, mHeadDim] as ftype4* stride 1
+    //     (each ftype4 packs 4 consecutive d-lane values).
+    //   * ATTENTION_C4: [mNumHead * (mHeadDim/4), mBatch * mSeqLen, 4]
+    //     — this matches Qwen3 c4-head exports; without this branch the
+    //     tensor-API kernel wrote to the default layout while the rest of
+    //     the graph assumed C4, producing garbage tokens.
+    int d_group0 = (hm * 4 + ncl) * 2 + 0;
+    int d_group1 = (hm * 4 + ncl) * 2 + 1;
+    int q_abs = seq_idx * q_seq_piece_len + sl * 32 + mcl;
+    if(sl * 32 + mcl < q_seq_piece_len && q_abs < q_seq_len) {
+#ifdef ATTENTION_C4
+        long c4_middle = (long)(b * q_seq_len + q_abs);
+        long c4_stride = (long)param.batch * (long)q_seq_len;
+        if(d_group0 < head_dim/4) {
+            output[(long)(hn * (head_dim/4) + d_group0) * c4_stride + c4_middle] =
+                ftype4(((threadgroup float4*)sdata)[sindex_base + 0]);
         }
-        if((hm * 4 + ncl) * 2 + 1 < head_dim/4) {
-            xy_out[1] =  ftype4(((threadgroup float4*)sdata)[sindex_base + 1]);
+        if(d_group1 < head_dim/4) {
+            output[(long)(hn * (head_dim/4) + d_group1) * c4_stride + c4_middle] =
+                ftype4(((threadgroup float4*)sdata)[sindex_base + 1]);
         }
+#else
+        auto xy_out = output + ((long)((b * q_seq_len + q_abs) * head_num + hn)) * head_dim/4
+                    + d_group0;
+        if(d_group0 < head_dim/4) {
+            xy_out[0] = ftype4(((threadgroup float4*)sdata)[sindex_base + 0]);
+        }
+        if(d_group1 < head_dim/4) {
+            xy_out[1] = ftype4(((threadgroup float4*)sdata)[sindex_base + 1]);
+        }
+#endif
     }
-
 }
 #endif
 


### PR DESCRIPTION
GitOrigin-RevId: 6712b454c35014a8b63b7126bf7635695e1b5dc5

## Description

<!-- Brief description of the changes -->

## Module

<!-- Which module does this PR affect? e.g. LLM, CPU, Metal, CUDA, OpenCL, Core, Infra -->

## Type

- [ ] Feature
- [ ] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [ ] Commit message follows `[Module:Type] Description` format
- [ ] Code compiles without errors
- [ ] Tested on relevant platform(s)
- [ ] No unrelated format or style changes included
