### PR TITLE
[Infra:Bugfix] Skip reverse sync for outbound PRs

### DIFF
--- a/.github/workflows/aone-pr-merge-trigger.yml
+++ b/.github/workflows/aone-pr-merge-trigger.yml
@@ -22,9 +22,12 @@ concurrency:
 jobs:
   trigger-reverse-sync:
     name: Trigger reverse sync
+    # Outbound sync PRs use same-repository sync/* branches and need no reverse sync.
     if: >-
       (github.event_name == 'pull_request_target' &&
-       github.event.pull_request.merged == true) ||
+       github.event.pull_request.merged == true &&
+       !(github.event.pull_request.head.repo.full_name == github.repository &&
+         startsWith(github.event.pull_request.head.ref, 'sync/'))) ||
       github.event_name == 'workflow_dispatch'
     runs-on: [self-hosted, aone-sync]
     timeout-minutes: 5


### PR DESCRIPTION
## Summary

- Skip reverse sync when a merged PR comes from a same-repository `sync/*` branch.
- Keep ordinary PR merges, fork PR merges, and manual dispatch behavior unchanged.

## Why

Outbound sync PRs already contain the internal changes. Merging one should not trigger an unnecessary reverse sync back to the internal repository.

## Validation

- `actionlint` validation passed.
- `git diff --cached --check` passed.
- Verified the trigger condition against outbound sync, ordinary same-repository, fork, unmerged, and manual-dispatch cases.
