### PR TITLE
[CPU:Perf] Optimize LinearAttention x86 kernels

### DIFF
--- a/source/backend/cpu/CPULinearAttention.cpp
+++ b/source/backend/cpu/CPULinearAttention.cpp
@@ -882,7 +882,8 @@ void CPULinearAttention::gated_delta_rule_mnn(const std::vector<Tensor*>& inputs
                 // ── Step 3+4: L2 Normalization + Scale, plus dot(k, q) ──
                 float kq = 0.0f;
                 if (bytes == 4) {
-                    kq = gcore->MNNNormalizeQKAndDot(reinterpret_cast<float*>(q_local), reinterpret_cast<float*>(k_local), qScale, useL2Norm, d_k);
+                    kq = gcore->MNNNormalizeQKAndDot(reinterpret_cast<float*>(q_local),
+                                                     reinterpret_cast<float*>(k_local), qScale, useL2Norm, d_k);
                 } else if (useL2Norm) {
                     const float eps = 1e-6f;
                     float qSumSq = 0.0f, kSumSq = 0.0f;
@@ -1044,7 +1045,8 @@ void CPULinearAttention::gated_delta_rule_decode(const std::vector<Tensor*>& inp
             // ── Step 3+4: L2 Normalization + Scale, plus dot(k, q) ──
             float kq = 0.0f;
             if (bytes == 4) {
-                kq = gcore->MNNNormalizeQKAndDot(reinterpret_cast<float*>(q_local), reinterpret_cast<float*>(k_local), qScale, useL2Norm, d_k);
+                kq = gcore->MNNNormalizeQKAndDot(reinterpret_cast<float*>(q_local), reinterpret_cast<float*>(k_local),
+                                                 qScale, useL2Norm, d_k);
             } else if (useL2Norm) {
                 const float eps = 1e-6f;
                 float qSumSq = 0.0f, kSumSq = 0.0f;

--- a/source/backend/cpu/CPULinearAttention.cpp
+++ b/source/backend/cpu/CPULinearAttention.cpp
@@ -879,8 +879,11 @@ void CPULinearAttention::gated_delta_rule_mnn(const std::vector<Tensor*>& inputs
                     _writeElement(v_local, i, vv, bytes);
                 }
 
-                // ── Step 3+4: L2 Normalization + Scale (fused) ──
-                if (useL2Norm) {
+                // ── Step 3+4: L2 Normalization + Scale, plus dot(k, q) ──
+                float kq = 0.0f;
+                if (bytes == 4) {
+                    kq = gcore->MNNNormalizeQKAndDot(reinterpret_cast<float*>(q_local), reinterpret_cast<float*>(k_local), qScale, useL2Norm, d_k);
+                } else if (useL2Norm) {
                     const float eps = 1e-6f;
                     float qSumSq = 0.0f, kSumSq = 0.0f;
                     for (int i = 0; i < d_k; ++i) {
@@ -905,10 +908,10 @@ void CPULinearAttention::gated_delta_rule_mnn(const std::vector<Tensor*>& inputs
                 float decay = decayPtr[b * L * H + t * H + h];
                 float beta_t = _readTokenChannel(betaPtr, betaC4, b, t, h, B, L, H, bytes, pack);
 
-                // dot(k, q) — small reduction in fp32 for precision.
-                float kq = 0.0f;
-                for (int i = 0; i < d_k; ++i) {
-                    kq += _readElement(k_local, i, bytes) * _readElement(q_local, i, bytes);
+                if (bytes != 4) {
+                    for (int i = 0; i < d_k; ++i) {
+                        kq += _readElement(k_local, i, bytes) * _readElement(q_local, i, bytes);
+                    }
                 }
 
                 // out_t is written; state S is updated in-place.
@@ -1038,8 +1041,11 @@ void CPULinearAttention::gated_delta_rule_decode(const std::vector<Tensor*>& inp
             ::memcpy(k_local, kBase, d_k * bytes);
             ::memcpy(v_local, vBase, d_v * bytes);
 
-            // ── Step 3+4: L2 Normalization + Scale (fused) ──
-            if (useL2Norm) {
+            // ── Step 3+4: L2 Normalization + Scale, plus dot(k, q) ──
+            float kq = 0.0f;
+            if (bytes == 4) {
+                kq = gcore->MNNNormalizeQKAndDot(reinterpret_cast<float*>(q_local), reinterpret_cast<float*>(k_local), qScale, useL2Norm, d_k);
+            } else if (useL2Norm) {
                 const float eps = 1e-6f;
                 float qSumSq = 0.0f, kSumSq = 0.0f;
                 for (int i = 0; i < d_k; ++i) {
@@ -1072,9 +1078,10 @@ void CPULinearAttention::gated_delta_rule_decode(const std::vector<Tensor*>& inp
 
             // Analytic correction: delta = beta * (v - decay * vPred);
             //                      out   = decay * out_q + dot(k,q) * delta.
-            float kq = 0.0f;
-            for (int i = 0; i < d_k; ++i) {
-                kq += _readElement(k_local, i, bytes) * _readElement(q_local, i, bytes);
+            if (bytes != 4) {
+                for (int i = 0; i < d_k; ++i) {
+                    kq += _readElement(k_local, i, bytes) * _readElement(q_local, i, bytes);
+                }
             }
             for (int i = 0; i < d_v; ++i) {
                 const float vPred_i = decay * _readElement(localVPred, i, bytes);

--- a/source/backend/cpu/compute/CommonOptFunction.cpp
+++ b/source/backend/cpu/compute/CommonOptFunction.cpp
@@ -274,6 +274,32 @@ static void MNNCountMaxMinValue(const float* source, float* minVal, float* maxVa
 #endif
 }
 
+static float MNNNormalizeQKAndDotDefault(float* q, float* k, float qScale, bool useL2Norm, size_t dk) {
+    if (!useL2Norm) {
+        float qk = 0.0f;
+        for (size_t i = 0; i < dk; ++i) {
+            q[i] *= qScale;
+            qk += q[i] * k[i];
+        }
+        return qk;
+    }
+    float qSumSq = 0.0f;
+    float kSumSq = 0.0f;
+    float qk = 0.0f;
+    for (size_t i = 0; i < dk; ++i) {
+        qSumSq += q[i] * q[i];
+        kSumSq += k[i] * k[i];
+        qk += q[i] * k[i];
+    }
+    const float qNormScale = qScale / sqrtf(qSumSq + 1e-6f);
+    const float kNormScale = 1.0f / sqrtf(kSumSq + 1e-6f);
+    for (size_t i = 0; i < dk; ++i) {
+        q[i] *= qNormScale;
+        k[i] *= kNormScale;
+    }
+    return qk * qNormScale * kNormScale;
+}
+
 #ifdef MNN_LOW_MEMORY
 static void MNNAbsMaxFP32(const float* source, float* absmax, size_t src_depth_quad, size_t realSize, int pack) {
 #ifdef __aarch64__
@@ -4821,6 +4847,7 @@ void MNNCoreFunctionInit() {
     gCoreFunction->MNNDualMatVec = MNNDualMatVecDefault;
     gCoreFunction->MNNDecayRankOneUpdate = MNNDecayRankOneUpdateDefault;
     gCoreFunction->MNNFusedGatedDelta = MNNFusedGatedDeltaDefault;
+    gCoreFunction->MNNNormalizeQKAndDot = MNNNormalizeQKAndDotDefault;
 
     // Lowp
     gCoreFunction->MNNFp32ToLowp = nullptr;

--- a/source/backend/cpu/compute/CommonOptFunction.h
+++ b/source/backend/cpu/compute/CommonOptFunction.h
@@ -370,6 +370,7 @@ struct CoreFunctions {
     // 'kq' must be precomputed as dot(k,q) by the caller.
     void (*MNNFusedGatedDelta)(float* S, const float* k, const float* q, const float* v, float* out, float decay,
                                float beta, float kq, size_t dk, size_t dv);
+    float (*MNNNormalizeQKAndDot)(float* q, float* k, float qScale, bool useL2Norm, size_t dk);
     void (*MNNCountMaxMinValue)(const float* source, float* minVal, float* maxVal, size_t size);
     // Packed layout is [channelUnit, batch, pack]. residual and sum are an optional pair; threads split batch work.
     void (*MNNNormPacked)(float* dest, float* sum, const float* source, const float* residual, const float* gamma,

--- a/source/backend/cpu/x86_x64/AVX2Functions.cpp
+++ b/source/backend/cpu/x86_x64/AVX2Functions.cpp
@@ -128,6 +128,7 @@ bool AVX2Functions::init(int cpuFlags) {
     coreFunction->pack = 8;
     coreFunction->MNNNormPacked = _MNNNormPacked_Float<8>;
     _AVX_ExtraInit(coreFunction);
+    _AVX_LinearAttentionInit(coreFunction);
     // Winograd
     _AVX_WinogradInit(coreFunction);
     if (cpuFlags & libyuv::kCpuHasFMA3) {
@@ -146,6 +147,7 @@ bool AVX2Functions::init(int cpuFlags) {
         coreFunction->MNNNormPacked = _MNNNormPacked_Float<16>;
         _AVX512_ReorderInit(coreFunction);
         _AVX512_ExtraInit(coreFunction);
+        _AVX512_LinearAttentionInit(coreFunction);
         _AVX512_WinogradInit(coreFunction);
         coreFunction->MNNPackForMatMul_B = _AVX512_MNNPackForMatMul_B;
         coreFunction->MNNPackC4ForMatMul_A = _AVX512_MNNPackC8ForMatMul_A;

--- a/source/backend/cpu/x86_x64/avx/FunctionSummary.hpp
+++ b/source/backend/cpu/x86_x64/avx/FunctionSummary.hpp
@@ -65,6 +65,7 @@ void _AVX_MNNUnpackCUnitTranspose(float* dst, const float* src, size_t area, siz
 void _AVX_MNNPackForMatMul_B(float* dest, const float* source, size_t h, size_t kernelsize, size_t ic, bool transpose);
 
 void _AVX_ExtraInit(void* functions);
+void _AVX_LinearAttentionInit(void* functions);
 void _AVX_WinogradInit(void* functions);
 
 void _AVX_MNNGelu(float *dst, const float *src, size_t size, float* parameters);

--- a/source/backend/cpu/x86_x64/avx/LinearAttentionFunctions.cpp
+++ b/source/backend/cpu/x86_x64/avx/LinearAttentionFunctions.cpp
@@ -1,0 +1,191 @@
+//
+//  LinearAttentionFunctions.cpp
+//  MNN
+//
+
+#include "FunctionSummary.hpp"
+
+namespace {
+
+using namespace MNN;
+
+void _AVX_MNNDualMatVec(const float* S, const float* k, const float* q, float* outK, float* outQ, size_t dk,
+                        size_t dv) {
+    size_t j = 0;
+    for (; j + 8 <= dv; j += 8) {
+        __m256 sumK = _mm256_setzero_ps();
+        __m256 sumQ = _mm256_setzero_ps();
+        for (size_t i = 0; i < dk; ++i) {
+            const __m256 state = _mm256_loadu_ps(S + i * dv + j);
+            sumK = _mm256_add_ps(sumK, _mm256_mul_ps(state, _mm256_set1_ps(k[i])));
+            sumQ = _mm256_add_ps(sumQ, _mm256_mul_ps(state, _mm256_set1_ps(q[i])));
+        }
+        _mm256_storeu_ps(outK + j, sumK);
+        _mm256_storeu_ps(outQ + j, sumQ);
+    }
+    for (; j < dv; ++j) {
+        float sumK = 0.0f;
+        float sumQ = 0.0f;
+        for (size_t i = 0; i < dk; ++i) {
+            const float state = S[i * dv + j];
+            sumK += state * k[i];
+            sumQ += state * q[i];
+        }
+        outK[j] = sumK;
+        outQ[j] = sumQ;
+    }
+}
+
+void _AVX_MNNDecayRankOneUpdate(float* S, const float* k, const float* delta, float decay, size_t dk, size_t dv) {
+    const __m256 decayVec = _mm256_set1_ps(decay);
+    for (size_t i = 0; i < dk; ++i) {
+        float* row = S + i * dv;
+        const __m256 key = _mm256_set1_ps(k[i]);
+        size_t j = 0;
+        for (; j + 8 <= dv; j += 8) {
+            const __m256 state = _mm256_loadu_ps(row + j);
+            const __m256 update = _mm256_mul_ps(key, _mm256_loadu_ps(delta + j));
+            _mm256_storeu_ps(row + j, _mm256_add_ps(_mm256_mul_ps(decayVec, state), update));
+        }
+        for (; j < dv; ++j) {
+            row[j] = decay * row[j] + k[i] * delta[j];
+        }
+    }
+}
+
+void _AVX_MNNFusedGatedDelta(float* S, const float* k, const float* q, const float* v, float* out, float decay,
+                             float beta, float kq, size_t dk, size_t dv) {
+    const __m256 decayVec = _mm256_set1_ps(decay);
+    const __m256 betaVec = _mm256_set1_ps(beta);
+    const __m256 kqVec = _mm256_set1_ps(kq);
+    size_t j = 0;
+    // Process two vectors per state row to improve locality for common
+    // d_v=64/128 shapes without exhausting AVX2 registers.
+    for (; j + 16 <= dv; j += 16) {
+        __m256 sumK0 = _mm256_setzero_ps();
+        __m256 sumQ0 = _mm256_setzero_ps();
+        __m256 sumK1 = _mm256_setzero_ps();
+        __m256 sumQ1 = _mm256_setzero_ps();
+        for (size_t i = 0; i < dk; ++i) {
+            const float* row = S + i * dv + j;
+            const __m256 key = _mm256_set1_ps(k[i]);
+            const __m256 query = _mm256_set1_ps(q[i]);
+            const __m256 state0 = _mm256_loadu_ps(row);
+            const __m256 state1 = _mm256_loadu_ps(row + 8);
+            sumK0 = _mm256_add_ps(sumK0, _mm256_mul_ps(state0, key));
+            sumQ0 = _mm256_add_ps(sumQ0, _mm256_mul_ps(state0, query));
+            sumK1 = _mm256_add_ps(sumK1, _mm256_mul_ps(state1, key));
+            sumQ1 = _mm256_add_ps(sumQ1, _mm256_mul_ps(state1, query));
+        }
+        const __m256 delta0 =
+            _mm256_mul_ps(betaVec, _mm256_sub_ps(_mm256_loadu_ps(v + j), _mm256_mul_ps(decayVec, sumK0)));
+        const __m256 delta1 =
+            _mm256_mul_ps(betaVec, _mm256_sub_ps(_mm256_loadu_ps(v + j + 8), _mm256_mul_ps(decayVec, sumK1)));
+        _mm256_storeu_ps(out + j, _mm256_add_ps(_mm256_mul_ps(decayVec, sumQ0), _mm256_mul_ps(kqVec, delta0)));
+        _mm256_storeu_ps(out + j + 8, _mm256_add_ps(_mm256_mul_ps(decayVec, sumQ1), _mm256_mul_ps(kqVec, delta1)));
+        for (size_t i = 0; i < dk; ++i) {
+            float* row = S + i * dv + j;
+            const __m256 key = _mm256_set1_ps(k[i]);
+            _mm256_storeu_ps(row,
+                             _mm256_add_ps(_mm256_mul_ps(decayVec, _mm256_loadu_ps(row)), _mm256_mul_ps(key, delta0)));
+            _mm256_storeu_ps(
+                row + 8, _mm256_add_ps(_mm256_mul_ps(decayVec, _mm256_loadu_ps(row + 8)), _mm256_mul_ps(key, delta1)));
+        }
+    }
+    for (; j + 8 <= dv; j += 8) {
+        __m256 sumK = _mm256_setzero_ps();
+        __m256 sumQ = _mm256_setzero_ps();
+        for (size_t i = 0; i < dk; ++i) {
+            const __m256 state = _mm256_loadu_ps(S + i * dv + j);
+            sumK = _mm256_add_ps(sumK, _mm256_mul_ps(state, _mm256_set1_ps(k[i])));
+            sumQ = _mm256_add_ps(sumQ, _mm256_mul_ps(state, _mm256_set1_ps(q[i])));
+        }
+        const __m256 delta =
+            _mm256_mul_ps(betaVec, _mm256_sub_ps(_mm256_loadu_ps(v + j), _mm256_mul_ps(decayVec, sumK)));
+        _mm256_storeu_ps(out + j, _mm256_add_ps(_mm256_mul_ps(decayVec, sumQ), _mm256_mul_ps(kqVec, delta)));
+        for (size_t i = 0; i < dk; ++i) {
+            float* row = S + i * dv + j;
+            const __m256 state = _mm256_loadu_ps(row);
+            const __m256 update = _mm256_mul_ps(_mm256_set1_ps(k[i]), delta);
+            _mm256_storeu_ps(row, _mm256_add_ps(_mm256_mul_ps(decayVec, state), update));
+        }
+    }
+    for (; j < dv; ++j) {
+        float sumK = 0.0f;
+        float sumQ = 0.0f;
+        for (size_t i = 0; i < dk; ++i) {
+            const float state = S[i * dv + j];
+            sumK += state * k[i];
+            sumQ += state * q[i];
+        }
+        const float delta = beta * (v[j] - decay * sumK);
+        out[j] = decay * sumQ + kq * delta;
+        for (size_t i = 0; i < dk; ++i) {
+            S[i * dv + j] = decay * S[i * dv + j] + k[i] * delta;
+        }
+    }
+}
+
+float _AVX_MNNNormalizeQKAndDot(float* q, float* k, float qScale, bool useL2Norm, size_t dk) {
+    __m256 qSum = _mm256_setzero_ps();
+    __m256 kSum = _mm256_setzero_ps();
+    __m256 qkSum = _mm256_setzero_ps();
+    size_t i = 0;
+    for (; i + 8 <= dk; i += 8) {
+        const __m256 qVec = _mm256_loadu_ps(q + i);
+        const __m256 kVec = _mm256_loadu_ps(k + i);
+        if (useL2Norm) {
+            qSum = _mm256_add_ps(qSum, _mm256_mul_ps(qVec, qVec));
+            kSum = _mm256_add_ps(kSum, _mm256_mul_ps(kVec, kVec));
+        }
+        qkSum = _mm256_add_ps(qkSum, _mm256_mul_ps(qVec, kVec));
+    }
+    alignas(32) float qSumValues[8];
+    alignas(32) float kSumValues[8];
+    alignas(32) float qkSumValues[8];
+    _mm256_store_ps(qSumValues, qSum);
+    _mm256_store_ps(kSumValues, kSum);
+    _mm256_store_ps(qkSumValues, qkSum);
+    float qSumScalar = 0.0f;
+    float kSumScalar = 0.0f;
+    float qkScalar = 0.0f;
+    for (int lane = 0; lane < 8; ++lane) {
+        qSumScalar += qSumValues[lane];
+        kSumScalar += kSumValues[lane];
+        qkScalar += qkSumValues[lane];
+    }
+    for (; i < dk; ++i) {
+        if (useL2Norm) {
+            qSumScalar += q[i] * q[i];
+            kSumScalar += k[i] * k[i];
+        }
+        qkScalar += q[i] * k[i];
+    }
+    const float qNormScale = useL2Norm ? qScale / sqrtf(qSumScalar + 1e-6f) : qScale;
+    const float kNormScale = useL2Norm ? 1.0f / sqrtf(kSumScalar + 1e-6f) : 1.0f;
+    const __m256 qScaleVec = _mm256_set1_ps(qNormScale);
+    const __m256 kScaleVec = _mm256_set1_ps(kNormScale);
+    for (i = 0; i + 8 <= dk; i += 8) {
+        _mm256_storeu_ps(q + i, _mm256_mul_ps(_mm256_loadu_ps(q + i), qScaleVec));
+        if (useL2Norm) {
+            _mm256_storeu_ps(k + i, _mm256_mul_ps(_mm256_loadu_ps(k + i), kScaleVec));
+        }
+    }
+    for (; i < dk; ++i) {
+        q[i] *= qNormScale;
+        if (useL2Norm) {
+            k[i] *= kNormScale;
+        }
+    }
+    return qkScalar * qNormScale * kNormScale;
+}
+
+} // namespace
+
+extern "C" void _AVX_LinearAttentionInit(void* functions) {
+    auto coreFunction = static_cast<MNN::CoreFunctions*>(functions);
+    coreFunction->MNNDualMatVec = _AVX_MNNDualMatVec;
+    coreFunction->MNNDecayRankOneUpdate = _AVX_MNNDecayRankOneUpdate;
+    coreFunction->MNNFusedGatedDelta = _AVX_MNNFusedGatedDelta;
+    coreFunction->MNNNormalizeQKAndDot = _AVX_MNNNormalizeQKAndDot;
+}

--- a/source/backend/cpu/x86_x64/avx512/FunctionSummary.hpp
+++ b/source/backend/cpu/x86_x64/avx512/FunctionSummary.hpp
@@ -49,6 +49,7 @@ void _AVX512_MNNPackedSparseMatMulEpx1(float* C, const float* A, const float* B,
 
 void _AVX512_ReorderInit(void* functions);
 void _AVX512_ExtraInit(void* functions);
+void _AVX512_LinearAttentionInit(void* functions);
 void _AVX512_WinogradInit(void* functions);
 void _AVX512_MNNInt8FunctionInit(void* functions, bool suppotVNNI);
 
@@ -57,5 +58,4 @@ extern MNN::CoreFunctions::MNNPackedMatMulKernel _AVX512_MNNPackedMatMulOC32Func
 extern MNN::CoreFunctions::MNNPackedMatMulKernel _AVX512_MNNPackedMatMulOC48Functions[AVX512_INPUT_TILE_MAX];
 
 }
-
 

--- a/source/backend/cpu/x86_x64/avx512/FunctionSummary.hpp
+++ b/source/backend/cpu/x86_x64/avx512/FunctionSummary.hpp
@@ -56,6 +56,4 @@ void _AVX512_MNNInt8FunctionInit(void* functions, bool suppotVNNI);
 extern MNN::CoreFunctions::MNNPackedMatMulKernel _AVX512_MNNPackedMatMulOC16Functions[AVX512_INPUT_TILE_MAX];
 extern MNN::CoreFunctions::MNNPackedMatMulKernel _AVX512_MNNPackedMatMulOC32Functions[AVX512_INPUT_TILE_MAX];
 extern MNN::CoreFunctions::MNNPackedMatMulKernel _AVX512_MNNPackedMatMulOC48Functions[AVX512_INPUT_TILE_MAX];
-
 }
-

--- a/source/backend/cpu/x86_x64/avx512/LinearAttentionFunctions.cpp
+++ b/source/backend/cpu/x86_x64/avx512/LinearAttentionFunctions.cpp
@@ -1,0 +1,209 @@
+//
+//  LinearAttentionFunctions.cpp
+//  MNN
+//
+//  AVX-512 kernels for the gated-delta-rule recurrence used by LinearAttention.
+//
+
+#include "FunctionSummary.hpp"
+
+namespace {
+
+void _AVX512_MNNDualMatVec(const float* S, const float* k, const float* q, float* outK, float* outQ, size_t dk,
+                           size_t dv) {
+    size_t j = 0;
+    for (; j + 16 <= dv; j += 16) {
+        __m512 sumK = _mm512_setzero_ps();
+        __m512 sumQ = _mm512_setzero_ps();
+        for (size_t i = 0; i < dk; ++i) {
+            const __m512 state = _mm512_loadu_ps(S + i * dv + j);
+            sumK = _mm512_fmadd_ps(state, _mm512_set1_ps(k[i]), sumK);
+            sumQ = _mm512_fmadd_ps(state, _mm512_set1_ps(q[i]), sumQ);
+        }
+        _mm512_storeu_ps(outK + j, sumK);
+        _mm512_storeu_ps(outQ + j, sumQ);
+    }
+    for (; j < dv; ++j) {
+        float sumK = 0.0f;
+        float sumQ = 0.0f;
+        for (size_t i = 0; i < dk; ++i) {
+            const float state = S[i * dv + j];
+            sumK += state * k[i];
+            sumQ += state * q[i];
+        }
+        outK[j] = sumK;
+        outQ[j] = sumQ;
+    }
+}
+
+float _AVX512_MNNNormalizeQKAndDot(float* q, float* k, float qScale, bool useL2Norm, size_t dk) {
+    __m512 qSum = _mm512_setzero_ps();
+    __m512 kSum = _mm512_setzero_ps();
+    __m512 qkSum = _mm512_setzero_ps();
+    size_t i = 0;
+    for (; i + 16 <= dk; i += 16) {
+        const __m512 qVec = _mm512_loadu_ps(q + i);
+        const __m512 kVec = _mm512_loadu_ps(k + i);
+        if (useL2Norm) {
+            qSum = _mm512_fmadd_ps(qVec, qVec, qSum);
+            kSum = _mm512_fmadd_ps(kVec, kVec, kSum);
+        }
+        qkSum = _mm512_fmadd_ps(qVec, kVec, qkSum);
+    }
+    alignas(64) float qs[16];
+    alignas(64) float ks[16];
+    alignas(64) float qks[16];
+    _mm512_store_ps(qs, qSum);
+    _mm512_store_ps(ks, kSum);
+    _mm512_store_ps(qks, qkSum);
+    float qSumScalar = 0.0f;
+    float kSumScalar = 0.0f;
+    float qkScalar = 0.0f;
+    for (int lane = 0; lane < 16; ++lane) {
+        qSumScalar += qs[lane];
+        kSumScalar += ks[lane];
+        qkScalar += qks[lane];
+    }
+    for (; i < dk; ++i) {
+        if (useL2Norm) {
+            qSumScalar += q[i] * q[i];
+            kSumScalar += k[i] * k[i];
+        }
+        qkScalar += q[i] * k[i];
+    }
+    const float qNormScale = useL2Norm ? qScale / sqrtf(qSumScalar + 1e-6f) : qScale;
+    const float kNormScale = useL2Norm ? 1.0f / sqrtf(kSumScalar + 1e-6f) : 1.0f;
+    const __m512 qScaleVec = _mm512_set1_ps(qNormScale);
+    const __m512 kScaleVec = _mm512_set1_ps(kNormScale);
+    for (i = 0; i + 16 <= dk; i += 16) {
+        _mm512_storeu_ps(q + i, _mm512_mul_ps(_mm512_loadu_ps(q + i), qScaleVec));
+        if (useL2Norm) {
+            _mm512_storeu_ps(k + i, _mm512_mul_ps(_mm512_loadu_ps(k + i), kScaleVec));
+        }
+    }
+    for (; i < dk; ++i) {
+        q[i] *= qNormScale;
+        if (useL2Norm) {
+            k[i] *= kNormScale;
+        }
+    }
+    return qkScalar * qNormScale * kNormScale;
+}
+
+void _AVX512_MNNDecayRankOneUpdate(float* S, const float* k, const float* delta, float decay, size_t dk, size_t dv) {
+    const __m512 decayVec = _mm512_set1_ps(decay);
+    for (size_t i = 0; i < dk; ++i) {
+        float* row = S + i * dv;
+        const __m512 key = _mm512_set1_ps(k[i]);
+        size_t j = 0;
+        for (; j + 16 <= dv; j += 16) {
+            const __m512 oldState = _mm512_loadu_ps(row + j);
+            const __m512 deltaVec = _mm512_loadu_ps(delta + j);
+            _mm512_storeu_ps(row + j, _mm512_fmadd_ps(key, deltaVec, _mm512_mul_ps(decayVec, oldState)));
+        }
+        for (; j < dv; ++j) {
+            row[j] = decay * row[j] + k[i] * delta[j];
+        }
+    }
+}
+
+void _AVX512_MNNFusedGatedDelta(float* S, const float* k, const float* q, const float* v, float* out, float decay,
+                                float beta, float kq, size_t dk, size_t dv) {
+    const __m512 decayVec = _mm512_set1_ps(decay);
+    const __m512 betaVec = _mm512_set1_ps(beta);
+    const __m512 kqVec = _mm512_set1_ps(kq);
+    size_t j = 0;
+    // Process one 64-float state row at a time for common d_v=64/128 shapes.
+    // This avoids re-walking the same rows once per 16-float vector block.
+    for (; j + 64 <= dv; j += 64) {
+        __m512 sumK0 = _mm512_setzero_ps();
+        __m512 sumQ0 = _mm512_setzero_ps();
+        __m512 sumK1 = _mm512_setzero_ps();
+        __m512 sumQ1 = _mm512_setzero_ps();
+        __m512 sumK2 = _mm512_setzero_ps();
+        __m512 sumQ2 = _mm512_setzero_ps();
+        __m512 sumK3 = _mm512_setzero_ps();
+        __m512 sumQ3 = _mm512_setzero_ps();
+        for (size_t i = 0; i < dk; ++i) {
+            const float* row = S + i * dv + j;
+            const __m512 key = _mm512_set1_ps(k[i]);
+            const __m512 query = _mm512_set1_ps(q[i]);
+            const __m512 state0 = _mm512_loadu_ps(row);
+            const __m512 state1 = _mm512_loadu_ps(row + 16);
+            const __m512 state2 = _mm512_loadu_ps(row + 32);
+            const __m512 state3 = _mm512_loadu_ps(row + 48);
+            sumK0 = _mm512_fmadd_ps(state0, key, sumK0);
+            sumQ0 = _mm512_fmadd_ps(state0, query, sumQ0);
+            sumK1 = _mm512_fmadd_ps(state1, key, sumK1);
+            sumQ1 = _mm512_fmadd_ps(state1, query, sumQ1);
+            sumK2 = _mm512_fmadd_ps(state2, key, sumK2);
+            sumQ2 = _mm512_fmadd_ps(state2, query, sumQ2);
+            sumK3 = _mm512_fmadd_ps(state3, key, sumK3);
+            sumQ3 = _mm512_fmadd_ps(state3, query, sumQ3);
+        }
+        const __m512 delta0 =
+            _mm512_mul_ps(betaVec, _mm512_sub_ps(_mm512_loadu_ps(v + j), _mm512_mul_ps(decayVec, sumK0)));
+        const __m512 delta1 =
+            _mm512_mul_ps(betaVec, _mm512_sub_ps(_mm512_loadu_ps(v + j + 16), _mm512_mul_ps(decayVec, sumK1)));
+        const __m512 delta2 =
+            _mm512_mul_ps(betaVec, _mm512_sub_ps(_mm512_loadu_ps(v + j + 32), _mm512_mul_ps(decayVec, sumK2)));
+        const __m512 delta3 =
+            _mm512_mul_ps(betaVec, _mm512_sub_ps(_mm512_loadu_ps(v + j + 48), _mm512_mul_ps(decayVec, sumK3)));
+        _mm512_storeu_ps(out + j, _mm512_fmadd_ps(kqVec, delta0, _mm512_mul_ps(decayVec, sumQ0)));
+        _mm512_storeu_ps(out + j + 16, _mm512_fmadd_ps(kqVec, delta1, _mm512_mul_ps(decayVec, sumQ1)));
+        _mm512_storeu_ps(out + j + 32, _mm512_fmadd_ps(kqVec, delta2, _mm512_mul_ps(decayVec, sumQ2)));
+        _mm512_storeu_ps(out + j + 48, _mm512_fmadd_ps(kqVec, delta3, _mm512_mul_ps(decayVec, sumQ3)));
+        for (size_t i = 0; i < dk; ++i) {
+            float* row = S + i * dv + j;
+            const __m512 key = _mm512_set1_ps(k[i]);
+            _mm512_storeu_ps(row, _mm512_fmadd_ps(key, delta0, _mm512_mul_ps(decayVec, _mm512_loadu_ps(row))));
+            _mm512_storeu_ps(row + 16,
+                             _mm512_fmadd_ps(key, delta1, _mm512_mul_ps(decayVec, _mm512_loadu_ps(row + 16))));
+            _mm512_storeu_ps(row + 32,
+                             _mm512_fmadd_ps(key, delta2, _mm512_mul_ps(decayVec, _mm512_loadu_ps(row + 32))));
+            _mm512_storeu_ps(row + 48,
+                             _mm512_fmadd_ps(key, delta3, _mm512_mul_ps(decayVec, _mm512_loadu_ps(row + 48))));
+        }
+    }
+    for (; j + 16 <= dv; j += 16) {
+        __m512 sumK = _mm512_setzero_ps();
+        __m512 sumQ = _mm512_setzero_ps();
+        for (size_t i = 0; i < dk; ++i) {
+            const __m512 state = _mm512_loadu_ps(S + i * dv + j);
+            sumK = _mm512_fmadd_ps(state, _mm512_set1_ps(k[i]), sumK);
+            sumQ = _mm512_fmadd_ps(state, _mm512_set1_ps(q[i]), sumQ);
+        }
+        const __m512 delta =
+            _mm512_mul_ps(betaVec, _mm512_sub_ps(_mm512_loadu_ps(v + j), _mm512_mul_ps(decayVec, sumK)));
+        _mm512_storeu_ps(out + j, _mm512_fmadd_ps(kqVec, delta, _mm512_mul_ps(decayVec, sumQ)));
+        for (size_t i = 0; i < dk; ++i) {
+            float* row = S + i * dv + j;
+            const __m512 state = _mm512_loadu_ps(row);
+            _mm512_storeu_ps(row, _mm512_fmadd_ps(_mm512_set1_ps(k[i]), delta, _mm512_mul_ps(decayVec, state)));
+        }
+    }
+    for (; j < dv; ++j) {
+        float sumK = 0.0f;
+        float sumQ = 0.0f;
+        for (size_t i = 0; i < dk; ++i) {
+            const float state = S[i * dv + j];
+            sumK += state * k[i];
+            sumQ += state * q[i];
+        }
+        const float delta = beta * (v[j] - decay * sumK);
+        out[j] = decay * sumQ + kq * delta;
+        for (size_t i = 0; i < dk; ++i) {
+            S[i * dv + j] = decay * S[i * dv + j] + k[i] * delta;
+        }
+    }
+}
+
+} // namespace
+
+extern "C" void _AVX512_LinearAttentionInit(void* functions) {
+    auto coreFunction = static_cast<MNN::CoreFunctions*>(functions);
+    coreFunction->MNNDualMatVec = _AVX512_MNNDualMatVec;
+    coreFunction->MNNDecayRankOneUpdate = _AVX512_MNNDecayRankOneUpdate;
+    coreFunction->MNNFusedGatedDelta = _AVX512_MNNFusedGatedDelta;
+    coreFunction->MNNNormalizeQKAndDot = _AVX512_MNNNormalizeQKAndDot;
+}

--- a/test/op/FusedGatedDeltaTest.cpp
+++ b/test/op/FusedGatedDeltaTest.cpp
@@ -83,7 +83,7 @@ static void applyL2NormAndScale(float* q, float* k, int dk) {
 
 // Build a LinearAttention op as a Module so we can run forward(). Uses the
 // same FlatBuffers-based construction as LinearAttentionTest.
-static std::shared_ptr<Module> makeModule(int numKHeads, int numVHeads, int dk, int dv) {
+static std::shared_ptr<Module> makeModule(int numKHeads, int numVHeads, int dk, int dv, bool useL2Norm) {
     auto qkv = _Input();
     auto gate = _Input();
     auto beta = _Input();
@@ -99,7 +99,7 @@ static std::shared_ptr<Module> makeModule(int numKHeads, int numVHeads, int dk, 
     p->num_v_heads = numVHeads;
     p->head_k_dim = dk;
     p->head_v_dim = dv;
-    p->use_qk_l2norm = true;
+    p->use_qk_l2norm = useL2Norm;
 
     auto out = Variable::create(Expr::create(op.get(), {qkv, gate, beta, convW}));
     auto buffer = Variable::save({out});
@@ -126,6 +126,7 @@ struct Case {
     int dv;
     int L;        // 1 → exercises gated_delta_rule_decode; >1 → gated_delta_rule_mnn (prefill)
     int numSteps; // number of forward() invocations; state accumulates across steps
+    bool useL2Norm;
 };
 
 // Run one Case: drives the LinearAttention module forward `numSteps` times,
@@ -147,7 +148,7 @@ static bool runCase(const Case& cs, std::mt19937& rng, float tolerance) {
     const int D = 2 * key_dim + val_dim;
     const int gqa_factor = (Hv > Hk) ? (Hv / Hk) : 1;
 
-    auto module = makeModule(Hk, Hv, dk, dv);
+    auto module = makeModule(Hk, Hv, dk, dv, cs.useL2Norm);
     if (!module) {
         MNN_PRINT("FusedGatedDeltaTest[%s]: module creation failed\n", cs.name);
         return false;
@@ -224,7 +225,14 @@ static bool runCase(const Case& cs, std::mt19937& rng, float tolerance) {
                     for (int i = 0; i < dv; ++i) {
                         vLocal[i] = convOut[(b * D + 2 * key_dim + h * dv + i) * L + t];
                     }
-                    applyL2NormAndScale(qLocal.data(), kLocal.data(), dk);
+                    if (cs.useL2Norm) {
+                        applyL2NormAndScale(qLocal.data(), kLocal.data(), dk);
+                    } else {
+                        const float qScale = 1.0f / std::sqrt(static_cast<float>(dk));
+                        for (int i = 0; i < dk; ++i) {
+                            qLocal[i] *= qScale;
+                        }
+                    }
                     float decay = std::exp(gPtr[b * L * Hv + t * Hv + h]);
                     float beta_t = bPtr[b * L * Hv + t * Hv + h];
                     float* state = refS.data() + (b * Hv + h) * dk * dv;
@@ -269,16 +277,21 @@ public:
         //  - prefill (L>1): multi-head + GQA at dk=128/dv=128 to exercise the
         //    gated_delta_rule_mnn path with the shared per-thread buffer
         std::vector<Case> cases = {
-            // {name,                    Hk, Hv,  dk,  dv,  L, steps}
-            {"decode_1h_dk64_dv64", 1, 1, 64, 64, 1, 4},
-            {"decode_1h_dk64_dv128", 1, 1, 64, 128, 1, 4},
-            {"decode_1h_dk128_dv64", 1, 1, 128, 64, 1, 4},
-            {"decode_1h_dk128_dv128", 1, 1, 128, 128, 1, 4},    // ← Qwen3-Next shape
-            {"decode_4h_dk128_dv128", 4, 4, 128, 128, 1, 3},    // multi-head decode
-            {"decode_gqa2_dk128_dv128", 2, 4, 128, 128, 1, 3},  // GQA 2:1 decode
-            {"prefill_1h_dk128_dv128", 1, 1, 128, 128, 8, 2},   // L>1 single head
-            {"prefill_4h_dk128_dv128", 4, 4, 128, 128, 8, 2},   // L>1 multi-head
-            {"prefill_gqa2_dk128_dv128", 2, 4, 128, 128, 8, 2}, // L>1 + GQA
+            // {name, Hk, Hv, dk, dv, L, steps, useL2Norm}
+            {"decode_1h_dk64_dv64", 1, 1, 64, 64, 1, 4, true},
+            {"decode_1h_dk64_dv128", 1, 1, 64, 128, 1, 4, true},
+            {"decode_1h_dk128_dv64", 1, 1, 128, 64, 1, 4, true},
+            {"decode_1h_dk128_dv128", 1, 1, 128, 128, 1, 4, true}, // Qwen3-Next shape
+            {"decode_1h_dk63_dv65", 1, 1, 63, 65, 1, 4, true},
+            {"decode_1h_dk127_dv129", 1, 1, 127, 129, 1, 4, true},
+            {"decode_4h_dk128_dv128", 4, 4, 128, 128, 1, 3, true},
+            {"decode_gqa2_dk128_dv128", 2, 4, 128, 128, 1, 3, true},
+            {"prefill_1h_dk128_dv128", 1, 1, 128, 128, 8, 2, true},
+            {"prefill_4h_dk128_dv128", 4, 4, 128, 128, 8, 2, true},
+            {"prefill_gqa2_dk128_dv128", 2, 4, 128, 128, 8, 2, true},
+            {"prefill_1h_dk63_dv65", 1, 1, 63, 65, 5, 2, true},
+            {"decode_no_l2_dk64_dv128", 1, 1, 64, 128, 1, 4, false},
+            {"prefill_no_l2_dk128_dv128", 1, 1, 128, 128, 8, 2, false},
         };
 
         // fp16 path accumulates more round-off — loosen tolerance for low-precision.


### PR DESCRIPTION
## Description

Optimize FP32 CPU LinearAttention gated-delta-rule execution on x86.

- Add scalar fallback plus AVX2 and AVX-512 kernels through the existing `CoreFunctions` runtime dispatch.
- Fuse Q/K L2 normalization, query scaling, and `dot(k, q)` for FP32.
- Process contiguous state-row blocks in AVX2 (16 floats) and AVX-512 (64 floats).
- Extend end-to-end coverage for SIMD tails and vector-sized no-L2Norm decode/prefill cases.

## Performance

Measurements use `test/speed/LinearAttentionSpeed.cpp` on Intel Xeon Gold 5418Y, pinned to CPUs `0,2,4,6` with `taskset`. Each benchmark invocation uses 5 warmup iterations and 20 repeats; A/B comparisons were interleaved for 10 outer runs and report the median.

### End-to-end AVX-512 dispatch

This compares builds with `MNN_AVX512=OFF` and `MNN_AVX512=ON`; the AVX2 path is available in both builds.

| Scenario | Baseline | Optimized | Speedup |
| --- | ---: | ---: | ---: |
| Decode H16 d64 | 0.151 ms | 0.069 ms | 2.19x |
| Decode H16 d128 | 0.310 ms | 0.145 ms | 2.14x |
| Prefill64 H16 d64 | 2.184 ms | 0.578 ms | 3.78x |
| Prefill2048 H16 d64 | 58.662 ms | 14.389 ms | 4.08x |

### Incremental row-block benefit

Each row compares the prior ISA kernel with the same ISA kernel plus this PR’s contiguous state-row block. It is not a comparison with the scalar baseline.

| ISA | Scenario | Prior kernel | Row-block kernel | Speedup |
| --- | --- | ---: | ---: | ---: |
| AVX2 | Prefill64 H16 d64 | 0.633 ms | 0.573 ms | 1.10x |
| AVX2 | Prefill2048 H16 d64 | 17.74 ms | 16.13 ms | 1.10x |
| AVX-512 | Prefill64 H16 d64 | 0.512 ms | 0.458 ms | 1.12x |
| AVX-512 | Prefill2048 H16 d64 | 13.62 ms | 12.14 ms | 1.12x |

## Module

CPU

## Type

- [ ] Feature
- [ ] Bugfix
- [x] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [x] Test
- [ ] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [x] Tested on relevant platform(s): AVX2 and AVX-512 builds, `op/linear_attention`, and `op/fused_gated_delta`
- [x] No unrelated format or style changes included