### PR TITLE
[Test:Bugfix] Relax FP16 loadMap output tolerance

### DIFF
--- a/source/jni/mnnnetnative.cpp
+++ b/source/jni/mnnnetnative.cpp
@@ -13,6 +13,30 @@
 #include <MNN/Interpreter.hpp>
 #include <MNN/Tensor.hpp>
 #include <memory>
+#include <utility>
+
+static bool appendStringArray(JNIEnv* env, jobjectArray array, std::vector<std::string>& strings) {
+    const auto size = env->GetArrayLength(array);
+    strings.reserve(strings.size() + size);
+    for (jsize i = 0; i < size; ++i) {
+        auto stringObject = static_cast<jstring>(env->GetObjectArrayElement(array, i));
+        if (nullptr == stringObject) {
+            if (env->ExceptionCheck()) {
+                return false;
+            }
+            continue;
+        }
+        const char* characters = env->GetStringUTFChars(stringObject, nullptr);
+        if (nullptr == characters) {
+            env->DeleteLocalRef(stringObject);
+            return false;
+        }
+        strings.emplace_back(characters);
+        env->ReleaseStringUTFChars(stringObject, characters);
+        env->DeleteLocalRef(stringObject);
+    }
+    return true;
+}
 
 extern "C" JNIEXPORT jlong JNICALL
 Java_com_taobao_android_mnn_MNNNetNative_nativeCreateNetFromFile(JNIEnv *env, jclass type, jstring modelName_) {
@@ -56,34 +80,19 @@ extern "C" JNIEXPORT jlong JNICALL Java_com_taobao_android_mnn_MNNNetNative_nati
     }
 
     if (jsaveTensors != NULL) {
-        int size = env->GetArrayLength(jsaveTensors);
         std::vector<std::string> saveNamesVector;
-
-        for (int i = 0; i < size; i++) {
-            jstring jname       = (jstring)env->GetObjectArrayElement(jsaveTensors, i);
-            const char *name    = env->GetStringUTFChars(jname, NULL);
-            std::string nameStr = name;
-            saveNamesVector.push_back(nameStr);
-
-            env->ReleaseStringUTFChars(jname, name);
+        if (!appendStringArray(env, jsaveTensors, saveNamesVector)) {
+            return 0;
         }
-        config.saveTensors = saveNamesVector;
+        config.saveTensors = std::move(saveNamesVector);
     }
 
     if (joutputTensors != NULL) {
-        int size = env->GetArrayLength(joutputTensors);
-        std::vector<std::string> saveNamesVector;
-
-        for (int i = 0; i < size; i++) {
-            jstring jname       = (jstring)env->GetObjectArrayElement(joutputTensors, i);
-            const char *name    = env->GetStringUTFChars(jname, NULL);
-            std::string nameStr = name;
-            saveNamesVector.push_back(nameStr);
-
-            env->ReleaseStringUTFChars(jname, name);
+        std::vector<std::string> outputNamesVector;
+        if (!appendStringArray(env, joutputTensors, outputNamesVector)) {
+            return 0;
         }
-
-        config.path.outputs = saveNamesVector;
+        config.path.outputs = std::move(outputNamesVector);
     }
 
     auto session = ((MNN::Interpreter *)netPtr)->createSession(config);

--- a/test/expr/LoadMapInputTest.cpp
+++ b/test/expr/LoadMapInputTest.cpp
@@ -82,8 +82,8 @@ public:
         auto varMap = Variable::loadMap("tmp/regression_4750.mnn");
         auto io = Variable::getInputAndOutput(varMap);
         if (io.first.size() != 1 || io.second.size() != 1) {
-            MNN_PRINT("LoadMapOutputTest: expected single input/output, got %zu/%zu\n",
-                      io.first.size(), io.second.size());
+            MNN_PRINT("LoadMapOutputTest: expected single input/output, got %zu/%zu\n", io.first.size(),
+                      io.second.size());
             return false;
         }
         auto input = io.first.begin()->second;
@@ -110,10 +110,13 @@ public:
             MNN_PRINT("LoadMapOutputTest: readMap returned NULL (bug #4750)\n");
             return false;
         }
-        // Expected first value: 27 * 0.1 * 0.5 + 0.01 = 1.36
+        // Expected first value: 27 * 0.1 * 0.5 + 0.01 = 1.36. FP16 stores
+        // 0.1 approximately and accumulates the rounding error across the convolution.
+        constexpr float expected = 1.36f;
+        const float tolerance = precision == BackendConfig::Precision_Low ? 0.005f : 0.001f;
         auto val = out[0];
-        if (val < 1.359f || val > 1.361f) {
-            MNN_PRINT("LoadMapOutputTest: unexpected output value %f (expected 1.36)\n", val);
+        if (val < expected - tolerance || val > expected + tolerance) {
+            MNN_PRINT("LoadMapOutputTest: unexpected output value %f (expected %f +/- %f)\n", val, expected, tolerance);
             return false;
         }
         return true;


### PR DESCRIPTION
Automated sync from the internal MNN development repository.

- Pending commits: 2
- Head branch: `sync/ali-to-github`
- Commit authors are preserved from the source commits.

### Commits

- `64f5b152b7` [JNI:Bugfix] Fix string array handling (#4753, #4754) — wangzhaode <zhaode.wzd@alibaba-inc.com>
- `b9cedef914` [Test:Bugfix] Relax FP16 loadMap output tolerance — wangzhaode <zhaode.wzd@alibaba-inc.com>