### PR TITLE
[Express:Bugfix] Fix loadMap/load output readMap returning NULL

### DIFF
--- a/express/Expr.cpp
+++ b/express/Expr.cpp
@@ -1055,6 +1055,15 @@ std::vector<VARP> Variable::load(const uint8_t* buffer, size_t length) {
                 auto outputIndex = op->outputIndexes[index];
                 delete expr->inside()->mOutputTensors[index];
                 expr->inside()->mOutputTensors[index] = Tensor::clone(allTensors[outputIndex].get());
+                // Restore the memoryType that Expr::create correctly set (MEMORY_HOST):
+                // Tensor::clone shares allTensors' describe (memoryType defaults to
+                // MEMORY_BACKEND), which would otherwise make mapOutput's copy branch
+                // fail to allocate a host buffer and return NULL on readMap (#4750).
+                // Safe: the cloned tensor's host is null for non-CONST nodes (allTensors
+                // are metadata-only for these; CONST/TRAIN nodes don't enter this branch,
+                // their weight-bearing host is preserved by Expr::create), so restoring
+                // MEMORY_HOST cannot cause a double-free on destruction.
+                TensorUtils::getDescribe(expr->inside()->mOutputTensors[index])->memoryType = Tensor::InsideDescribe::MEMORY_HOST;
                 Utils::copyTensorToInfo(expr->inside()->mOutputInfos.data() + index, expr->inside()->mOutputTensors[index]);
             }
         } else if (expr->inputType() == VARP::INPUT) {

--- a/test/expr/LoadMapInputTest.cpp
+++ b/test/expr/LoadMapInputTest.cpp
@@ -10,6 +10,7 @@
 #include <MNN/expr/ExprCreator.hpp>
 #include <MNN/expr/NeuralNetWorkOp.hpp>
 #include <MNN/expr/Executor.hpp>
+#include "core/MNNFileUtils.h"
 #include "MNNTestSuite.h"
 
 using namespace MNN::Express;
@@ -60,3 +61,62 @@ public:
     }
 };
 MNNTestSuiteRegister(LoadMapInputWriteMapTest, "expr/LoadMapInputWriteMap");
+
+// Regression test for #4750: reading the loadMap output via readMap() returned
+// NULL because Variable::load replaced the output tensor with a Tensor::clone
+// whose shared describe carried memoryType=MEMORY_BACKEND, so mapOutput's copy
+// branch could not allocate a host buffer.
+class LoadMapOutputReadMapTest : public MNNTestCase {
+public:
+    virtual bool run(int precision) override {
+        // Build a tiny NCHW-input model (Conv3x3 + ReLU) and save it.
+        auto x = _Input({1, 3, 8, 8}, NCHW);
+        std::vector<float> weight(4 * 3 * 3 * 3, 0.1f);
+        std::vector<float> bias(4, 0.01f);
+        auto w = _Const(weight.data(), {4, 3, 3, 3}, NCHW);
+        auto b = _Const(bias.data(), {4}, NCHW);
+        auto y = _Relu(_Conv(w, b, x));
+        MNNCreateDir("tmp");
+        Variable::save({y}, "tmp/regression_4750.mnn");
+
+        auto varMap = Variable::loadMap("tmp/regression_4750.mnn");
+        auto io = Variable::getInputAndOutput(varMap);
+        if (io.first.size() != 1 || io.second.size() != 1) {
+            MNN_PRINT("LoadMapOutputTest: expected single input/output, got %zu/%zu\n",
+                      io.first.size(), io.second.size());
+            return false;
+        }
+        auto input = io.first.begin()->second;
+        auto output = io.second.begin()->second;
+
+        auto ptr = input->writeMap<float>();
+        if (nullptr == ptr) {
+            MNN_PRINT("LoadMapOutputTest: writeMap returned NULL\n");
+            return false;
+        }
+        auto inInfo = input->getInfo();
+        int size = 1;
+        for (auto d : inInfo->dim) {
+            size *= d;
+        }
+        for (int i = 0; i < size; ++i) {
+            ptr[i] = 0.5f;
+        }
+
+        auto out = output->readMap<float>();
+        if (nullptr == out) {
+            // Before the fix this was NULL (output tensor memoryType was
+            // overwritten to MEMORY_BACKEND by Tensor::clone in Variable::load).
+            MNN_PRINT("LoadMapOutputTest: readMap returned NULL (bug #4750)\n");
+            return false;
+        }
+        // Expected first value: 27 * 0.1 * 0.5 + 0.01 = 1.36
+        auto val = out[0];
+        if (val < 1.359f || val > 1.361f) {
+            MNN_PRINT("LoadMapOutputTest: unexpected output value %f (expected 1.36)\n", val);
+            return false;
+        }
+        return true;
+    }
+};
+MNNTestSuiteRegister(LoadMapOutputReadMapTest, "expr/LoadMapOutputReadMap");


### PR DESCRIPTION
## Description

`Variable::load` / `Variable::loadMap` 加载的模型，输入可写（#4733 修复后）、推理可算，
但输出 `readMap` 返回 NULL——`expressDemo` 修复 #4733 后不崩但仍无输出。

**Root cause**：`Variable::load` 对非 INPUT 节点执行 `Tensor::clone(allTensors[i])`，
clone 共享源 describe（memoryType 默认 MEMORY_BACKEND），覆盖了 `Expr::create`
正确设置的 MEMORY_HOST。`mapOutput` 拷贝分支（`allocMemoryForHostTensor` 要求
MEMORY_HOST）无法分配 host → readMap 返回 NULL。

**Fix**：clone 后恢复 `memoryType = MEMORY_HOST`（与 #4733 的 INPUT 分支同源修复）。

```cpp
// express/Expr.cpp（Variable::load 的 clone 分支内）
expr->inside()->mOutputTensors[index] = Tensor::clone(allTensors[outputIndex].get());
// 还原 Expr::create 的正确状态（memoryType=MEMORY_HOST）
TensorUtils::getDescribe(expr->inside()->mOutputTensors[index])->memoryType = Tensor::InsideDescribe::MEMORY_HOST;
```

## Module

Express

## Type

- [ ] Feature
- [x] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [x] Tested on relevant platform(s)
- [x] No unrelated format or style changes included

## Reproduction

模型由代码生成，无需附件（完整可编译示例见 issue #4750）。核心流程：

```cpp
Variable::save({y}, "tiny.mnn");              // 生成 Conv3x3+ReLU 模型（输入 1x3x8x8 NCHW）
auto varMap = Variable::loadMap("tiny.mnn");
auto io = Variable::getInputAndOutput(varMap);
auto input = io.first.begin()->second, output = io.second.begin()->second;
auto ptr = input->writeMap<float>();          // ✅ OK（#4733 后）
// 写输入 0.5...
auto out = output->readMap<float>();          // ❌ 修复前 NULL → 修复后有效值
```

## Verification

- ✅ 修复前后对比（临时还原 B1 实测）：readMap NULL → 1.36（数学正确：27×0.1×0.5+0.01）
- ✅ 新增回归测试 `expr/LoadMapOutputReadMap` 通过（独立验证）
- ✅ expr/ 全量单测 54 个通过（53 原有 + 新增 1）
- ✅ Module API / Session API 正常（1.36，无副作用）
- ✅ Const / 重复 readMap / resize 专项通过
- ✅ 量化模型 readMap 非 NULL（量化输出数值精度为量化链路本身问题，与本 PR 无关）
- 注：MNN 全量测试套件在 x86 批跑有卡点（op/InterpInt8、op/randomuniform 单独跑通过但批跑卡）——已用原始 master 对照实验确认与本次修改无关

## Scope

本 PR 严格限定 Express `Variable::load` 的输出路径（1 行修复 + 回归测试）。
不影响：Module API / Session API / Const 节点 / 输入路径（#4733 已处理）。

## Related

- Fixes #4750
- 同源修复：#4733（INPUT 分支，已合入）
