### PR TITLE
[QNN:Bugfix] Fix NPU export and error logging

### DIFF
--- a/source/backend/qnn/backend/QNNBackend.cpp
+++ b/source/backend/qnn/backend/QNNBackend.cpp
@@ -80,13 +80,7 @@ static void createQnnContext(){
     // Create Log.
     Qnn_LogHandle_t logHandle = nullptr;
     {
-        QnnLog_Callback_t logCallback = [](const char* fmt, QnnLog_Level_t level, uint64_t timestamp, va_list args) {
-            if (level <= QNN_LOG_LEVEL_ERROR) {
-                char buf[512];
-                vsnprintf(buf, sizeof(buf), fmt, args);
-                MNN_PRINT("QNN_LOG[%d]: %s\n", level, buf);
-            }
-        };
+        QnnLog_Callback_t logCallback = nullptr;
         if ((QNN_GET_ERROR_CODE(qnnInterface.logCreate(logCallback, QNN_LOG_LEVEL_ERROR, &logHandle)) != QNN_SUCCESS) ||
             (logHandle == nullptr)) {
             MNN_PRINT("MNN_QNN: Failed to initialize logging in the backend.\n");

--- a/source/backend/qnn/backend/QNNBackend.cpp
+++ b/source/backend/qnn/backend/QNNBackend.cpp
@@ -18,6 +18,7 @@
 // #define QNN_PROFILE_OP
 // #define QNN_PROFILE_SUMMARIZE
 // #define QNN_VERBOSE
+// #define QNN_DEBUG
 #ifdef ENABLE_QNN_CONVERT_MODE
 #define QNN_FORWARD_TYPE MNN_CONVERT_QNN
 #else
@@ -81,6 +82,15 @@ static void createQnnContext(){
     Qnn_LogHandle_t logHandle = nullptr;
     {
         QnnLog_Callback_t logCallback = nullptr;
+#ifdef QNN_DEBUG
+        logCallback = [](const char* fmt, QnnLog_Level_t level, uint64_t timestamp, va_list args) {
+            if (level <= QNN_LOG_LEVEL_ERROR) {
+                char buf[512];
+                vsnprintf(buf, sizeof(buf), fmt, args);
+                MNN_PRINT("QNN_LOG[%d]: %s\n", level, buf);
+            }
+        };
+#endif
         if ((QNN_GET_ERROR_CODE(qnnInterface.logCreate(logCallback, QNN_LOG_LEVEL_ERROR, &logHandle)) != QNN_SUCCESS) ||
             (logHandle == nullptr)) {
             MNN_PRINT("MNN_QNN: Failed to initialize logging in the backend.\n");

--- a/transformers/llm/export/llmexport.py
+++ b/transformers/llm/export/llmexport.py
@@ -907,6 +907,8 @@ def export(path, **kwargs):
     args = parser.parse_args(['--path', path])
     for k, v in kwargs.items():
         setattr(args, k, v)
+    if args.generate_for_npu:
+        args.transformer_c4 = False
     if 'bge' in path:
         llm_exporter = EmbeddingExporter(args)
     else:
@@ -918,6 +920,8 @@ def main():
     parser = argparse.ArgumentParser(description='llm_exporter', formatter_class=argparse.RawTextHelpFormatter)
     build_args(parser)
     args = parser.parse_args()
+    if args.generate_for_npu:
+        args.transformer_c4 = False
 
     model_path = args.path
 


### PR DESCRIPTION
## Description

This PR fixes two QNN integration issues in the LLM NPU workflow.

Transformer C4 became the default for LLM exports in #4629. The NPU export flow inherited this default even though the downstream QNN conversion path does not fully support the C4 graph layout. Without this change, `llmexport.py --generate_for_npu` can produce a C4 model unless users also pass `--disable_transformer_c4`. In a Qwen3-0.6B comparison with `max_history_token=0`, the C4 model caused `compilefornpu` to exit with code 139 after unsupported-operation and invalid-tensor-shape errors, while the non-C4 model completed successfully and generated 30 merge targets.

Force `transformer_c4=False` whenever `generate_for_npu` is enabled in both the command-line entry point and the Python `export()` API. The override is applied before exporter construction because the export graph reads this option while creating fused RoPE and Attention nodes. Regular non-NPU exports retain the existing Transformer C4 default.

The QNN backend also registered a custom error callback that forwarded every QNN error-level event to MNN's standard output. QAIRT may emit error-level messages while probing HTP PD/domain options and then recover successfully. In testing, `contextCreateFromBinary()` returned success for all 90 context loads, but the callback still printed FastRPC/SMMU failure messages, making successful QNN execution appear to have failed and polluting application output.

Pass a null callback to `QnnLog_create()` so QNN can use the target platform's default log stream, as defined by the QNN logging API. Actual host API failures remain covered by the existing return-code checks.

Validation:
- Passed `python -m py_compile transformers/llm/export/llmexport.py`.
- Verified CLI and Python API NPU exports force C4 off while regular exports keep C4 enabled.
- Built the QNN-enabled `libMNN.so` with QAIRT 2.42.
- Verified the non-C4 Qwen3-0.6B conversion completes with 30 merge targets at `max_history_token=0`.
- Verified 90/90 QNN context loads returned success; after removing the callback, process-level QNN error lines dropped to zero without changing execution throughput.
- Verified `llm_demo` completed a QNN-backed prompt and decode run successfully.
- Passed `git diff --check`.

## Module

QNN

## Type

- [ ] Feature
- [x] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [x] Tested on relevant platform(s)
- [x] No unrelated format or style changes included

link: https://github.com/alibaba/MNN/issues/4716