### PR TITLE
[Infra:Bugfix] Pin PyMNN CI test dependencies

### DIFF
--- a/.github/workflows/pymnn_linux.yml
+++ b/.github/workflows/pymnn_linux.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: prepare
         run: |
-            sudo pip3 install numpy opencv-python torch
+            sudo pip3 install "numpy<2.5" "opencv-python<5" torch
       - name: build
         run: |
             cd pymnn/pip_package

--- a/.github/workflows/pymnn_macos.yml
+++ b/.github/workflows/pymnn_macos.yml
@@ -29,7 +29,7 @@ jobs:
             python-version: '3.8.10'
       - name: prepare
         run: |
-            pip3 install numpy opencv-python torch
+            pip3 install "numpy<2.5" "opencv-python<5" torch
       - name: build
         run: |
             cd pymnn/pip_package

--- a/.github/workflows/pymnn_windows.yml
+++ b/.github/workflows/pymnn_windows.yml
@@ -30,7 +30,7 @@ jobs:
             python-version: '3.9'
       - name: prepare
         run: |
-            pip3 install numpy==1.25 opencv-python torch
+            pip3 install numpy==1.25 "opencv-python<5" torch
       - name: build
         run: |
             cd pymnn/pip_package


### PR DESCRIPTION
## Summary

- pin NumPy below 2.5 in the Linux and macOS PyMNN CI workflows
- pin `opencv-python` below 5 across Linux, macOS, and Windows
- keep the existing Windows NumPy 1.25 pin unchanged

## Root cause

The PyMNN CI workflows installed test dependencies without upper bounds. Dependency updates changed the test environment:

- NumPy 2.5 removed `np.row_stack`, breaking `test_joining` on Linux
- OpenCV Python 5 changed one-dimensional `merge` and `split` result shapes, breaking two comparison tests on Linux and macOS

## Impact

This change only affects GitHub Actions test setup. It does not change PyMNN source code, package metadata, runtime dependencies, or internal repository synchronization.

## Validation

- Linux PyMNN CI passed: https://github.com/alibaba/MNN/actions/runs/29923242643
- macOS PyMNN CI passed: https://github.com/alibaba/MNN/actions/runs/29923242299
- Windows PyMNN CI passed: https://github.com/alibaba/MNN/actions/runs/29923242385
- all three workflow YAML files parse successfully
- `git diff --check` passed
