### PR TITLE
[Metal:Bugfix] Decide flash-attn prefill before KV alloc and fail KV …

### DIFF
--- a/source/backend/metal/MetalAttention.mm
+++ b/source/backend/metal/MetalAttention.mm
@@ -454,39 +454,10 @@ void AttentionBufExecution::onEncode(const std::vector<Tensor*>& inputs, const s
 
     int group_size = mNumHead / mKvNumHead;
 
-    // temp memory alloc, handle variable set
-    Tensor* tempTensorK;
-    Tensor* tempTensorV;
-    handleKVAllocMemory();
-    id<MTLBuffer> tempBufferK;
-    id<MTLBuffer> tempBufferV;
-    if (mKvInDisk) {
-        tempBufferK = mKVCacheManager->getKeyBuffer();
-        tempBufferV = mKVCacheManager->getValueBuffer();
-    } else if (mKVCache) {
-        tempTensorK = mKVCacheManager->getKeyTensor();
-        tempTensorV = mKVCacheManager->getValueTensor();
-    } else {
-        tempTensorK = mTempK.get();
-        tempTensorV = mTempV.get();
-    }
-
     // whether use simdgroup
     bool supportSimdReduce = rt->supportSimdGroupReduce();
     bool supportSimdMatrix = rt->supportSimdGroupMatrix();
     bool supportTensorMatrix = mtbn->isSupportTensorApi(); // rt->supportTensorOps();
-
-    // decode and thread number not too large
-    mQkSimdReduce = supportSimdReduce && mShortSeq;
-    // loop_k can divide 8, thus avoid branch
-    mQkSimdMatrix = supportSimdMatrix && mSeqLen >= 16 && mHeadDim % 8 == 0;
-    // 32x32x32 tensor block — minimum seqLen=32 matches tile size
-    mQkTensorMatrix = supportTensorMatrix && mSeqLen >= 32 && mHeadDim % 32 == 0;
-
-    mSftmSimdReduce = supportSimdReduce;
-    mQkvSimdReduce = supportSimdReduce && mShortSeq && mHeadDim * mNumHead < mKvSeqLen * 32;
-    mQkvSimdMatrix = supportSimdMatrix && mSeqLen >= 16;
-    mCopySimdReduce = mKVCache && supportSimdReduce && mKVCacheManager->useDynamicScaleBuffer();
 
     // Fused prefill flash-attention: opt-in.
     // Two ways to enable (either turns FA on):
@@ -511,6 +482,12 @@ void AttentionBufExecution::onEncode(const std::vector<Tensor*>& inputs, const s
     // long context the fused path skips the O(seq^2 * B * H) mTempQK /
     // mTempSoftMax scratch allocations, which dominates peak memory.  Trade
     // is acceptable for long-context / constrained-device runs.
+    //
+    // NOTE: must be decided BEFORE handleKVAllocMemory(), which relies on
+    // mFlashAttnPrefill to skip the O(B * H * seq * kv_max) mTempQK /
+    // mTempSoftMax scratch allocation.  Deciding it afterwards made the first
+    // prefill allocate that scratch with a stale flag (GBs at 4K context on
+    // multi-B models), pushing Metal past the app memory limit.
     {
         int attentionOption = static_cast<MetalBackend*>(backend())->getRuntime()->hint().attentionOption;
         bool enableFromConfig = (attentionOption / 8) >= 1;
@@ -545,6 +522,35 @@ void AttentionBufExecution::onEncode(const std::vector<Tensor*>& inputs, const s
                       (int)mQuantKey, (int)mQuantValue);
         }
     }
+
+    // temp memory alloc, handle variable set
+    Tensor* tempTensorK;
+    Tensor* tempTensorV;
+    handleKVAllocMemory();
+    id<MTLBuffer> tempBufferK;
+    id<MTLBuffer> tempBufferV;
+    if (mKvInDisk) {
+        tempBufferK = mKVCacheManager->getKeyBuffer();
+        tempBufferV = mKVCacheManager->getValueBuffer();
+    } else if (mKVCache) {
+        tempTensorK = mKVCacheManager->getKeyTensor();
+        tempTensorV = mKVCacheManager->getValueTensor();
+    } else {
+        tempTensorK = mTempK.get();
+        tempTensorV = mTempV.get();
+    }
+
+    // decode and thread number not too large
+    mQkSimdReduce = supportSimdReduce && mShortSeq;
+    // loop_k can divide 8, thus avoid branch
+    mQkSimdMatrix = supportSimdMatrix && mSeqLen >= 16 && mHeadDim % 8 == 0;
+    // 32x32x32 tensor block — minimum seqLen=32 matches tile size
+    mQkTensorMatrix = supportTensorMatrix && mSeqLen >= 32 && mHeadDim % 32 == 0;
+
+    mSftmSimdReduce = supportSimdReduce;
+    mQkvSimdReduce = supportSimdReduce && mShortSeq && mHeadDim * mNumHead < mKvSeqLen * 32;
+    mQkvSimdMatrix = supportSimdMatrix && mSeqLen >= 16;
+    mCopySimdReduce = mKVCache && supportSimdReduce && mKVCacheManager->useDynamicScaleBuffer();
 
     bool trivialFloatMask = mHasMask && mIsAddMask && mSeqLen == 1 && inputs[3]->elementSize() == 1;
     // Max KV length for fused decode QK+softmax kernel depends on group_size

--- a/source/backend/metal/MetalKVCacheManager.hpp
+++ b/source/backend/metal/MetalKVCacheManager.hpp
@@ -33,7 +33,7 @@ private:
 
 private:
     void expandKVCacheInDisk(size_t oldSize, size_t curSize, size_t old_piece_stride, size_t old_piece_size, size_t new_piece_stride, bool need_copy, file_t specKeyFile = INVALID_FILE, file_t specValueFile = INVALID_FILE);
-    void expandKVCacheInMem(size_t oldSize, size_t old_piece_stride, size_t old_piece_size, size_t new_piece_stride, bool need_copy);
+    bool expandKVCacheInMem(size_t oldSize, size_t old_piece_stride, size_t old_piece_size, size_t new_piece_stride, bool need_copy);
 public:
     MetalKVCacheManager(Backend * backend, KVCacheConfig & kvConfig): KVCacheManager(backend, kvConfig) {
         // nothing todo

--- a/source/backend/metal/MetalKVCacheManager.mm
+++ b/source/backend/metal/MetalKVCacheManager.mm
@@ -174,10 +174,11 @@ void MetalKVCacheManager::onRealloc(KVMeta* meta) {
         size_t old_piece_size = (size_t)copy_len * valueByte;
         size_t old_piece_stride = (size_t)mMaxLength * valueByte;
 
+        auto oldTotalSize = mCurrentTotalSize;
+        auto oldMaxLength = mMaxLength;
         // align max kv_seq_len to mKvAlignNum, for simd/tensor matrix load alignment
         mMaxLength = ROUND_UP(kv_seq_len + mConfig.mExpandChunk, mConfig.mKvAlignNum);
 
-        auto oldTotalSize = mCurrentTotalSize;
         size_t size = (size_t)mKvNumHead * mMaxLength * mHeadDim * keyByte;
         mCurrentTotalSize = size;
         size_t new_piece_stride = (size_t)mMaxLength * valueByte;
@@ -187,7 +188,10 @@ void MetalKVCacheManager::onRealloc(KVMeta* meta) {
         if(mKVCacheInDisk) {
             expandKVCacheInDisk(oldTotalSize, mCurrentTotalSize, old_piece_stride, old_piece_size, new_piece_stride, needCopy);
         } else {
-            expandKVCacheInMem(old_size, old_piece_stride, old_piece_size, new_piece_stride, needCopy);
+            if (!expandKVCacheInMem(old_size, old_piece_stride, old_piece_size, new_piece_stride, needCopy)) {
+                mMaxLength = oldMaxLength;
+                mCurrentTotalSize = oldTotalSize;
+            }
         }
     }
 
@@ -255,7 +259,7 @@ void MetalKVCacheManager::onRealloc(KVMeta* meta) {
     }
 }
 
-void MetalKVCacheManager::expandKVCacheInMem(size_t oldSize, size_t old_piece_stride, size_t old_piece_size, size_t new_piece_stride, bool need_copy) {
+bool MetalKVCacheManager::expandKVCacheInMem(size_t oldSize, size_t old_piece_stride, size_t old_piece_size, size_t new_piece_stride, bool need_copy) {
     auto mtbn = static_cast<MetalBackend *>(mBackend);
     int keyByte = mQuantKey ? 1 : (mtbn->useFp16InsteadFp32() ? 2 : 4);
     int valueByte = mQuantValue ? 1 : (mtbn->useFp16InsteadFp32() ? 2 : 4);
@@ -266,16 +270,20 @@ void MetalKVCacheManager::expandKVCacheInMem(size_t oldSize, size_t old_piece_st
 
     auto res = mBackend->onAcquireBuffer(new_key, Backend::STATIC);
     res = res && mBackend->onAcquireBuffer(new_value, Backend::STATIC);
-    if(!res) {
-        MNN_ERROR("attition kv cache realloc memory error:%d\n", res);
+    auto newKeyBuf = MetalBackend::getBuffer(new_key);
+    auto newValueBuf = MetalBackend::getBuffer(new_value);
+    if (!res || nil == newKeyBuf.first || nil == newValueBuf.first) {
+        // keep the old (smaller) cache instead of memset-ing a nil buffer
+        MNN_ERROR("MNN::Metal: OUT_OF_MEMORY expanding kv cache to %d, keep old cache\n", mMaxLength);
+        delete new_key;
+        delete new_value;
+        return false;
     }
 
     // memset for qkv matmul mad, in case dirty data
-    auto newKeyBuf = MetalBackend::getBuffer(new_key);
     auto new_key_ptr = (uint8_t*)[newKeyBuf.first contents] + newKeyBuf.second;
     ::memset(new_key_ptr, 0, (size_t)mMaxLength * mKvNumHead * mHeadDim * keyByte);
 
-    auto newValueBuf = MetalBackend::getBuffer(new_value);
     auto new_value_ptr = (uint8_t*)[newValueBuf.first contents] + newValueBuf.second;
     ::memset(new_value_ptr, 0, (size_t)mMaxLength * mKvNumHead * mHeadDim * valueByte);
 
@@ -309,6 +317,7 @@ void MetalKVCacheManager::expandKVCacheInMem(size_t oldSize, size_t old_piece_st
         mKScaleBuffer = nil;
         mVScaleBuffer = nil;
     }
+    return true;
 }
 
 void MetalKVCacheManager::expandKVCacheInDisk(size_t oldSize, size_t curSize, size_t old_piece_stride, size_t old_piece_size, size_t new_piece_stride, bool need_copy, file_t specKeyFile, file_t specValueFile) {


### PR DESCRIPTION
…cache expansion safely

Link: https://code.alibaba-inc.com/AliNN/AliNNPrivate/codereview/28810722
GitOrigin-RevId: 7512195623e71f808e9d804b7982b18c4b5dbb99

## Description

<!-- Brief description of the changes -->

## Module

<!-- Which module does this PR affect? e.g. LLM, CPU, Metal, CUDA, OpenCL, Core, Infra -->

## Type

- [ ] Feature
- [ ] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [ ] Commit message follows `[Module:Type] Description` format
- [ ] Code compiles without errors
- [ ] Tested on relevant platform(s)
- [ ] No unrelated format or style changes included
