### PR TITLE
[Express:Bugfix] Fix loadMap input tensor losing host buffer

### DIFF
--- a/express/Expr.cpp
+++ b/express/Expr.cpp
@@ -1049,12 +1049,24 @@ std::vector<VARP> Variable::load(const uint8_t* buffer, size_t length) {
             // Set tensor shape from net
             expr->mCanDecompose = false;
         }
-        if (nullptr != expr->get() || expr->inputType() == VARP::INPUT) {
+        if (nullptr != expr->get()) {
+            // Non-INPUT node: keep the existing behavior (replace with cloned tensor from net metadata)
             for (int index = 0; index < op->outputIndexes.size(); ++index) {
                 auto outputIndex = op->outputIndexes[index];
                 delete expr->inside()->mOutputTensors[index];
                 expr->inside()->mOutputTensors[index] = Tensor::clone(allTensors[outputIndex].get());
                 Utils::copyTensorToInfo(expr->inside()->mOutputInfos.data() + index, expr->inside()->mOutputTensors[index]);
+            }
+        } else if (expr->inputType() == VARP::INPUT) {
+            // INPUT node: keep the tensor created by Expr::create (host already allocated,
+            // usage = INPUT, memoryType = MEMORY_HOST). Only migrate quantAttr if the model
+            // declares quantization info for this input.
+            for (int index = 0; index < op->outputIndexes.size(); ++index) {
+                auto outputIndex = op->outputIndexes[index];
+                auto srcTensor = allTensors[outputIndex].get();
+                if (nullptr != srcTensor && TensorUtils::getDescribe(srcTensor)->quantAttr) {
+                    TensorUtils::getDescribe(expr->inside()->mOutputTensors[index])->quantAttr = TensorUtils::getDescribe(srcTensor)->quantAttr;
+                }
             }
         }
 

--- a/test/expr/LoadMapInputTest.cpp
+++ b/test/expr/LoadMapInputTest.cpp
@@ -1,0 +1,62 @@
+//
+//  LoadMapInputTest.cpp
+//  MNNTests
+//
+//  Created by MNN on 2026/08/07.
+//  Copyright © 2018, Alibaba Group Holding Limited
+//
+
+#include <MNN/expr/Expr.hpp>
+#include <MNN/expr/ExprCreator.hpp>
+#include <MNN/expr/NeuralNetWorkOp.hpp>
+#include <MNN/expr/Executor.hpp>
+#include "MNNTestSuite.h"
+
+using namespace MNN::Express;
+
+// Regression test for #4731: Variable::loadMap input tensor lost its host buffer,
+// making writeMap() return NULL and downstream format conversion crash with a
+// null source pointer (e.g. expressDemo SIGSEGV on NCHW-input models).
+class LoadMapInputWriteMapTest : public MNNTestCase {
+public:
+    virtual bool run(int precision) override {
+        // Build a tiny NCHW-input model (Conv3x3 + ReLU) and save it.
+        auto x = _Input({1, 3, 8, 8}, NCHW);
+        std::vector<float> weight(4 * 3 * 3 * 3, 0.1f);
+        std::vector<float> bias(4, 0.01f);
+        auto w = _Const(weight.data(), {4, 3, 3, 3}, NCHW);
+        auto b = _Const(bias.data(), {4}, NCHW);
+        auto y = _Relu(_Conv(w, b, x));
+        Variable::save({y}, "regression_4731.mnn");
+
+        // Load the model and check the input VARP is writable.
+        auto varMap = Variable::loadMap("regression_4731.mnn");
+        auto io = Variable::getInputAndOutput(varMap);
+        if (io.first.empty() || io.second.empty()) {
+            MNN_PRINT("LoadMapInputTest: no input/output found\n");
+            return false;
+        }
+        auto input = io.first.begin()->second;
+        auto ptr = input->writeMap<float>();
+        if (nullptr == ptr) {
+            // Before the fix this was NULL (input tensor host was dropped by
+            // Tensor::clone in Variable::load), causing SIGSEGV downstream.
+            MNN_PRINT("LoadMapInputTest: writeMap returned NULL (bug #4731)\n");
+            return false;
+        }
+        auto inInfo = input->getInfo();
+        int size = 1;
+        for (auto d : inInfo->dim) {
+            size *= d;
+        }
+        for (int i = 0; i < size; ++i) {
+            ptr[i] = 0.5f;
+        }
+        // Forward must not crash (compute succeeds; output reading is a separate
+        // follow-up concern, see issue #4731).
+        auto output = io.second.begin()->second;
+        (void)output->readMap<float>();
+        return true;
+    }
+};
+MNNTestSuiteRegister(LoadMapInputWriteMapTest, "expr/LoadMapInputWriteMap");


### PR DESCRIPTION
## Description

`Variable::loadMap` 加载的模型输入 VARP 无法写入数据（`writeMap` 返回 NULL），导致下游格式转换解引用 NULL 源指针（如 `expressDemo` 在 NCHW 输入模型上 SIGSEGV）。

**Root cause**：`Variable::load`（`express/Expr.cpp`）对 INPUT 节点执行 `Tensor::clone(allTensors[i])`，clone 共享源 tensor 的 NULL host 指针，把 `Expr::create` 已为 INPUT 分配的 host buffer 丢弃了。

**Fix**：INPUT 节点跳过 clone 替换，保留 `Expr::create` 创建的 tensor（host 已分配、usage=INPUT、memoryType=MEMORY_HOST）；若模型为输入声明了量化信息（quantAttr），则显式迁移。

```cpp
if (nullptr != expr->get()) {
    // 非 INPUT：保持原行为（clone 替换，带 shape/type/quant 信息）
    ...
} else if (expr->inputType() == VARP::INPUT) {
    // INPUT：保留 Expr::create 的 tensor（host 已分配），仅迁移 quantAttr
    ...
}
```

## Module

Express

## Type

- [ ] Feature
- [x] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [x] Tested on relevant platform(s)
- [x] No unrelated format or style changes included

## Reproduction

生成 NCHW 输入模型（Conv3x3 + ReLU，输入 1x3x8x8）：

```cpp
auto x = _Input({1, 3, 8, 8}, NCHW);
std::vector<float> weight(4*3*3*3, 0.1f), bias(4, 0.01f);
auto y = _Relu(_Conv(_Const(weight.data(),{4,3,3,3},NCHW), _Const(bias.data(),{4},NCHW), x));
Variable::save({y}, "tiny.mnn");
```

运行 `./expressDemo.out tiny.mnn 0` → 修复前 SIGSEGV，修复后正常退出。

> 注：仅输入格式为 NCHW 的模型触发（`_ChangeInputFormat` 对同格式输入短路返回原 VARP）；
> 官方 NC4HW4 输入模型（如 squeezenetv1.1.mnn）不触发，属于格式巧合。

## Verification

- ✅ 修复后 `writeMap` 返回有效指针（修复前 NULL）——新增回归测试 `expr/LoadMapInputWriteMap` 覆盖
- ✅ `expressDemo` + NCHW 输入模型不再 SIGSEGV（修复前崩溃）
- ✅ expr/ 模块单元测试 53 个全部通过（原 52 + 新增回归 1）
- ✅ Module API 推理数值正确（回归）
- 注：MNN 全量单测套件（run_test.out，~376 case）未完整跑完（耗时过长），本 PR 验证聚焦 expr/ 子集（53 case）

## Scope

本 PR 严格限定 Express loadMap 的 **INPUT 节点**。以下均不在本 PR 范围：
- 输出节点 / Session 路径（`readMap` 在 forward 前返回 NULL 属正常行为——host 由 compute 阶段分配；expressDemo 已做 NULL 检查并优雅退出）
- 后端空指针防御（#4716 风格，另作 follow-up）

## Related

- Fixes #4731
