### PR TITLE
[Core:Bugfix] Regenerate schema headers for FusedLinear/GatedRMSNorm ops

### DIFF
--- a/schema/current/MNN_generated.h
+++ b/schema/current/MNN_generated.h
@@ -33,6 +33,9 @@ struct LinearAttentionParamT;
 struct RoPEParam;
 struct RoPEParamT;
 
+struct FusedLinearParam;
+struct FusedLinearParamT;
+
 struct FmhaV2Param;
 struct FmhaV2ParamT;
 
@@ -89,6 +92,8 @@ inline const flatbuffers::TypeTable *AttentionParamTypeTable();
 inline const flatbuffers::TypeTable *LinearAttentionParamTypeTable();
 
 inline const flatbuffers::TypeTable *RoPEParamTypeTable();
+
+inline const flatbuffers::TypeTable *FusedLinearParamTypeTable();
 
 inline const flatbuffers::TypeTable *FmhaV2ParamTypeTable();
 
@@ -295,6 +300,8 @@ enum OpType {
   OpType_GroupNorm = 304,
   OpType_LinearAttention = 305,
   OpType_RoPE = 306,
+  OpType_FusedLinear = 307,
+  OpType_GatedRMSNorm = 308,
   OpType_Extra = 512,
   OpType_ConvInt8 = 513,
   OpType_Int8ToFloat = 514,
@@ -309,7 +316,7 @@ enum OpType {
   OpType_MAX = OpType_GridSample
 };
 
-inline const OpType (&EnumValuesOpType())[184] {
+inline const OpType (&EnumValuesOpType())[186] {
   static const OpType values[] = {
     OpType_AbsVal,
     OpType_QuantizedAdd,
@@ -485,6 +492,8 @@ inline const OpType (&EnumValuesOpType())[184] {
     OpType_GroupNorm,
     OpType_LinearAttention,
     OpType_RoPE,
+    OpType_FusedLinear,
+    OpType_GatedRMSNorm,
     OpType_Extra,
     OpType_ConvInt8,
     OpType_Int8ToFloat,
@@ -808,8 +817,8 @@ inline const char * const *EnumNamesOpType() {
     "GroupNorm",
     "LinearAttention",
     "RoPE",
-    "",
-    "",
+    "FusedLinear",
+    "GatedRMSNorm",
     "",
     "",
     "",
@@ -1221,11 +1230,12 @@ enum OpParameter {
   OpParameter_LinearAttentionParam = 100,
   OpParameter_ShapeParam = 101,
   OpParameter_RoPEParam = 102,
+  OpParameter_FusedLinearParam = 103,
   OpParameter_MIN = OpParameter_NONE,
-  OpParameter_MAX = OpParameter_RoPEParam
+  OpParameter_MAX = OpParameter_FusedLinearParam
 };
 
-inline const OpParameter (&EnumValuesOpParameter())[103] {
+inline const OpParameter (&EnumValuesOpParameter())[104] {
   static const OpParameter values[] = {
     OpParameter_NONE,
     OpParameter_QuantizedAdd,
@@ -1329,7 +1339,8 @@ inline const OpParameter (&EnumValuesOpParameter())[103] {
     OpParameter_StftParam,
     OpParameter_LinearAttentionParam,
     OpParameter_ShapeParam,
-    OpParameter_RoPEParam
+    OpParameter_RoPEParam,
+    OpParameter_FusedLinearParam
   };
   return values;
 }
@@ -1439,13 +1450,14 @@ inline const char * const *EnumNamesOpParameter() {
     "LinearAttentionParam",
     "ShapeParam",
     "RoPEParam",
+    "FusedLinearParam",
     nullptr
   };
   return names;
 }
 
 inline const char *EnumNameOpParameter(OpParameter e) {
-  if (e < OpParameter_NONE || e > OpParameter_RoPEParam) return "";
+  if (e < OpParameter_NONE || e > OpParameter_FusedLinearParam) return "";
   const size_t index = static_cast<int>(e);
   return EnumNamesOpParameter()[index];
 }
@@ -1860,6 +1872,10 @@ template<> struct OpParameterTraits<ShapeParam> {
 
 template<> struct OpParameterTraits<RoPEParam> {
   static const OpParameter enum_value = OpParameter_RoPEParam;
+};
+
+template<> struct OpParameterTraits<FusedLinearParam> {
+  static const OpParameter enum_value = OpParameter_FusedLinearParam;
 };
 
 struct OpParameterUnion {
@@ -2709,6 +2725,14 @@ struct OpParameterUnion {
     return type == OpParameter_RoPEParam ?
       reinterpret_cast<const RoPEParamT *>(value) : nullptr;
   }
+  FusedLinearParamT *AsFusedLinearParam() {
+    return type == OpParameter_FusedLinearParam ?
+      reinterpret_cast<FusedLinearParamT *>(value) : nullptr;
+  }
+  const FusedLinearParamT *AsFusedLinearParam() const {
+    return type == OpParameter_FusedLinearParam ?
+      reinterpret_cast<const FusedLinearParamT *>(value) : nullptr;
+  }
 };
 
 bool VerifyOpParameter(flatbuffers::Verifier &verifier, const void *obj, OpParameter type);
@@ -3144,12 +3168,16 @@ struct LinearAttentionParamT : public flatbuffers::NativeTable {
   int32_t head_k_dim;
   int32_t head_v_dim;
   bool use_qk_l2norm;
+  bool gate_fold;
+  std::vector<float> gate_coef;
+  std::vector<float> gate_bias;
   LinearAttentionParamT()
       : num_k_heads(0),
         num_v_heads(0),
         head_k_dim(0),
         head_v_dim(0),
-        use_qk_l2norm(false) {
+        use_qk_l2norm(false),
+        gate_fold(false) {
   }
 };
 
@@ -3176,6 +3204,15 @@ struct LinearAttentionParam FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
   bool use_qk_l2norm() const {
     return GetField<uint8_t>(14, 0) != 0;
   }
+  bool gate_fold() const {
+    return GetField<uint8_t>(16, 0) != 0;
+  }
+  const flatbuffers::Vector<float> *gate_coef() const {
+    return GetPointer<const flatbuffers::Vector<float> *>(18);
+  }
+  const flatbuffers::Vector<float> *gate_bias() const {
+    return GetPointer<const flatbuffers::Vector<float> *>(20);
+  }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyOffset(verifier, 4) &&
@@ -3185,6 +3222,11 @@ struct LinearAttentionParam FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
            VerifyField<int32_t>(verifier, 10) &&
            VerifyField<int32_t>(verifier, 12) &&
            VerifyField<uint8_t>(verifier, 14) &&
+           VerifyField<uint8_t>(verifier, 16) &&
+           VerifyOffset(verifier, 18) &&
+           verifier.VerifyVector(gate_coef()) &&
+           VerifyOffset(verifier, 20) &&
+           verifier.VerifyVector(gate_bias()) &&
            verifier.EndTable();
   }
   LinearAttentionParamT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
@@ -3213,6 +3255,15 @@ struct LinearAttentionParamBuilder {
   void add_use_qk_l2norm(bool use_qk_l2norm) {
     fbb_.AddElement<uint8_t>(14, static_cast<uint8_t>(use_qk_l2norm), 0);
   }
+  void add_gate_fold(bool gate_fold) {
+    fbb_.AddElement<uint8_t>(16, static_cast<uint8_t>(gate_fold), 0);
+  }
+  void add_gate_coef(flatbuffers::Offset<flatbuffers::Vector<float>> gate_coef) {
+    fbb_.AddOffset(18, gate_coef);
+  }
+  void add_gate_bias(flatbuffers::Offset<flatbuffers::Vector<float>> gate_bias) {
+    fbb_.AddOffset(20, gate_bias);
+  }
   explicit LinearAttentionParamBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
@@ -3232,13 +3283,19 @@ inline flatbuffers::Offset<LinearAttentionParam> CreateLinearAttentionParam(
     int32_t num_v_heads = 0,
     int32_t head_k_dim = 0,
     int32_t head_v_dim = 0,
-    bool use_qk_l2norm = false) {
+    bool use_qk_l2norm = false,
+    bool gate_fold = false,
+    flatbuffers::Offset<flatbuffers::Vector<float>> gate_coef = 0,
+    flatbuffers::Offset<flatbuffers::Vector<float>> gate_bias = 0) {
   LinearAttentionParamBuilder builder_(_fbb);
+  builder_.add_gate_bias(gate_bias);
+  builder_.add_gate_coef(gate_coef);
   builder_.add_head_v_dim(head_v_dim);
   builder_.add_head_k_dim(head_k_dim);
   builder_.add_num_v_heads(num_v_heads);
   builder_.add_num_k_heads(num_k_heads);
   builder_.add_attn_type(attn_type);
+  builder_.add_gate_fold(gate_fold);
   builder_.add_use_qk_l2norm(use_qk_l2norm);
   return builder_.Finish();
 }
@@ -3353,6 +3410,105 @@ inline flatbuffers::Offset<RoPEParam> CreateRoPEParam(
 }
 
 flatbuffers::Offset<RoPEParam> CreateRoPEParam(flatbuffers::FlatBufferBuilder &_fbb, const RoPEParamT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+
+struct FusedLinearParamT : public flatbuffers::NativeTable {
+  typedef FusedLinearParam TableType;
+  std::vector<std::unique_ptr<Convolution2DT>> convs;
+  bool act_silu_mul;
+  bool has_ln;
+  std::unique_ptr<LayerNormT> ln;
+  bool ln_fold;
+  FusedLinearParamT()
+      : act_silu_mul(false),
+        has_ln(false),
+        ln_fold(false) {
+  }
+};
+
+struct FusedLinearParam FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef FusedLinearParamT NativeTableType;
+  static const flatbuffers::TypeTable *MiniReflectTypeTable() {
+    return FusedLinearParamTypeTable();
+  }
+  const flatbuffers::Vector<flatbuffers::Offset<Convolution2D>> *convs() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<Convolution2D>> *>(4);
+  }
+  bool act_silu_mul() const {
+    return GetField<uint8_t>(6, 0) != 0;
+  }
+  bool has_ln() const {
+    return GetField<uint8_t>(8, 0) != 0;
+  }
+  const LayerNorm *ln() const {
+    return GetPointer<const LayerNorm *>(10);
+  }
+  bool ln_fold() const {
+    return GetField<uint8_t>(12, 0) != 0;
+  }
+  bool Verify(flatbuffers::Verifier &verifier) const {
+    return VerifyTableStart(verifier) &&
+           VerifyOffset(verifier, 4) &&
+           verifier.VerifyVector(convs()) &&
+           verifier.VerifyVectorOfTables(convs()) &&
+           VerifyField<uint8_t>(verifier, 6) &&
+           VerifyField<uint8_t>(verifier, 8) &&
+           VerifyOffset(verifier, 10) &&
+           verifier.VerifyTable(ln()) &&
+           VerifyField<uint8_t>(verifier, 12) &&
+           verifier.EndTable();
+  }
+  FusedLinearParamT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(FusedLinearParamT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static flatbuffers::Offset<FusedLinearParam> Pack(flatbuffers::FlatBufferBuilder &_fbb, const FusedLinearParamT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+};
+
+struct FusedLinearParamBuilder {
+  flatbuffers::FlatBufferBuilder &fbb_;
+  flatbuffers::uoffset_t start_;
+  void add_convs(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Convolution2D>>> convs) {
+    fbb_.AddOffset(4, convs);
+  }
+  void add_act_silu_mul(bool act_silu_mul) {
+    fbb_.AddElement<uint8_t>(6, static_cast<uint8_t>(act_silu_mul), 0);
+  }
+  void add_has_ln(bool has_ln) {
+    fbb_.AddElement<uint8_t>(8, static_cast<uint8_t>(has_ln), 0);
+  }
+  void add_ln(flatbuffers::Offset<LayerNorm> ln) {
+    fbb_.AddOffset(10, ln);
+  }
+  void add_ln_fold(bool ln_fold) {
+    fbb_.AddElement<uint8_t>(12, static_cast<uint8_t>(ln_fold), 0);
+  }
+  explicit FusedLinearParamBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+        : fbb_(_fbb) {
+    start_ = fbb_.StartTable();
+  }
+  FusedLinearParamBuilder &operator=(const FusedLinearParamBuilder &);
+  flatbuffers::Offset<FusedLinearParam> Finish() {
+    const auto end = fbb_.EndTable(start_);
+    auto o = flatbuffers::Offset<FusedLinearParam>(end);
+    return o;
+  }
+};
+
+inline flatbuffers::Offset<FusedLinearParam> CreateFusedLinearParam(
+    flatbuffers::FlatBufferBuilder &_fbb,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Convolution2D>>> convs = 0,
+    bool act_silu_mul = false,
+    bool has_ln = false,
+    flatbuffers::Offset<LayerNorm> ln = 0,
+    bool ln_fold = false) {
+  FusedLinearParamBuilder builder_(_fbb);
+  builder_.add_ln(ln);
+  builder_.add_convs(convs);
+  builder_.add_ln_fold(ln_fold);
+  builder_.add_has_ln(has_ln);
+  builder_.add_act_silu_mul(act_silu_mul);
+  return builder_.Finish();
+}
+
+flatbuffers::Offset<FusedLinearParam> CreateFusedLinearParam(flatbuffers::FlatBufferBuilder &_fbb, const FusedLinearParamT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
 struct FmhaV2ParamT : public flatbuffers::NativeTable {
   typedef FmhaV2Param TableType;
@@ -4416,6 +4572,9 @@ struct Op FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   const RoPEParam *main_as_RoPEParam() const {
     return main_type() == OpParameter_RoPEParam ? static_cast<const RoPEParam *>(main()) : nullptr;
   }
+  const FusedLinearParam *main_as_FusedLinearParam() const {
+    return main_type() == OpParameter_FusedLinearParam ? static_cast<const FusedLinearParam *>(main()) : nullptr;
+  }
   const flatbuffers::String *name() const {
     return GetPointer<const flatbuffers::String *>(10);
   }
@@ -4859,6 +5018,10 @@ template<> inline const ShapeParam *Op::main_as<ShapeParam>() const {
 
 template<> inline const RoPEParam *Op::main_as<RoPEParam>() const {
   return main_as_RoPEParam();
+}
+
+template<> inline const FusedLinearParam *Op::main_as<FusedLinearParam>() const {
+  return main_as_FusedLinearParam();
 }
 
 struct OpBuilder {
@@ -5717,6 +5880,9 @@ inline void LinearAttentionParam::UnPackTo(LinearAttentionParamT *_o, const flat
   { auto _e = head_k_dim(); _o->head_k_dim = _e; };
   { auto _e = head_v_dim(); _o->head_v_dim = _e; };
   { auto _e = use_qk_l2norm(); _o->use_qk_l2norm = _e; };
+  { auto _e = gate_fold(); _o->gate_fold = _e; };
+  { auto _e = gate_coef(); if (_e) { _o->gate_coef.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->gate_coef[_i] = _e->Get(_i); } } };
+  { auto _e = gate_bias(); if (_e) { _o->gate_bias.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->gate_bias[_i] = _e->Get(_i); } } };
 }
 
 inline flatbuffers::Offset<LinearAttentionParam> LinearAttentionParam::Pack(flatbuffers::FlatBufferBuilder &_fbb, const LinearAttentionParamT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -5733,6 +5899,9 @@ inline flatbuffers::Offset<LinearAttentionParam> CreateLinearAttentionParam(flat
   auto _head_k_dim = _o->head_k_dim;
   auto _head_v_dim = _o->head_v_dim;
   auto _use_qk_l2norm = _o->use_qk_l2norm;
+  auto _gate_fold = _o->gate_fold;
+  auto _gate_coef = _o->gate_coef.size() ? _fbb.CreateVector(_o->gate_coef) : 0;
+  auto _gate_bias = _o->gate_bias.size() ? _fbb.CreateVector(_o->gate_bias) : 0;
   return MNN::CreateLinearAttentionParam(
       _fbb,
       _attn_type,
@@ -5740,7 +5909,10 @@ inline flatbuffers::Offset<LinearAttentionParam> CreateLinearAttentionParam(flat
       _num_v_heads,
       _head_k_dim,
       _head_v_dim,
-      _use_qk_l2norm);
+      _use_qk_l2norm,
+      _gate_fold,
+      _gate_coef,
+      _gate_bias);
 }
 
 inline RoPEParamT *RoPEParam::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
@@ -5782,6 +5954,44 @@ inline flatbuffers::Offset<RoPEParam> CreateRoPEParam(flatbuffers::FlatBufferBui
       _head_dim,
       _q_norm,
       _k_norm);
+}
+
+inline FusedLinearParamT *FusedLinearParam::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
+  auto _o = new FusedLinearParamT();
+  UnPackTo(_o, _resolver);
+  return _o;
+}
+
+inline void FusedLinearParam::UnPackTo(FusedLinearParamT *_o, const flatbuffers::resolver_function_t *_resolver) const {
+  (void)_o;
+  (void)_resolver;
+  { auto _e = convs(); if (_e) { _o->convs.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->convs[_i] = std::unique_ptr<Convolution2DT>(_e->Get(_i)->UnPack(_resolver)); } } };
+  { auto _e = act_silu_mul(); _o->act_silu_mul = _e; };
+  { auto _e = has_ln(); _o->has_ln = _e; };
+  { auto _e = ln(); if (_e) _o->ln = std::unique_ptr<LayerNormT>(_e->UnPack(_resolver)); };
+  { auto _e = ln_fold(); _o->ln_fold = _e; };
+}
+
+inline flatbuffers::Offset<FusedLinearParam> FusedLinearParam::Pack(flatbuffers::FlatBufferBuilder &_fbb, const FusedLinearParamT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
+  return CreateFusedLinearParam(_fbb, _o, _rehasher);
+}
+
+inline flatbuffers::Offset<FusedLinearParam> CreateFusedLinearParam(flatbuffers::FlatBufferBuilder &_fbb, const FusedLinearParamT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
+  (void)_rehasher;
+  (void)_o;
+  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const FusedLinearParamT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  auto _convs = _o->convs.size() ? _fbb.CreateVector<flatbuffers::Offset<Convolution2D>> (_o->convs.size(), [](size_t i, _VectorArgs *__va) { return CreateConvolution2D(*__va->__fbb, __va->__o->convs[i].get(), __va->__rehasher); }, &_va ) : 0;
+  auto _act_silu_mul = _o->act_silu_mul;
+  auto _has_ln = _o->has_ln;
+  auto _ln = _o->ln ? CreateLayerNorm(_fbb, _o->ln.get(), _rehasher) : 0;
+  auto _ln_fold = _o->ln_fold;
+  return MNN::CreateFusedLinearParam(
+      _fbb,
+      _convs,
+      _act_silu_mul,
+      _has_ln,
+      _ln,
+      _ln_fold);
 }
 
 inline FmhaV2ParamT *FmhaV2Param::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
@@ -6767,6 +6977,10 @@ inline bool VerifyOpParameter(flatbuffers::Verifier &verifier, const void *obj, 
       auto ptr = reinterpret_cast<const RoPEParam *>(obj);
       return verifier.VerifyTable(ptr);
     }
+    case OpParameter_FusedLinearParam: {
+      auto ptr = reinterpret_cast<const FusedLinearParam *>(obj);
+      return verifier.VerifyTable(ptr);
+    }
     default: return false;
   }
 }
@@ -7193,6 +7407,10 @@ inline void *OpParameterUnion::UnPack(const void *obj, OpParameter type, const f
       auto ptr = reinterpret_cast<const RoPEParam *>(obj);
       return ptr->UnPack(resolver);
     }
+    case OpParameter_FusedLinearParam: {
+      auto ptr = reinterpret_cast<const FusedLinearParam *>(obj);
+      return ptr->UnPack(resolver);
+    }
     default: return nullptr;
   }
 }
@@ -7607,6 +7825,10 @@ inline flatbuffers::Offset<void> OpParameterUnion::Pack(flatbuffers::FlatBufferB
       auto ptr = reinterpret_cast<const RoPEParamT *>(value);
       return CreateRoPEParam(_fbb, ptr, _rehasher).Union();
     }
+    case OpParameter_FusedLinearParam: {
+      auto ptr = reinterpret_cast<const FusedLinearParamT *>(value);
+      return CreateFusedLinearParam(_fbb, ptr, _rehasher).Union();
+    }
     default: return 0;
   }
 }
@@ -8019,6 +8241,10 @@ inline OpParameterUnion::OpParameterUnion(const OpParameterUnion &u) FLATBUFFERS
     }
     case OpParameter_RoPEParam: {
       FLATBUFFERS_ASSERT(false);  // RoPEParamT not copyable.
+      break;
+    }
+    case OpParameter_FusedLinearParam: {
+      FLATBUFFERS_ASSERT(false);  // FusedLinearParamT not copyable.
       break;
     }
     default:
@@ -8538,6 +8764,11 @@ inline void OpParameterUnion::Reset() {
       delete ptr;
       break;
     }
+    case OpParameter_FusedLinearParam: {
+      auto ptr = reinterpret_cast<FusedLinearParamT *>(value);
+      delete ptr;
+      break;
+    }
     default: break;
   }
   value = nullptr;
@@ -8729,12 +8960,14 @@ inline const flatbuffers::TypeTable *OpTypeTypeTable() {
     { flatbuffers::ET_INT, 0, 0 },
     { flatbuffers::ET_INT, 0, 0 },
     { flatbuffers::ET_INT, 0, 0 },
+    { flatbuffers::ET_INT, 0, 0 },
+    { flatbuffers::ET_INT, 0, 0 },
     { flatbuffers::ET_INT, 0, 0 }
   };
   static const flatbuffers::TypeFunction type_refs[] = {
     OpTypeTypeTable
   };
-  static const int64_t values[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 256, 257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 299, 300, 301, 302, 303, 304, 305, 306, 512, 513, 514, 515, 517, 518, 600, 601, 603, 604 };
+  static const int64_t values[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 256, 257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 299, 300, 301, 302, 303, 304, 305, 306, 307, 308, 512, 513, 514, 515, 517, 518, 600, 601, 603, 604 };
   static const char * const names[] = {
     "AbsVal",
     "QuantizedAdd",
@@ -8910,6 +9143,8 @@ inline const flatbuffers::TypeTable *OpTypeTypeTable() {
     "GroupNorm",
     "LinearAttention",
     "RoPE",
+    "FusedLinear",
+    "GatedRMSNorm",
     "Extra",
     "ConvInt8",
     "Int8ToFloat",
@@ -8922,7 +9157,7 @@ inline const flatbuffers::TypeTable *OpTypeTypeTable() {
     "GridSample"
   };
   static const flatbuffers::TypeTable tt = {
-    flatbuffers::ST_ENUM, 184, type_codes, type_refs, values, names
+    flatbuffers::ST_ENUM, 186, type_codes, type_refs, values, names
   };
   return &tt;
 }
@@ -9031,7 +9266,8 @@ inline const flatbuffers::TypeTable *OpParameterTypeTable() {
     { flatbuffers::ET_SEQUENCE, 0, 98 },
     { flatbuffers::ET_SEQUENCE, 0, 99 },
     { flatbuffers::ET_SEQUENCE, 0, 100 },
-    { flatbuffers::ET_SEQUENCE, 0, 101 }
+    { flatbuffers::ET_SEQUENCE, 0, 101 },
+    { flatbuffers::ET_SEQUENCE, 0, 102 }
   };
   static const flatbuffers::TypeFunction type_refs[] = {
     QuantizedAddTypeTable,
@@ -9135,7 +9371,8 @@ inline const flatbuffers::TypeTable *OpParameterTypeTable() {
     StftParamTypeTable,
     LinearAttentionParamTypeTable,
     ShapeParamTypeTable,
-    RoPEParamTypeTable
+    RoPEParamTypeTable,
+    FusedLinearParamTypeTable
   };
   static const char * const names[] = {
     "NONE",
@@ -9240,10 +9477,11 @@ inline const flatbuffers::TypeTable *OpParameterTypeTable() {
     "StftParam",
     "LinearAttentionParam",
     "ShapeParam",
-    "RoPEParam"
+    "RoPEParam",
+    "FusedLinearParam"
   };
   static const flatbuffers::TypeTable tt = {
-    flatbuffers::ST_UNION, 103, type_codes, type_refs, nullptr, names
+    flatbuffers::ST_UNION, 104, type_codes, type_refs, nullptr, names
   };
   return &tt;
 }
@@ -9388,7 +9626,10 @@ inline const flatbuffers::TypeTable *LinearAttentionParamTypeTable() {
     { flatbuffers::ET_INT, 0, -1 },
     { flatbuffers::ET_INT, 0, -1 },
     { flatbuffers::ET_INT, 0, -1 },
-    { flatbuffers::ET_BOOL, 0, -1 }
+    { flatbuffers::ET_BOOL, 0, -1 },
+    { flatbuffers::ET_BOOL, 0, -1 },
+    { flatbuffers::ET_FLOAT, 1, -1 },
+    { flatbuffers::ET_FLOAT, 1, -1 }
   };
   static const char * const names[] = {
     "attn_type",
@@ -9396,10 +9637,13 @@ inline const flatbuffers::TypeTable *LinearAttentionParamTypeTable() {
     "num_v_heads",
     "head_k_dim",
     "head_v_dim",
-    "use_qk_l2norm"
+    "use_qk_l2norm",
+    "gate_fold",
+    "gate_coef",
+    "gate_bias"
   };
   static const flatbuffers::TypeTable tt = {
-    flatbuffers::ST_TABLE, 6, type_codes, nullptr, nullptr, names
+    flatbuffers::ST_TABLE, 9, type_codes, nullptr, nullptr, names
   };
   return &tt;
 }
@@ -9426,6 +9670,31 @@ inline const flatbuffers::TypeTable *RoPEParamTypeTable() {
   };
   static const flatbuffers::TypeTable tt = {
     flatbuffers::ST_TABLE, 6, type_codes, type_refs, nullptr, names
+  };
+  return &tt;
+}
+
+inline const flatbuffers::TypeTable *FusedLinearParamTypeTable() {
+  static const flatbuffers::TypeCode type_codes[] = {
+    { flatbuffers::ET_SEQUENCE, 1, 0 },
+    { flatbuffers::ET_BOOL, 0, -1 },
+    { flatbuffers::ET_BOOL, 0, -1 },
+    { flatbuffers::ET_SEQUENCE, 0, 1 },
+    { flatbuffers::ET_BOOL, 0, -1 }
+  };
+  static const flatbuffers::TypeFunction type_refs[] = {
+    Convolution2DTypeTable,
+    LayerNormTypeTable
+  };
+  static const char * const names[] = {
+    "convs",
+    "act_silu_mul",
+    "has_ln",
+    "ln",
+    "ln_fold"
+  };
+  static const flatbuffers::TypeTable tt = {
+    flatbuffers::ST_TABLE, 5, type_codes, type_refs, nullptr, names
   };
   return &tt;
 }


### PR DESCRIPTION
schema/current/MNN_generated.h was stale after a5a0e501 added the FusedLinearParam, FusedLinear and GatedRMSNorm schema entries to schema/default/MNN.fbs. Re-run schema/generate.sh to resync the generated FlatBuffers header (adds FusedLinearParam, OpType_FusedLinear=307, OpType_GatedRMSNorm=308, and gate_fold/gate_coef/gate_bias on LinearAttentionParam).

## Description

<!-- Brief description of the changes -->

## Module

<!-- Which module does this PR affect? e.g. LLM, CPU, Metal, CUDA, OpenCL, Core, Infra -->

## Type

- [ ] Feature
- [ ] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [ ] Commit message follows `[Module:Type] Description` format
- [ ] Code compiles without errors
- [ ] Tested on relevant platform(s)
- [ ] No unrelated format or style changes included
