### PR TITLE
[LLM:Bugfix] Reset DFlash cross-turn state on generate_init to fix multi-turn crash

### DIFF
--- a/transformers/llm/engine/src/llm.cpp
+++ b/transformers/llm/engine/src/llm.cpp
@@ -835,6 +835,9 @@ void Llm::generate_init(std::ostream* os, const char* end_with) {
         mContext->all_seq_len = 0;
         mMeta->remove = mMeta->previous;
     }
+    if (mGenerationStrategy) {
+        mGenerationStrategy->reset();
+    }
     if(mContext->status != LlmStatus::NOT_LOADED) {
         mContext->status = LlmStatus::RUNNING;
     }

--- a/transformers/llm/engine/src/speculative_decoding/dflash.cpp
+++ b/transformers/llm/engine/src/speculative_decoding/dflash.cpp
@@ -23,6 +23,11 @@ DFlashGeneration::DFlashGeneration(Llm* llm, std::shared_ptr<LlmContext> context
     mMaskTokenId = config->dflash_mask_token_id();
 }
 
+void DFlashGeneration::reset() {
+    mInitialized = false;
+    mContextHidden = nullptr;
+}
+
 void DFlashGeneration::load(Module::Config module_config) {
     // Check if separate lm_head model exists
     std::string lmheadPath = mLlm->mConfig->dflash_lmhead();

--- a/transformers/llm/engine/src/speculative_decoding/generate.hpp
+++ b/transformers/llm/engine/src/speculative_decoding/generate.hpp
@@ -37,6 +37,9 @@ public:
         // do nothing
     };
     virtual void generate(GenerationParams& param) = 0;
+    virtual void reset() {
+        // do nothing
+    };
 protected:
     int draftVerify(MNN::Express::VARP logits, const std::vector<int>& drafts, bool& stop);
     std::shared_ptr<LlmContext> mContext;
@@ -121,6 +124,7 @@ public:
     virtual ~DFlashGeneration() = default;
     virtual void load(Module::Config module_config) override;
     virtual void generate(GenerationParams& param) override;
+    virtual void reset() override;
 private:
     MNN::Express::VARP dflashForward(const std::vector<int>& block_ids, MNN::Express::VARP context_hidden);
     MNN::Express::VARP fcForward(MNN::Express::VARP hidden_states);


### PR DESCRIPTION
Automated rolling sync from the internal MNN development repository.

- Pending commits: 1
- Head branch: `sync/ali-to-github`
- Commit authors are preserved from the source commits.

### Commits

- `dd48baa634` [LLM:Bugfix] Reset DFlash cross-turn state on generate_init to fix multi-turn crash — 花熊 <zhanghuaxiang.zhx@taobao.com>