### PR TITLE
[OpenCL:Chore] Update shared_gather_buf md5 after kernel fix in #4659

### DIFF
--- a/source/backend/opencl/execution/cl/opencl_source_map.hpp
+++ b/source/backend/opencl/execution/cl/opencl_source_map.hpp
@@ -413,7 +413,7 @@ const std::map<std::string, std::string> OpenCLProgramMd5Map = {
     {"range", "97feaf25d837a325382c162ad77ae0ca"},
     {"scale_buf", "9176b8e86fd4d326e7fa14640ce13b48"},
     {"matmul_buf", "b66faece7f0591d49c289e5227d9f680"},
-    {"shared_gather_buf", "74b2cbe87698151c5c3cf718fa279cd4"},
+    {"shared_gather_buf", "7bfae0b1bee7d3c1c92990bfbebad642"},
     {"pooling", "900d1388836badea36a7e06ad7763b0d"},
     {"conv_2d_buf", "2faa0378ab0d702419a92ecc2073851a"},
     {"gemm_int", "4e64d43a8ca423a9d0dc68dcfcd64c06"},


### PR DESCRIPTION
## Summary
- Follow-up to #4659: the `shared_gather_buf.cl` fix updated the embedded kernel source (`shared_gather_buf_mnn_cl.cpp`) but not its entry in `OpenCLProgramMd5Map` (`opencl_source_map.hpp`), because `opencl_codegen.py` writes that header to the script's CWD rather than the cl/ directory.
- The md5 is used to invalidate stale tuning caches when kernel source changes; this syncs it to the fixed kernel (`74b2cbe8...` → `7bfae0b1...`, verified by re-running the codegen — the only real md5 change in the regenerated map).

## Test plan
- [x] Re-ran `opencl_codegen.py` from the cl/ directory and confirmed `shared_gather_buf` is the only md5 that differs; all other diffs are brace-formatting noise (reverted).