### PR TITLE
[LLM:Bugfix] Export q/k norm for InternVL Qwen3 models

### DIFF
--- a/transformers/llm/export/utils/model_mapper.py
+++ b/transformers/llm/export/utils/model_mapper.py
@@ -344,7 +344,9 @@ class ModelMapper:
                 'q_proj': 'q_proj',
                 'k_proj': 'k_proj',
                 'v_proj': 'v_proj',
-                'o_proj': 'o_proj'
+                'o_proj': 'o_proj',
+                'q_norm': 'q_norm',
+                'k_norm': 'k_norm'
             }
         }
         self.regist('internvl_chat', intervl_map)


### PR DESCRIPTION
## Summary
- Add q_norm and k_norm to the internvl_chat attention export mapping.
- Fix InternVL3.5 models whose outer model_type is internvl_chat but language model is Qwen3.
- Without these mappings, exported MNN graphs miss Qwen3 q/k RMSNorm modules and generated text can become garbled.

## Root Cause
InternVL3.5 uses Qwen3 as the language model. Qwen3 attention contains q_norm and k_norm, but the existing internvl_chat mapper only exported q_proj, k_proj, v_proj, and o_proj.

## Verification
- python -m py_compile transformers/llm/export/utils/model_mapper.py
- Re-exported InternVL3_5-4B Q4 with the patched mapper.
- Before fix: exported llm.mnn.json had 0 q_norm/k_norm entries and llm_demo generated garbled text.
- After fix: exported llm.mnn.json contains q/k norm entries, and llm_demo generates normal text for 'tell me some famous actors'.

Related to #4681