### PR TITLE
[LLM:Bugfix] Open tokenizer file in binary mode to prevent MSVC crash

### DIFF
--- a/transformers/llm/engine/src/tokenizer/tokenizer.cpp
+++ b/transformers/llm/engine/src/tokenizer/tokenizer.cpp
@@ -76,7 +76,7 @@ Tokenizer* Tokenizer::createTokenizer(const std::string& filename) {
     // AUTOTIME;
     Tokenizer* tokenizer = nullptr;
     // check file
-    std::ifstream tok_file(filename);
+    std::ifstream tok_file(filename, std::ios::binary); // std::ifstream tok_file(filename);
     if (!tok_file.good()) {
         printf("Failed: can't load tokenzier from: %s.\n", filename.c_str());
         return tokenizer;

--- a/transformers/llm/engine/src/tokenizer/tokenizer.cpp
+++ b/transformers/llm/engine/src/tokenizer/tokenizer.cpp
@@ -76,7 +76,7 @@ Tokenizer* Tokenizer::createTokenizer(const std::string& filename) {
     // AUTOTIME;
     Tokenizer* tokenizer = nullptr;
     // check file
-    std::ifstream tok_file(filename, std::ios::binary); // std::ifstream tok_file(filename);
+    std::ifstream tok_file(filename);
     if (!tok_file.good()) {
         printf("Failed: can't load tokenzier from: %s.\n", filename.c_str());
         return tokenizer;
@@ -94,13 +94,17 @@ Tokenizer* Tokenizer::createTokenizer(const std::string& filename) {
     line_str >> tokenizer_type;
     if (tokenizer_type == PIPELINE) {
         // .mtok binary format (PipelineTokenizer)
+        tok_file.close();
+        // Reopen from the beginning in binary mode instead of reusing a
+        // text-mode tellg() position, that position isn't guaranteed to
+        // line up with a byte offset in a separately-opened stream on
+        // Windows/MSVC.
         auto* pt = new PipelineTokenizer();
         tokenizer = pt;
-        tokenizer->load_special(tok_file);
-        auto pos = tok_file.tellg();
-        tok_file.close();
         std::ifstream bin_file(filename, std::ios::binary);
-        bin_file.seekg(pos);
+        std::string bin_line;
+        std::getline(bin_file, bin_line);   // re-consume the magic/type line
+        tokenizer->load_special(bin_file);
         pt->load_vocab_binary(bin_file);
         bin_file.close();
         tokenizer->cache_special_tokens();


### PR DESCRIPTION
## Description

I tried running a converted model (SmolLM2-135M) using the LLM example on Windows, but it crashed right at startup with an access violation error (-1073741819) and no error message.

Then I ran the project in Visual Studio with the debugger attached to see where it was breaking. It stopped inside PipelineTokenizer::load_vocab_binary while reading tokenizer.mtok. It was trying to read a string over 55,000 characters long, which I thought it was reading random or corrupted data from the file.

In tokenizer.cpp (Tokenizer::createTokenizer), the code opens tokenizer.mtok in normal text mode first, saves the file position, and then reopens the file in binary mode using that saved position.

After searching I saw that on Windows/MSVC a position saved in text mode doesn't line up properly when used in binary mode (even if it happens to work on Linux, becasue it was working). Because of this, it jumps to the wrong byte in the file, reads garbage as the string length, and crashes.

So to fix I added `std::ios::binary` to the first `ifstream` and this fixed the offset issue and allowed the model to load and run successfully.

Note: I have tested this only on Windows 11 MSVC 2022

## Module

LLM

## Type

- [ ] Feature
- [X] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [X] Commit message follows `[Module:Type] Description` format
- [X] Code compiles without errors
- [ ] Tested on relevant platform(s) (Only windows)
- [X] No unrelated format or style changes included
