### PR TITLE
Fix Android chat rendering and history issues

### DIFF
--- a/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mnnllm/android/chat/ChatActivity.kt
+++ b/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mnnllm/android/chat/ChatActivity.kt
@@ -643,6 +643,7 @@ class ChatActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
+        saveInterruptedResponseIfNeeded()
         super.onDestroy()
         mockStreamRunnable?.let(mockStreamHandler::removeCallbacks)
         mockStreamRunnable = null
@@ -660,6 +661,26 @@ class ChatActivity : AppCompatActivity() {
         MainScope().launch {
             ApiServiceManager.stopApiService(ApplicationProvider.get())
         }
+    }
+
+    private fun saveInterruptedResponseIfNeeded() {
+        if (!::chatPresenter.isInitialized || !::chatListComponent.isInitialized) {
+            return
+        }
+        val recentItem = chatListComponent.recentItem ?: return
+        if (!ChatHistoryPersistencePolicy.shouldSaveInterruptedAssistant(
+                isGenerating = isGenerating,
+                isMockStreamSession = isMockStreamSession,
+                isDiffusion = isDiffusion,
+                itemType = recentItem.type,
+                text = recentItem.text
+            )
+        ) {
+            return
+        }
+        recentItem.loading = false
+        recentItem.forceShowLoadingWithText = false
+        chatPresenter.saveResponseToDatabase(recentItem)
     }
 
     override fun onStop() {

--- a/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mnnllm/android/chat/ChatHistoryPersistencePolicy.kt
+++ b/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mnnllm/android/chat/ChatHistoryPersistencePolicy.kt
@@ -1,0 +1,19 @@
+package com.alibaba.mnnllm.android.chat
+
+import com.alibaba.mnnllm.android.chat.chatlist.ChatViewHolders
+
+object ChatHistoryPersistencePolicy {
+    fun shouldSaveInterruptedAssistant(
+        isGenerating: Boolean,
+        isMockStreamSession: Boolean,
+        isDiffusion: Boolean,
+        itemType: Int,
+        text: String?
+    ): Boolean {
+        return isGenerating &&
+            !isMockStreamSession &&
+            !isDiffusion &&
+            itemType == ChatViewHolders.ASSISTANT &&
+            !text.isNullOrEmpty()
+    }
+}

--- a/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mnnllm/android/chat/ChatPresenter.kt
+++ b/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mnnllm/android/chat/ChatPresenter.kt
@@ -19,6 +19,7 @@ import com.alibaba.mnnllm.android.utils.FileUtils
 import com.alibaba.mnnllm.android.model.ModelTypeUtils
 import com.alibaba.mnnllm.android.model.ModelUtils
 import com.alibaba.mnnllm.android.modelsettings.ModelConfig
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -285,7 +286,8 @@ class ChatPresenter(
     suspend fun requestGenerate(userData: ChatDataItem, generateListener: GenerateListener): HashMap<String, Any> {
         this.generateListener = generateListener
         val prompt = PromptUtils.generateUserPrompt(userData)
-        
+        var userInputSaved = false
+
         // Ensure user input is saved first
         try {
             if (this.sessionName.isNullOrEmpty()) {
@@ -296,6 +298,7 @@ class ChatPresenter(
             // Always save user input to database first
             Log.d(TAG, "requestGenerate: saving user input for sessionId=$sessionId")
             chatDataManager!!.addChatData(sessionId, userData)
+            userInputSaved = true
             
             this.generateListener?.onGenerateStart()
             additionalListeners.forEach { it.onGenerateStart() }
@@ -305,12 +308,14 @@ class ChatPresenter(
             }.await()
             
             return result
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "requestGenerate: Error during request generation", e)
-            
+
             // Still try to save user input even if generation fails
             try {
-                if (sessionId != null) {
+                if (!userInputSaved && sessionId != null) {
                     chatDataManager!!.addChatData(sessionId, userData)
                 }
             } catch (saveException: Exception) {

--- a/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mnnllm/android/chat/chatlist/ChatListComponent.kt
+++ b/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mnnllm/android/chat/chatlist/ChatListComponent.kt
@@ -44,17 +44,24 @@ class ChatListComponent(private val context: Context,
         }
     }
     private lateinit var recyclerView: RecyclerView
-    private lateinit var linearLayoutManager: LinearLayoutManager
     private lateinit var adapter: ChatRecyclerViewAdapter
     private lateinit var emptyView: View
     private lateinit var emptyModelAvatarView: ModelAvatarView
     private lateinit var emptyMessageTextView: TextView
     private lateinit var btnScrollToBottom: View
     private var isUserScrolling: Boolean = false
-    private var forceBottomDuringStreaming: Boolean = false
     private var modelName:String? = null
     private var historyData: List<ChatDataItem>? = null
     private var onResumeAutoScrollListener: (() -> Unit)? = null
+    private val maintainBottomRunnable = Runnable {
+        if (!isUserScrolling) {
+            val remainingDistance = distanceFromBottomPx()
+            if (remainingDistance > 0) {
+                recyclerView.scrollBy(0, remainingDistance)
+            }
+            updateScrollToBottomButtonVisibility()
+        }
+    }
 
     init {
         setupRecyclerView()
@@ -97,8 +104,7 @@ class ChatListComponent(private val context: Context,
     private fun setupRecyclerView() {
         recyclerView = binding.recyclerView
         recyclerView.setItemAnimator(null)
-        linearLayoutManager = LinearLayoutManager(context)
-        recyclerView.setLayoutManager(linearLayoutManager)
+        recyclerView.setLayoutManager(LinearLayoutManager(context))
         binding.layoutBottomContainer.addOnLayoutChangeListener { v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom ->
             val insets: WindowInsets? = v.rootWindowInsets
             val bottomInset = insets!!.systemWindowInsetBottom
@@ -112,7 +118,7 @@ class ChatListComponent(private val context: Context,
             override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
                 super.onScrollStateChanged(recyclerView, newState)
                 if (newState == RecyclerView.SCROLL_STATE_DRAGGING) {
-                    forceBottomDuringStreaming = false
+                    recyclerView.removeCallbacks(maintainBottomRunnable)
                 }
                 isUserScrolling = resolveUserScrollingState(isUserScrolling, newState, isAtBottom())
                 updateScrollToBottomButtonVisibility()
@@ -177,56 +183,40 @@ class ChatListComponent(private val context: Context,
         }
     }
 
-    private fun scrollToEnd() {
-        recyclerView.postDelayed({
-            val position = adapter.itemCount - 1
-            linearLayoutManager.scrollToPositionWithOffset(position, -9999)
-        }, 100)
-    }
-
     private fun scrollToBottom() {
         Log.d(TAG, "scrollToBottom")
         val position = adapter.itemCount - 1
         if (position >= 0) {
             recyclerView.post {
                 recyclerView.scrollToPosition(position)
-                recyclerView.post {
-                    linearLayoutManager.scrollToPositionWithOffset(position, -99999)
-                    recyclerView.post(object : Runnable {
-                        private var attempts = 0
+                recyclerView.post(object : Runnable {
+                    private var attempts = 0
 
-                        override fun run() {
-                            val remainingDistance = distanceFromBottomPx()
-                            if (remainingDistance <= scrollToBottomThresholdPx() || attempts >= 4) {
-                                updateScrollToBottomButtonVisibility()
-                                return
-                            }
-                            attempts += 1
-                            recyclerView.scrollBy(0, remainingDistance)
-                            recyclerView.post(this)
+                    override fun run() {
+                        val remainingDistance = distanceFromBottomPx()
+                        if (remainingDistance <= scrollToBottomThresholdPx() || attempts >= 4) {
+                            updateScrollToBottomButtonVisibility()
+                            return
                         }
-                    })
-                }
+                        attempts += 1
+                        recyclerView.scrollBy(0, remainingDistance)
+                        recyclerView.post(this)
+                    }
+                })
             }
         }
     }
 
     private fun resumeAutoScroll() {
         isUserScrolling = false
-        forceBottomDuringStreaming = true
         scrollToBottom()
         updateScrollToBottomButtonVisibility()
         onResumeAutoScrollListener?.invoke()
     }
 
     private fun maintainBottomDuringStreaming() {
-        recyclerView.post {
-            val remainingDistance = distanceFromBottomPx()
-            if (remainingDistance > 0) {
-                recyclerView.scrollBy(0, remainingDistance)
-            }
-            updateScrollToBottomButtonVisibility()
-        }
+        recyclerView.removeCallbacks(maintainBottomRunnable)
+        recyclerView.postOnAnimation(maintainBottomRunnable)
     }
 
     private fun updateScrollToBottomButtonVisibility() {
@@ -271,11 +261,7 @@ class ChatListComponent(private val context: Context,
     fun updateAssistantResponse(chatDataItem: ChatDataItem) {
         adapter.updateRecentItem(chatDataItem)
         if (!isUserScrolling) {
-            if (forceBottomDuringStreaming) {
-                maintainBottomDuringStreaming()
-            } else {
-                scrollToEnd()
-            }
+            maintainBottomDuringStreaming()
         }
         updateEmptyViewVisibility()
         updateScrollToBottomButtonVisibility()
@@ -283,7 +269,6 @@ class ChatListComponent(private val context: Context,
 
     fun onStartSendMessage(userData: ChatDataItem) {
         isUserScrolling = false
-        forceBottomDuringStreaming = false
         adapter.addItem(userData)
         addResponsePlaceholder()
         updateEmptyViewVisibility()

--- a/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mnnllm/android/chat/chatlist/ChatViewHolders.kt
+++ b/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mnnllm/android/chat/chatlist/ChatViewHolders.kt
@@ -175,7 +175,7 @@ object ChatViewHolders {
 
     class AssistantViewHolder @SuppressLint("ClickableViewAccessibility") constructor(view: View) :
         RecyclerView.ViewHolder(view), View.OnClickListener, OnLongClickListener {
-        private val viewText: TextView = view.findViewById(R.id.tv_chat_text)
+        private val viewText: MarkdownMessageView = view.findViewById(R.id.tv_chat_text)
         private val viewThinking: TextView = view.findViewById(R.id.tv_chat_thinking)
         private val thinkingContainer: View = view.findViewById(R.id.ll_thinking_container)
         private val thinkingMarker: View = view.findViewById(R.id.view_thinking_marker)
@@ -203,7 +203,10 @@ object ChatViewHolders {
                 builder.addInlineProcessor(LatexInlineProcessor())
             })
             .usePlugin(TablePlugin.create(itemView.context))
-            .usePlugin(JLatexMathPlugin.create(viewText.textSize, viewText.textSize) { builder ->
+            .usePlugin(JLatexMathPlugin.create(
+                itemView.resources.getDimension(R.dimen.h3),
+                itemView.resources.getDimension(R.dimen.h3)
+            ) { builder ->
                 builder.inlinesEnabled(true)
             })
             .build()
@@ -220,16 +223,7 @@ object ChatViewHolders {
                 chatDataItem.toggleThinking()
                 updateThinkingView(chatDataItem, itemView.context)
                 
-                if (AssistantTextRenderPolicy.usePlainText(chatDataItem)) {
-                    viewText.text = chatDataItem.displayText
-                } else {
-                    val streamText = if (chatDataItem.loading) {
-                        preprocessStreamingMarkdown(chatDataItem.displayText ?: "", true)
-                    } else {
-                        chatDataItem.displayText ?: ""
-                    }
-                    markdown.setMarkdown(viewText, streamText)
-                }
+                renderAssistantText(chatDataItem)
             }
 
             // Setup action buttons
@@ -304,17 +298,34 @@ object ChatViewHolders {
             return result
         }
 
+        private fun renderAssistantText(data: ChatDataItem) {
+            val sourceText = data.displayText ?: ""
+            if (sourceText.isEmpty()) {
+                viewText.visibility = View.GONE
+                return
+            }
+
+            viewText.visibility = View.VISIBLE
+            if (AssistantTextRenderPolicy.usePlainText(data)) {
+                viewText.showPlainText(sourceText)
+                return
+            }
+
+            val streamText = if (data.loading) {
+                preprocessStreamingMarkdown(sourceText, true)
+            } else {
+                sourceText
+            }
+            viewText.renderMarkdown(markdown, sourceText, streamText, data.loading)
+        }
+
         fun bind(data: ChatDataItem, modelName: String?, payloads: List<Any?>?) {
             if (!payloads.isNullOrEmpty()) {
                 if (data.thinkingText != null && !TextUtils.isEmpty(data.thinkingText)) {
                     updateThinkingView(data, itemView.context)
                 }
                 if (data.displayText != null) {
-                    if (AssistantTextRenderPolicy.usePlainText(data)) {
-                        viewText.text = data.displayText
-                    } else {
-                        markdown.setMarkdown(viewText, data.displayText!!)
-                    }
+                    renderAssistantText(data)
                 }
                 imageGenerated.visibility =
                     if (data.imageUri != null) View.VISIBLE else View.GONE
@@ -326,21 +337,7 @@ object ChatViewHolders {
             }
 
             updateThinkingView(data, itemView.context)
-            if (AssistantTextRenderPolicy.usePlainText(data)) {
-                viewText.text = data.displayText
-            } else {
-                val streamText = if (data.loading) {
-                    preprocessStreamingMarkdown(data.displayText ?: "", true)
-                } else {
-                    data.displayText ?: ""
-                }
-                if (streamText.isEmpty()) {
-                    viewText.visibility = View.GONE
-                } else {
-                    viewText.visibility = View.VISIBLE
-                    markdown.setMarkdown(viewText, streamText)
-                }
-            }
+            renderAssistantText(data)
 
             viewAssistantLoading.visibility = if (AssistantLoadingVisibilityDecider.shouldShow(data)) {
                 View.VISIBLE
@@ -426,16 +423,18 @@ object ChatViewHolders {
                 return false
             }
             
-            val textView = v as? TextView ?: return false
             v.performHapticFeedback(android.view.HapticFeedbackConstants.LONG_PRESS)
             PopupWindowHelper().showPopupWindow(
                 v.getContext(), v
             ) { v ->
                 if (v.id == R.id.assistant_text_copy) {
-                    UiUtils.copyText(itemView.context, textView)
+                    ClipboardUtils.copyToClipboard(
+                        itemView.context,
+                        chatDataItem.displayText ?: chatDataItem.text ?: ""
+                    )
                 } else if (v.id == R.id.assistant_text_select) {
                     val intent = Intent(v.context, SelectTextActivity::class.java)
-                    intent.putExtra("content", chatDataItem.text)
+                    intent.putExtra("content", chatDataItem.displayText ?: chatDataItem.text)
                     v.context.startActivity(intent)
                 } else if (v.id == R.id.assistant_text_report) {
                     val chatActivity = UiUtils.getActivity(v.context) as ChatActivity

--- a/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mnnllm/android/chat/chatlist/MarkdownBlockParser.kt
+++ b/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mnnllm/android/chat/chatlist/MarkdownBlockParser.kt
@@ -1,0 +1,108 @@
+package com.alibaba.mnnllm.android.chat.chatlist
+
+internal object MarkdownBlockParser {
+    sealed class Block(open val content: String) {
+        data class Markdown(override val content: String) : Block(content)
+        data class Table(override val content: String) : Block(content)
+        data class Code(override val content: String, val language: String?) : Block(content)
+    }
+
+    private val openingFence = Regex("""^ {0,3}(`{3,}|~{3,})(.*)$""")
+    private val tableSeparator = Regex(
+        """^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$"""
+    )
+
+    fun parse(text: String, isStreaming: Boolean): List<Block> {
+        if (text.isEmpty()) return emptyList()
+
+        val endsWithNewLine = text.endsWith('\n')
+        val lines = if (endsWithNewLine) {
+            text.dropLast(1).split('\n')
+        } else {
+            text.split('\n')
+        }
+        val blocks = mutableListOf<Block>()
+        val markdown = StringBuilder()
+        var lineIndex = 0
+
+        fun appendLine(builder: StringBuilder, line: String, index: Int) {
+            builder.append(line)
+            if (index < lines.lastIndex || endsWithNewLine) {
+                builder.append('\n')
+            }
+        }
+
+        fun flushMarkdown() {
+            if (markdown.isNotEmpty()) {
+                blocks += Block.Markdown(markdown.toString())
+                markdown.clear()
+            }
+        }
+
+        while (lineIndex < lines.size) {
+            val line = lines[lineIndex]
+            val fenceMatch = openingFence.matchEntire(line)
+            if (fenceMatch != null) {
+                flushMarkdown()
+                val fence = fenceMatch.groupValues[1]
+                val language = fenceMatch.groupValues[2]
+                    .trim()
+                    .substringBefore(' ')
+                    .ifEmpty { null }
+                val code = StringBuilder()
+                lineIndex += 1
+                while (lineIndex < lines.size) {
+                    val codeLine = lines[lineIndex]
+                    if (isClosingFence(codeLine, fence)) {
+                        lineIndex += 1
+                        break
+                    }
+                    appendLine(code, codeLine, lineIndex)
+                    lineIndex += 1
+                }
+                blocks += Block.Code(code.toString().removeSuffix("\n"), language)
+                continue
+            }
+
+            if (isTableStart(lines, lineIndex)) {
+                flushMarkdown()
+                val table = StringBuilder()
+                appendLine(table, lines[lineIndex], lineIndex)
+                appendLine(table, lines[lineIndex + 1], lineIndex + 1)
+                lineIndex += 2
+
+                while (lineIndex < lines.size && looksLikeTableRow(lines[lineIndex])) {
+                    val trailingIncompleteRow = isStreaming && !endsWithNewLine && lineIndex == lines.lastIndex
+                    if (trailingIncompleteRow) {
+                        lineIndex += 1
+                        break
+                    }
+                    appendLine(table, lines[lineIndex], lineIndex)
+                    lineIndex += 1
+                }
+                blocks += Block.Table(table.toString().removeSuffix("\n"))
+                continue
+            }
+
+            appendLine(markdown, line, lineIndex)
+            lineIndex += 1
+        }
+
+        flushMarkdown()
+        return blocks
+    }
+
+    private fun isTableStart(lines: List<String>, index: Int): Boolean {
+        if (index + 1 >= lines.size || !lines[index].contains('|')) return false
+        return tableSeparator.matches(lines[index + 1])
+    }
+
+    private fun looksLikeTableRow(line: String): Boolean {
+        return line.isNotBlank() && line.contains('|')
+    }
+
+    private fun isClosingFence(line: String, openingFence: String): Boolean {
+        val fenceChar = Regex.escape(openingFence.first().toString())
+        return Regex("""^ {0,3}$fenceChar{${openingFence.length},}\s*$""").matches(line)
+    }
+}

--- a/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mnnllm/android/chat/chatlist/MarkdownMessageView.kt
+++ b/apps/Android/MnnLlmChat/app/src/main/java/com/alibaba/mnnllm/android/chat/chatlist/MarkdownMessageView.kt
@@ -1,0 +1,165 @@
+package com.alibaba.mnnllm.android.chat.chatlist
+
+import android.content.Context
+import android.graphics.Typeface
+import android.util.AttributeSet
+import android.util.TypedValue
+import android.view.View
+import android.widget.HorizontalScrollView
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import com.alibaba.mnnllm.android.R
+import io.noties.markwon.Markwon
+
+class MarkdownMessageView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : LinearLayout(context, attrs, defStyleAttr) {
+
+    private var renderedBlocks: List<MarkdownBlockParser.Block> = emptyList()
+    private var plainTextMode = false
+
+    init {
+        orientation = VERTICAL
+    }
+
+    fun showPlainText(text: CharSequence) {
+        if (!plainTextMode || childCount != 1 || getChildAt(0) !is TextView) {
+            removeAllViews()
+            addView(createTextView())
+        }
+        plainTextMode = true
+        renderedBlocks = emptyList()
+        (getChildAt(0) as TextView).text = text
+    }
+
+    fun renderMarkdown(
+        markwon: Markwon,
+        sourceText: String,
+        preprocessedText: String = sourceText,
+        isStreaming: Boolean = false
+    ) {
+        var blocks = MarkdownBlockParser.parse(sourceText, isStreaming)
+        val streamingSuffix = preprocessedText.takeIf { it.startsWith(sourceText) }
+            ?.substring(sourceText.length)
+            .orEmpty()
+        if (streamingSuffix.isNotEmpty()) {
+            val lastMarkdownIndex = blocks.indexOfLast { it is MarkdownBlockParser.Block.Markdown }
+            blocks = if (lastMarkdownIndex >= 0) {
+                blocks.toMutableList().also { updatedBlocks ->
+                    val markdownBlock = updatedBlocks[lastMarkdownIndex] as MarkdownBlockParser.Block.Markdown
+                    updatedBlocks[lastMarkdownIndex] = markdownBlock.copy(
+                        content = markdownBlock.content + streamingSuffix
+                    )
+                }
+            } else {
+                blocks + MarkdownBlockParser.Block.Markdown(streamingSuffix)
+            }
+        }
+
+        plainTextMode = false
+        if (!hasSameStructure(renderedBlocks, blocks)) {
+            rebuild(markwon, blocks)
+            return
+        }
+
+        blocks.forEachIndexed { index, block ->
+            if (block != renderedBlocks[index]) {
+                updateBlock(markwon, getChildAt(index), block)
+            }
+        }
+        renderedBlocks = blocks
+    }
+
+    private fun hasSameStructure(
+        oldBlocks: List<MarkdownBlockParser.Block>,
+        newBlocks: List<MarkdownBlockParser.Block>
+    ): Boolean {
+        return oldBlocks.size == newBlocks.size && oldBlocks.indices.all { index ->
+            oldBlocks[index]::class == newBlocks[index]::class
+        }
+    }
+
+    private fun rebuild(markwon: Markwon, blocks: List<MarkdownBlockParser.Block>) {
+        removeAllViews()
+        blocks.forEach { block ->
+            val view = when (block) {
+                is MarkdownBlockParser.Block.Code -> createCodeBlockView(block.content)
+                is MarkdownBlockParser.Block.Markdown,
+                is MarkdownBlockParser.Block.Table -> createTextView().also {
+                    markwon.setMarkdown(it, block.content)
+                }
+            }
+            addView(view)
+        }
+        renderedBlocks = blocks
+    }
+
+    private fun updateBlock(markwon: Markwon, view: View, block: MarkdownBlockParser.Block) {
+        when (block) {
+            is MarkdownBlockParser.Block.Code -> {
+                val scrollView = view as HorizontalScrollView
+                (scrollView.getChildAt(0) as TextView).text = block.content
+            }
+            is MarkdownBlockParser.Block.Markdown,
+            is MarkdownBlockParser.Block.Table -> markwon.setMarkdown(view as TextView, block.content)
+        }
+    }
+
+    private fun createTextView(): TextView {
+        return TextView(context).apply {
+            layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
+            setTextAppearance(R.style.Light)
+            setTextColor(resolveColor(com.google.android.material.R.attr.colorOnSurface))
+            setTextSize(TypedValue.COMPLEX_UNIT_PX, resources.getDimension(R.dimen.h3))
+            forwardLongClicksToContainer(this)
+        }
+    }
+
+    private fun createCodeBlockView(code: String): HorizontalScrollView {
+        val codeText = TextView(context).apply {
+            layoutParams = LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT)
+            background = ContextCompat.getDrawable(context, R.drawable.bg_markdown_code_block)
+            typeface = Typeface.MONOSPACE
+            setTextColor(resolveColor(com.google.android.material.R.attr.colorOnSurface))
+            setTextSize(TypedValue.COMPLEX_UNIT_PX, resources.getDimension(R.dimen.h4))
+            setPadding(dp(12), dp(10), dp(12), dp(10))
+            setHorizontallyScrolling(true)
+            text = code
+            forwardLongClicksToContainer(this)
+        }
+        return HorizontalScrollView(context).apply {
+            layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT).also {
+                it.topMargin = dp(4)
+                it.bottomMargin = dp(4)
+            }
+            isFillViewport = false
+            isHorizontalScrollBarEnabled = true
+            isScrollbarFadingEnabled = false
+            forwardLongClicksToContainer(this)
+            addView(codeText)
+        }
+    }
+
+    private fun forwardLongClicksToContainer(view: View) {
+        view.setOnLongClickListener {
+            this@MarkdownMessageView.performLongClick()
+        }
+    }
+
+    private fun resolveColor(attribute: Int): Int {
+        val value = TypedValue()
+        context.theme.resolveAttribute(attribute, value, true)
+        return if (value.resourceId != 0) {
+            ContextCompat.getColor(context, value.resourceId)
+        } else {
+            value.data
+        }
+    }
+
+    private fun dp(value: Int): Int {
+        return (value * resources.displayMetrics.density + 0.5F).toInt()
+    }
+}

--- a/apps/Android/MnnLlmChat/app/src/main/res/drawable/bg_markdown_code_block.xml
+++ b/apps/Android/MnnLlmChat/app/src/main/res/drawable/bg_markdown_code_block.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="?attr/colorSurfaceVariant" />
+    <corners android:radius="8dp" />
+</shape>

--- a/apps/Android/MnnLlmChat/app/src/main/res/layout/item_holder_assistant.xml
+++ b/apps/Android/MnnLlmChat/app/src/main/res/layout/item_holder_assistant.xml
@@ -71,18 +71,15 @@
             tools:visibility="visible" />
     </LinearLayout>
 
-    <TextView
+    <com.alibaba.mnnllm.android.chat.chatlist.MarkdownMessageView
         android:id="@+id/tv_chat_text"
         tools:text="this is the generated text"
         android:layout_toEndOf="@id/ic_header"
         android:layout_below="@id/ll_thinking_container"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingStart="@dimen/space10"
         android:paddingEnd="@dimen/space10"
-        android:textAppearance="@style/Light"
-        android:textColor="?colorOnSurface"
-        android:textSize="@dimen/h3"
         android:visibility="visible" />
         
     <ImageView

--- a/apps/Android/MnnLlmChat/app/src/test/java/com/alibaba/mnnllm/android/chat/ChatHistoryPersistencePolicyTest.kt
+++ b/apps/Android/MnnLlmChat/app/src/test/java/com/alibaba/mnnllm/android/chat/ChatHistoryPersistencePolicyTest.kt
@@ -1,0 +1,74 @@
+package com.alibaba.mnnllm.android.chat
+
+import com.alibaba.mnnllm.android.chat.chatlist.ChatViewHolders
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatHistoryPersistencePolicyTest {
+
+    @Test
+    fun `saves partial assistant response when llm generation is interrupted`() {
+        assertTrue(
+            ChatHistoryPersistencePolicy.shouldSaveInterruptedAssistant(
+                isGenerating = true,
+                isMockStreamSession = false,
+                isDiffusion = false,
+                itemType = ChatViewHolders.ASSISTANT,
+                text = "partial response"
+            )
+        )
+    }
+
+    @Test
+    fun `does not save an empty assistant placeholder`() {
+        assertFalse(
+            ChatHistoryPersistencePolicy.shouldSaveInterruptedAssistant(
+                isGenerating = true,
+                isMockStreamSession = false,
+                isDiffusion = false,
+                itemType = ChatViewHolders.ASSISTANT,
+                text = ""
+            )
+        )
+    }
+
+    @Test
+    fun `does not save diffusion progress text`() {
+        assertFalse(
+            ChatHistoryPersistencePolicy.shouldSaveInterruptedAssistant(
+                isGenerating = true,
+                isMockStreamSession = false,
+                isDiffusion = true,
+                itemType = ChatViewHolders.ASSISTANT,
+                text = "Generating image"
+            )
+        )
+    }
+
+    @Test
+    fun `does not save when generation already finished`() {
+        assertFalse(
+            ChatHistoryPersistencePolicy.shouldSaveInterruptedAssistant(
+                isGenerating = false,
+                isMockStreamSession = false,
+                isDiffusion = false,
+                itemType = ChatViewHolders.ASSISTANT,
+                text = "completed response"
+            )
+        )
+    }
+
+    @Test
+    fun `does not save debug mock stream output`() {
+        assertFalse(
+            ChatHistoryPersistencePolicy.shouldSaveInterruptedAssistant(
+                isGenerating = true,
+                isMockStreamSession = true,
+                isDiffusion = false,
+                itemType = ChatViewHolders.ASSISTANT,
+                text = "mock response"
+            )
+        )
+    }
+}

--- a/apps/Android/MnnLlmChat/app/src/test/java/com/alibaba/mnnllm/android/chat/chatlist/AssistantMarkdownTableRenderTest.kt
+++ b/apps/Android/MnnLlmChat/app/src/test/java/com/alibaba/mnnllm/android/chat/chatlist/AssistantMarkdownTableRenderTest.kt
@@ -4,6 +4,7 @@ import android.os.Looper
 import android.text.Spanned
 import android.view.LayoutInflater
 import android.widget.FrameLayout
+import android.widget.HorizontalScrollView
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import com.alibaba.mnnllm.android.R
@@ -39,8 +40,8 @@ class AssistantMarkdownTableRenderTest {
         holder.bind(data, "Qwen", null)
         shadowOf(Looper.getMainLooper()).idle()
 
-        val chatText = itemView.findViewById<TextView>(R.id.tv_chat_text)
-        val rendered = chatText.text as Spanned
+        val chatText = itemView.findViewById<MarkdownMessageView>(R.id.tv_chat_text)
+        val rendered = (chatText.getChildAt(0) as TextView).text as Spanned
         val spanNames = rendered.getSpans(0, rendered.length, Any::class.java)
             .map { it.javaClass.simpleName }
 
@@ -48,5 +49,34 @@ class AssistantMarkdownTableRenderTest {
             "Expected table-related spans for rendered markdown table, actual=$spanNames text=${rendered}",
             spanNames.any { it.contains("Table", ignoreCase = true) }
         )
+    }
+
+    @Test
+    fun `assistant fenced code should render in a horizontal scroll view`() {
+        val activity = Robolectric.buildActivity(AppCompatActivity::class.java).setup().get()
+        activity.setTheme(R.style.AppTheme)
+        val itemView = LayoutInflater.from(activity)
+            .inflate(R.layout.item_holder_assistant, FrameLayout(activity), false)
+        val holder = ChatViewHolders.AssistantViewHolder(itemView)
+        val data = ChatDataItem(ChatViewHolders.ASSISTANT).apply {
+            displayText = """
+                Before
+
+                ```kotlin
+                val result = thisIsAnIntentionallyLongFunctionNameForHorizontalScrolling()
+                ```
+
+                After
+            """.trimIndent()
+        }
+
+        holder.bind(data, "Qwen", null)
+
+        val chatText = itemView.findViewById<MarkdownMessageView>(R.id.tv_chat_text)
+        val codeBlock = chatText.getChildAt(1) as HorizontalScrollView
+        val codeText = codeBlock.getChildAt(0) as TextView
+
+        assertTrue(codeBlock.isHorizontalScrollBarEnabled)
+        assertTrue(codeText.text.contains("thisIsAnIntentionallyLongFunctionName"))
     }
 }

--- a/apps/Android/MnnLlmChat/app/src/test/java/com/alibaba/mnnllm/android/chat/chatlist/MarkdownBlockParserTest.kt
+++ b/apps/Android/MnnLlmChat/app/src/test/java/com/alibaba/mnnllm/android/chat/chatlist/MarkdownBlockParserTest.kt
@@ -1,0 +1,76 @@
+package com.alibaba.mnnllm.android.chat.chatlist
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MarkdownBlockParserTest {
+
+    @Test
+    fun `splits fenced code into a horizontally scrollable block`() {
+        val blocks = MarkdownBlockParser.parse(
+            "Before\n\n```kotlin\nval longValue = someVeryLongFunctionName()\n```\n\nAfter",
+            isStreaming = false
+        )
+
+        assertEquals(3, blocks.size)
+        assertTrue(blocks[0] is MarkdownBlockParser.Block.Markdown)
+        assertEquals(
+            MarkdownBlockParser.Block.Code("val longValue = someVeryLongFunctionName()", "kotlin"),
+            blocks[1]
+        )
+        assertTrue(blocks[2] is MarkdownBlockParser.Block.Markdown)
+    }
+
+    @Test
+    fun `keeps a markdown table isolated from surrounding prose`() {
+        val blocks = MarkdownBlockParser.parse(
+            "Before\n\n| Name | Value |\n| --- | --- |\n| A | 1 |\n\nAfter",
+            isStreaming = false
+        )
+
+        assertEquals(3, blocks.size)
+        assertTrue(blocks[1] is MarkdownBlockParser.Block.Table)
+        assertEquals(
+            "| Name | Value |\n| --- | --- |\n| A | 1 |",
+            blocks[1].content
+        )
+    }
+
+    @Test
+    fun `does not render an incomplete streaming table row`() {
+        val blocks = MarkdownBlockParser.parse(
+            "| Name | Value |\n| --- | --- |\n| incomplete",
+            isStreaming = true
+        )
+
+        assertEquals(1, blocks.size)
+        assertEquals(
+            "| Name | Value |\n| --- | --- |",
+            blocks[0].content
+        )
+    }
+
+    @Test
+    fun `supports tilde fences and an unfinished code block`() {
+        val blocks = MarkdownBlockParser.parse(
+            "~~~python\nprint('streaming')",
+            isStreaming = true
+        )
+
+        assertEquals(
+            listOf(MarkdownBlockParser.Block.Code("print('streaming')", "python")),
+            blocks
+        )
+    }
+
+    @Test
+    fun `preserves one trailing newline without adding another blank line`() {
+        val blocks = MarkdownBlockParser.parse("First line\n", isStreaming = false)
+
+        assertEquals(
+            listOf(MarkdownBlockParser.Block.Markdown("First line\n")),
+            blocks
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Render fenced Markdown code blocks in dedicated horizontal scroll views instead of forcing long code lines to wrap.
- Split Markdown responses into stable text, table, and code blocks so completed tables are not re-rendered for every following streaming token; defer incomplete streaming table rows until a newline arrives.
- Stabilize long streaming replies by coalescing automatic scroll requests to one per frame and scrolling by the measured bottom gap instead of fixed pixel offsets; user dragging still pauses auto-scroll.
- Preserve chat history when leaving a conversation during LLM generation: avoid inserting the user message twice and save any partial assistant response already generated.

## Why

The Android chat view previously rendered the entire assistant response into one Markwon `TextView`. This forced fenced code to wrap and caused completed table spans to be repeatedly laid out during streaming updates.

Streaming also queued a delayed scroll for every token and positioned the last item with fixed `-9999`/`-99999` pixel offsets. Once a reply became taller than those offsets, the list could repeatedly jump back into an earlier part of the response. The updated path coalesces pending work and uses the actual remaining distance to the bottom.

When `ChatActivity` was destroyed during generation, coroutine cancellation entered a generic error handler that wrote the already-persisted user message again. Assistant output was only persisted by the normal completion callback, so any partial response was lost. Cancellation is now propagated without retrying the saved input, and meaningful partial LLM output is persisted before teardown; empty placeholders and diffusion progress text are excluded.

## Validation

- `./test.sh static` — passed (3/3)
- Android parser and Robolectric rendering tests — passed
- Relevant Markdown, table, and history persistence unit tests — passed
- #4528 Android device verification — passed on OnePlus PJZ110 / Android 16 / Qwen3-0.6B; the user message remained unique and the partial assistant response was retained.

## Manual Android verification checklist (Monday)

- [ ] **#4639 long streaming reply:** generate a response much taller than the screen (preferably over 10,000 px) and confirm the view remains at the latest token without jumping back.
- [ ] **#4639 manual scrolling:** while that response is still streaming, drag upward and confirm the app does not pull the list back down; tap the bottom button and confirm it returns to the latest token and continues following smoothly.
- [ ] **#4640 fenced code:** generate a code block containing lines wider than the screen; confirm horizontal scrolling works, long lines do not wrap, and vertical chat scrolling remains usable.
- [ ] **#4705 streaming table:** generate a multi-row Markdown table token by token; confirm completed rows do not repeatedly flicker or relayout and an incomplete final row appears correctly after its newline arrives.
- [x] **#4528 exit after tokens:** leave the chat after part of the assistant response appears, reopen the session, and confirm the user message appears once and the partial assistant response is retained.
- [ ] **#4528 exit before first token:** leave immediately after sending, reopen the session, and confirm the user message appears once with no empty assistant placeholder.
- [ ] **Basic regression:** verify a short plain-text response, a normal completed response, reopening history, and sending a second prompt in the same session.

This PR remains a draft until the Android device checklist is complete.

Related to #4640, #4705, #4639, and #4528.
