### PR TITLE
[OpenCL:Bugfix]fix: correct KVCache reserve logic and stride alignment in Eagle3 for opencl

### DIFF
--- a/source/backend/opencl/execution/buffer/AttentionBufExecution.cpp
+++ b/source/backend/opencl/execution/buffer/AttentionBufExecution.cpp
@@ -330,14 +330,15 @@ bool KVCacheCLManager::reallocKVCache(const KVMeta* meta, int seqlen, bool isExe
             mPastLength = start;
             return true;
         }
-
-        size_t pastkvSize = mKvNumHead * UP_DIV(mMaxLength, 4) * mHeadDim * 4 * mByte;
+        size_t curMaxlen = ROUND_UP(mMaxLength, 4);
+        size_t pastkvSize = mKvNumHead * UP_DIV(curMaxlen, 4) * mHeadDim * 4 * mByte;
         char* keyPtr = (char*)mOpenCLBackend->getOpenCLRuntime()->commandQueue().enqueueMapBuffer(
             *mPastKey.get(), true, CL_MAP_READ | CL_MAP_WRITE, 0, pastkvSize, nullptr, nullptr, &res);
         char* valuePtr = (char*)mOpenCLBackend->getOpenCLRuntime()->commandQueue().enqueueMapBuffer(
             *mPastValue.get(), true, CL_MAP_READ | CL_MAP_WRITE, 0, pastkvSize, nullptr, nullptr, &res);
 
         // TODO: need to ensure reserve info is sorted
+        auto copyDstIndex = start;
         for (int n = 0; n < meta->n_reserve; ++n) {
             auto begin = meta->reserve[2 * n];
             auto length = meta->reserve[2 * n + 1];
@@ -345,22 +346,21 @@ bool KVCacheCLManager::reallocKVCache(const KVMeta* meta, int seqlen, bool isExe
             // past_value : [mKvNumHead, mMaxLength, mHeadDim]
 
             auto copySrcIndex = start + begin;
-            auto copyDstIndex = start;
             for (int i = 0; i < mKvNumHead * mHeadDim; i++) {
-                ::memcpy(keyPtr + (i * mMaxLength + copyDstIndex) * mByte,
-                         keyPtr + (i * mMaxLength + copySrcIndex) * mByte, length * mByte);
+                ::memmove(keyPtr + (i * curMaxlen + copyDstIndex) * mByte,
+                         keyPtr + (i * curMaxlen + copySrcIndex) * mByte, length * mByte);
             }
             for (int i = 0; i < mKvNumHead; i++) {
                 for (int j = 0; j < length; j++) {
-                    ::memcpy(valuePtr + (i * mMaxLength + copyDstIndex + j) * mHeadDim * mByte,
-                             valuePtr + (i * mMaxLength + copySrcIndex + j) * mHeadDim * mByte, mHeadDim * mByte);
+                    ::memmove(valuePtr + (i * curMaxlen + copyDstIndex + j) * mHeadDim * mByte,
+                             valuePtr + (i * curMaxlen + copySrcIndex + j) * mHeadDim * mByte, mHeadDim * mByte);
                 }
             }
-            start += length;
+            copyDstIndex += length;
         }
         mOpenCLBackend->getOpenCLRuntime()->commandQueue().enqueueUnmapMemObject(*mPastKey.get(), keyPtr);
         mOpenCLBackend->getOpenCLRuntime()->commandQueue().enqueueUnmapMemObject(*mPastValue.get(), valuePtr);
-        mPastLength = (int)start;
+        mPastLength = (int)copyDstIndex;
     }
     return true;
 }


### PR DESCRIPTION
## Description

修复issue #4737，主要修改`source/backend/opencl/execution/buffer/AttentionBufExecution.cpp`文件中关于`opencl`后端的`kvcache`回滚问题:
1. Fix incorrect stride calculation in AttentionBufExecution.cpp (lines 137-146):
   - Previously used raw `mMaxLength` as stride
   - Now correctly aligned to `ROUND_UP(mMaxLength, 4)` for OpenCL buffer requirements
2. Fix logical error in KVCache reserve code (AttentionBufExecution.cpp, lines 129-152):
   - `copySrcIndex = start + begin` was computed incorrectly
   - Root cause: `start` was being mutated by `start += length` before index calculation
   - Now compute index using immutable base offset to prevent corruption

## Module

<!-- Which module does this PR affect? e.g. LLM, CPU, Metal, CUDA, OpenCL, Core, Infra -->

## Type

- [ ] Feature
- [x] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [x] Tested on relevant platform(s)
- [x] No unrelated format or style changes included
