### PR TITLE
[Infra:Test] Add second squash sync marker

### DIFF
--- a/docs/sync_e2e/squash.md
+++ b/docs/sync_e2e/squash.md
@@ -1,0 +1,3 @@
+# Multi-commit sync test
+
+First internal commit for the outbound squash test.

--- a/docs/sync_e2e/squash.md
+++ b/docs/sync_e2e/squash.md
@@ -1,3 +1,5 @@
 # Multi-commit sync test
 
 First internal commit for the outbound squash test.
+
+Second internal commit for the outbound squash test.


### PR DESCRIPTION
Automated rolling sync from the internal MNN development repository.

- Pending commits: 2
- Head branch: `sync/e2e-squash-20260807`
- Commit authors are preserved from the source commits.

### Commits

- `cbeafeb4fc` [Infra:Test] Add first squash sync marker — wangzhaode <zhaode.wzd@alibaba-inc.com>
- `9c45ce8e73` [Infra:Test] Add second squash sync marker — wangzhaode <zhaode.wzd@alibaba-inc.com>