### PR TITLE
[Tools:Bugfix] MNN2QNNModel: emit per-output raw shape attributes for…

### DIFF
--- a/tools/cpp/MNN2QNNModel.cpp
+++ b/tools/cpp/MNN2QNNModel.cpp
@@ -554,8 +554,8 @@ int main(int argc, const char* argv[]) {
 
 
     for (int i=0; i<outputInfos.size(); ++i) {
-        attr.reset(new MNN::AttributeT);
         for(int j = 0; j < outputInfos[i].size(); j++) {
+            attr.reset(new MNN::AttributeT);
             attr->key = "o_" + std::to_string(i) + std::string("_") +  std::to_string(j);
             attr->tensor.reset(new BlobT);
             attr->tensor->dataType = OpCommonUtils::convertDataType(outputInfos[i][j].type);
@@ -574,8 +574,8 @@ int main(int argc, const char* argv[]) {
                     attr->tensor->dataFormat = MNN_DATA_FORMAT_NCHW;
                     break;
             }
+            extra->attr.emplace_back(std::move(attr));
         }
-        extra->attr.emplace_back(std::move(attr));
     }
 
     // Compile NPU Module


### PR DESCRIPTION
## Problem
  `MNN2QNNModel` reset the shared `AttributeT` once per shape index and emplaced it
  only after the inner output loop, so every output overwrote the previous one and
  only the last key (`o_<shapeIndex>_<N-1>`) was serialized into the Extra op.

  At load time `PluginShapeRaw::compute` (source/backend/qnn/backend/QNNBackend.cpp)
  looks up `o_<shapeIndex>_<i>` for every output and aborts with
  `MNN_QNN: Failed to find raw shape o_0_0`, so any multi-output QNN graph failed
  shape inference. Single-output models happened to work because their only key
  coincided with the last one written.

  ## Fix
  Move the `reset` / `emplace_back` inside the inner loop so one attribute is
  recorded per `(shapeIndex, output)` pair. This matches the existing correct
  implementation in `tools/cpp/compilefornpu.cpp`.

  ## Test
  - Converted a multi-output model with `MNN2QNNModel` and confirmed it now loads
    and runs on the QNN backend instead of failing shape inference.
  - Single-output models unaffected.