### PR TITLE
[LLM:Feature] Support text-only Qwen3.5 (model_type=qwen3_5_text) in llmexport

### DIFF
--- a/transformers/llm/export/utils/model_mapper.py
+++ b/transformers/llm/export/utils/model_mapper.py
@@ -1085,6 +1085,22 @@ class ModelMapper:
             'linear_attention': qwen3_5_linear_attention
         }
         self.regist('qwen3_5', qwen3_5_map)
+        # Text-only Qwen3.5 (model_type=qwen3_5_text, Qwen3_5ForCausalLM): no visual tower;
+        # config fields live at the top level rather than under text_config.* (only the
+        # multimodal variant nests them).
+        qwen3_5_text_config = {k: v.replace('text_config.', '') for k, v in qwen3_5_config.items()}
+        # The live module hierarchy is flat: transformers builds model.layers (not
+        # language_model.layers); the checkpoint's language_model.* keys are remapped on
+        # load. do_map walks live modules, so use the flat default_model minus visual.
+        qwen3_5_text_model = {k: v for k, v in self.default_model.items() if k != 'visual'}
+        qwen3_5_text_map = {
+            'config': qwen3_5_text_config,
+            'model': qwen3_5_text_model,
+            'decoder': self.default_decoder,
+            'attention': self.default_attention,
+            'linear_attention': qwen3_5_linear_attention
+        }
+        self.regist('qwen3_5_text', qwen3_5_text_map)
         qwen3_5_moe_mlp = {
             'num_experts': 'experts.num_experts',
             'top_k': 'gate.top_k',

--- a/transformers/llm/export/utils/transformers.py
+++ b/transformers/llm/export/utils/transformers.py
@@ -91,7 +91,7 @@ class Attention(torch.nn.Module):
             self.num_key_value_heads = config.num_key_value_heads
         self.num_key_value_groups = self.num_heads // self.num_key_value_heads
         ModelMapper.do_map(self, attn, mapper['attention'])
-        if config.model_type in ['qwen3_5', 'qwen3_5_moe']:
+        if config.model_type in ['qwen3_5', 'qwen3_5_moe', 'qwen3_5_text']:
             # Qwen3.5 attention norms use gamma=(1+weight). FusedRoPE stores
             # norm.weight as gamma, so canonicalize the offset semantics first.
             self.q_norm = canonical_rms_norm(getattr(self, 'q_norm', None), 1.0)
@@ -1049,7 +1049,7 @@ class Rotary(torch.nn.Module):
             return self.chatglm_rotary_pos(x, cos, sin)
         if self.model_type == 'chatglm2':
             return self.chatglm2_rotary_pos(x, cos, sin)
-        if self.model_type in ['phi-msft', 'qwen3_5', 'qwen3_5_moe']:
+        if self.model_type in ['phi-msft', 'qwen3_5', 'qwen3_5_moe', 'qwen3_5_text']:
             return self.phi_rotary_pos(x, cos, sin)
         if self.model_type in ['ernie4_5', 'glm_ocr']:
             return self.ernie_rotary_pos(x, cos, sin)


### PR DESCRIPTION
## Description

支持纯文本版 Qwen3.5（`Qwen3_5ForCausalLM`，`model_type=qwen3_5_text`）的导出。

`llmexport` 目前只处理多模态版 Qwen3.5（`model_type=qwen3_5`）。纯文本变体——也就是做纯文本任务的微调/蒸馏时，用 `AutoModelForCausalLM` 加载官方 Qwen3.5 得到的那个架构——**既导不出来，强行绕过去导出的模型数值也是错的**。

缺了两处：

**1. mapper 没注册，回退到 Llama 的 default_map。** `get_map()` 找不到 `qwen3_5_text`，返回 `default_map`，而它不认识 Gated-DeltaNet 线性注意力的 config，导出直接崩：

```
AttributeError: 'LlmConfig' object has no attribute 'linear_conv_kernel_dim'
```

**2. Q/K RMSNorm 的 unit-offset 没应用，这一处是数值上致命的。** Qwen3.5 的 q_norm/k_norm 用的是 `gamma = (1 + weight)` 语义，在 `Attention.__init__` 里通过 `canonical_rms_norm(norm, 1.0)` 规范化，但条件只写了 `model_type in ['qwen3_5', 'qwen3_5_moe']`。纯文本变体跳过了这一步，用的是 `weight`（接近 0）而不是 `1 + weight`（接近 1），Q/K 归一化被破坏。

麻烦的是模型仍然能转换、也能吐出**语句通顺**的文本，很容易被忽略，实际 logits 已经被系统性压平了。我这边实测：同一个 prompt 下正确 token 的 logit 在 HF 是 25.98、在 MNN 只有 19.23，greedy 解码第 0 个 token 就分叉。

**改动：**

- 注册 `qwen3_5_text` mapper：config 走顶层路径（多模态版才把字段嵌在 `text_config.*` 下）、model 走扁平路径（`model.layers`、`lm_head`、无 `visual`），decoder / attention / linear_attention 三个子映射直接复用现有的 qwen3_5 版本。
- 把 `qwen3_5_text` 加进 q/k norm 的 unit-offset 判断，以及 `apply_rotary_pos` 的 partial-rotary 分发。

不改变任何其他 model_type 的行为。

**验证**（0.8B 微调模型，24 层 GDN 混合注意力，`partial_rotary_factor=0.25`，交错 mrope，词表 248320）：

- tokenizer：326 条文本（中英混排、设备名、MAC/IP、emoji）HF 与 MNN 编码逐条一致。
- 逐 token 对拍（bf16 导出，greedy，precision=high）：5 条工具调用 prompt 的前 128 个 token 与 HF 完全一致。修复前是第 0 个 token 就分叉。
- 4bit 部署（`--quant_bit 4 --quant_block 64 --sym`）：在 93 条工具调用评测集上准确率 88.0%，HF bf16 是 90.2%，剩下的差距来自量化而非转换。

复现：修复前对任意 `Qwen3_5ForCausalLM` 权重执行 `llmexport.py --path <ckpt> --export mnn` 会报 `linear_conv_kernel_dim` 缺失，修复后正常。

## Module

LLM（`transformers/llm/export`）

## Type

- [x] Feature
- [ ] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [x] Tested on relevant platform(s)
- [x] No unrelated format or style changes included
