### PR TITLE
[QNN:Bugfix] Add support for convert llm/visual mnn model into same q…

### DIFF
--- a/docs/transformers/llm.md
+++ b/docs/transformers/llm.md
@@ -1127,6 +1127,7 @@ make -j16
 | `--cache_path` | str | `tmp` | 转换过程中的临时缓存目录 |
 | `--chunk_size` | int | `128` | NPU 的 chunk 大小 |
 | `--max_history_token` | int | `0` | 最大历史 token 数，0 表示不限制 |
+| `--reuse_config_qnn_json` | bool | (选填) | 是否复用config_qnn.json |
 
 ##### 用法一：转换 LLM 语言模型
 
@@ -1169,6 +1170,8 @@ python3 npu/generate_llm_qnn.py \
 ```
 
 转换完成后，会在模型目录下生成 `qnn/` 子目录和 `config_qnn.json`（其中 `visual_model` 字段指向转换后的 QNN 视觉模型）。
+
+> **注意**: `--reuse_config_qnn_json` 用于llm/visual均使用npu推理场景,该参数对先转换llm或visual没有限制，只需在第二次转换时带上`--resue_config_qnn_json`即可。
 
 ##### 用法三：使用自定义 input_json 转换任意模型
 

--- a/transformers/llm/export/npu/generate_llm_qnn.py
+++ b/transformers/llm/export/npu/generate_llm_qnn.py
@@ -7,6 +7,7 @@ import subprocess
 import json
 import shutil
 import time
+import glob
 
 def makeIO(args, model_name, inputjson, external_file = None):
     exe = os.path.join(os.getcwd(), args.mnn_path, "generateIO")
@@ -230,6 +231,11 @@ def seperate(args, model_name, ids):
         "KVCACHE_SIZE_LIMIT":args.max_history_token,
         "cache":"qnn"
     }
+    is_visual = args.model_name == "visual.mnn"
+    if not is_visual:
+        config["graph_name"] = "graphllm"
+    else:
+        config["graph_name"] = "graphvisual"
     for i in ids:
         config['testdir'].append(os.path.join("testdir", '%d' %i))
     cache = os.path.join(os.getcwd(), args.cache_path)
@@ -251,12 +257,33 @@ def compile_qnn(args):
     process.wait()
     return process.returncode
 
+def clean_stale_files(file_path):
+    for file in glob.glob(file_path):
+        if os.path.isfile(file):
+            os.remove(file)
+
 def output_qnn(args, model_name=None):
-    if os.path.exists(os.path.join(args.model, 'qnn')):
-        shutil.rmtree(os.path.join(args.model, 'qnn'))
-    shutil.move(os.path.join(args.cache_path, 'qnn'), os.path.join(args.model, 'qnn'))
+    if not args.reuse_config_qnn_json:
+        if os.path.exists(os.path.join(args.model, 'qnn')):
+            shutil.rmtree(os.path.join(args.model, 'qnn'))
+        shutil.move(os.path.join(args.cache_path, 'qnn'), os.path.join(args.model, 'qnn'))
+    else:
+        model_name = model_name or args.model_name
+        is_visual = model_name == "visual.mnn"
+        if is_visual:
+            clean_stale_files(os.path.join(args.model, "qnn/graphvisual*.bin"))
+        else:
+            clean_stale_files(os.path.join(args.model, "qnn/graphllm*.bin"))
+        if os.path.exists(os.path.join(args.model, "qnn", model_name)):
+            os.remove(os.path.join(args.model, "qnn", model_name))
+        shutil.copytree(os.path.join(args.cache_path, 'qnn'), os.path.join(args.model, 'qnn'), dirs_exist_ok=True)
+
     if args.need_config_json is True:
-        config_path = os.path.join(args.model, 'config.json')
+        config_path = {}
+        if args.reuse_config_qnn_json:
+          config_path = os.path.join(args.model, 'config_qnn.json')
+        else:
+          config_path = os.path.join(args.model, 'config.json')
         config_npu = {}
         if os.path.exists(config_path):
             with open(config_path, 'r', encoding='utf-8') as f:
@@ -417,6 +444,9 @@ def main():
                         )
     parser.add_argument('--need_config_json', type=bool, default=True,
                         help='wheather generate config json'
+                        )
+    parser.add_argument('--reuse_config_qnn_json', action="store_true",
+                        help='wheather to overwrite config_qnn.json for convert both llm/visual model to same qnn folder'
                         )
     args = parser.parse_args()
     convert(args)


### PR DESCRIPTION
…nn folder (Qnn model)

first visual convert:
python3 npu/generate_llm_qnn.py --model ../../../model/Qwen3-VL-4B-Instruct-MNN-QNN --soc_id=57 --dsp_arch=v75 --image_sizes 256x256 --model_name visual.mnn

second llm convert:
python3 npu/generate_llm_qnn.py --model ../../../model/Qwen3-VL-4B-Instruct-MNN-QNN --soc_id=57 --dsp_arch=v75 --reuse_config_qnn_json

layout of qnn model:

|-- config.json
|-- config_qnn.json
|-- embeddings_bf16.bin
|-- export_args.json
|-- llm.mnn
|-- llm.mnn.json
|-- llm.mnn.weight
|-- llm_config.json
|-- qnn
| |-- graphllm0.bin
| |-- ...
| |-- graphllmxx.bin
| |-- graphvisual0.bin
| |-- llm.mnn
| `-- visual.mnn
|-- tokenizer.mtok
|-- visual.mnn
-- visual.mnn.weight

2 directories, 52 files

push Qwen3-VL-4B-Instruct-MNN-QNN to /data/local/tmp, then will get both visual & llm inference on npu.

## Description
@wangzhaode 
This PR is replace old one (https://github.com/alibaba/MNN/pull/4549) as merge conflict reason.

two point addressed:
1, change --reuse_config_qnn_json from type=bool to action="store_true"
2, clean stale files (qnn/graphvisualxx.bin, qnn/visual.mnn, qnn/graphllmxx.bin, qnn/llm.mnn) before tmp/qnn copy

## Module

QNN

## Type

- [ ] Feature
- [ *] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [ ] Commit message follows `[Module:Type] Description` format
- [ ] Code compiles without errors
- [ *] Tested on relevant platform(s)
- [ ] No unrelated format or style changes included
