### PR TITLE
[iOS] Add preset X-ASR flow to Qwen3.5 chat

### DIFF
--- a/apps/iOS/MNNLLMChat/.gitignore
+++ b/apps/iOS/MNNLLMChat/.gitignore
@@ -1,4 +1,10 @@
 MNN
+
+# Preset-ASR assets are provisioned separately and must not enter Git.
+libsherpa-mnn.a
+MNNLLMiOS/LocalModel/preset_audio/
+MNNLLMiOS/LocalModel/xasr-mnn-int8/
+MNNLLMiOS/LocalModel/Qwen3.5-2B-MNN/
 .DS_Store
 MNNLLMiOS/LocalModel/Qwen3.5-2B/
 _model_holding/

--- a/apps/iOS/MNNLLMChat/LocalPackages/Chat/Sources/ExyteChat/ChatView/MessageView/MessageView.swift
+++ b/apps/iOS/MNNLLMChat/LocalPackages/Chat/Sources/ExyteChat/ChatView/MessageView/MessageView.swift
@@ -155,7 +155,7 @@ struct MessageView: View {
                 attachmentsView(message)
             }
 
-            if !message.text.isEmpty {
+            if !message.text.isEmpty, message.recording == nil {
                 textWithTimeView(message)
                     .font(Font(font))
 
@@ -175,11 +175,17 @@ struct MessageView: View {
             }
 
             if let recording = message.recording {
-                VStack(alignment: .trailing, spacing: 8) {
+                VStack(alignment: .leading, spacing: 10) {
                     recordingView(recording)
-                    messageTimeView()
-                        .padding(.bottom, 8)
-                        .padding(.trailing, 12)
+                    if !message.text.isEmpty {
+                        audioEvidenceView(message.text)
+                    }
+                    HStack {
+                        Spacer()
+                        messageTimeView()
+                    }
+                    .padding(.bottom, 8)
+                    .padding(.horizontal, MessageView.horizontalTextPadding)
                 }
             }
         }
@@ -348,6 +354,31 @@ struct MessageView: View {
         )
         .padding(.horizontal, MessageView.horizontalTextPadding)
         .padding(.top, 8)
+    }
+
+    @ViewBuilder
+    func audioEvidenceView(_ text: String) -> some View {
+        let lines = text.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: true)
+        VStack(alignment: .leading, spacing: 4) {
+            if let transcript = lines.first {
+                Text(String(transcript))
+                    .font(.caption)
+                    .foregroundColor(message.user.isCurrentUser
+                        ? theme.colors.messageMyText.opacity(0.86)
+                        : theme.colors.messageFriendText.opacity(0.86))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            if lines.count > 1 {
+                Text(String(lines[1]))
+                    .font(.caption2.monospacedDigit())
+                    .foregroundColor(message.user.isCurrentUser
+                        ? theme.colors.messageMyText.opacity(0.62)
+                        : theme.colors.messageFriendText.opacity(0.62))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.horizontal, MessageView.horizontalTextPadding)
+        .accessibilityElement(children: .combine)
     }
 
     func messageTimeView(needsCapsule: Bool = false) -> some View {

--- a/apps/iOS/MNNLLMChat/LocalPackages/Chat/Sources/ExyteChat/ChatView/Recording/RecordWaveform.swift
+++ b/apps/iOS/MNNLLMChat/LocalPackages/Chat/Sources/ExyteChat/ChatView/Recording/RecordWaveform.swift
@@ -9,8 +9,6 @@ import SwiftUI
 
 struct RecordWaveformWithButtons: View {
 
-    @Environment(\.chatTheme) private var theme
-
     @StateObject var recordPlayer = RecordingPlayer()
 
     // 160 is screen left-padding/right-padding and playButton's width.
@@ -30,21 +28,25 @@ struct RecordWaveformWithButtons: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            Group {
-                if recordPlayer.playing {
-                    theme.images.message.pauseAudio
-                        .renderingMode(.template)
-                } else {
-                    theme.images.message.playAudio
-                        .renderingMode(.template)
-                }
-            }
-            .foregroundColor(colorButton)
-            .viewSize(40)
-            .circleBackground(colorButtonBg)
-            .onTapGesture {
+            Button {
                 recordPlayer.togglePlay(recording)
+            } label: {
+                Image(systemName: recordPlayer.playing ? "pause.fill" : "play.fill")
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundColor(colorButton)
+                    .offset(x: recordPlayer.playing ? 0 : 1)
+                    .frame(width: 44, height: 44)
+                    .background(Circle().fill(colorButtonBg))
+                    .overlay {
+                        Circle()
+                            .stroke(colorButton.opacity(0.18), lineWidth: 1)
+                    }
+                    .shadow(color: Color.black.opacity(0.10), radius: 2, y: 1)
             }
+            .buttonStyle(.plain)
+            .contentShape(Circle())
+            .accessibilityLabel(recordPlayer.playing ? "暂停音频" : "播放音频")
+            .accessibilityHint("播放或暂停样例音频")
             
             VStack(alignment: .leading, spacing: 5) {
                 RecordWaveformPlaying(samples: recording.waveformSamples, progress: recordPlayer.progress, color: colorWaveform, addExtraDots: false) { progress in

--- a/apps/iOS/MNNLLMChat/LocalPackages/swift-cmark/Package.swift
+++ b/apps/iOS/MNNLLMChat/LocalPackages/swift-cmark/Package.swift
@@ -26,9 +26,6 @@ let package = Package(
         .library(
             name: "cmark-gfm-extensions",
             targets: ["cmark-gfm-extensions"]),
-        .executable(
-            name: "cmark-gfm-bin",
-            targets: ["cmark-gfm-bin"]),
         .executable(name: "api_test",
             targets: ["api_test"])
     ],
@@ -53,16 +50,6 @@ let package = Package(
             "ext_scanners.re",
           ],
           cSettings: cSettings
-        ),
-        .target(name: "cmark-gfm-bin",
-          dependencies: [
-            "cmark-gfm",
-            "cmark-gfm-extensions",
-          ],
-          path: "bin",
-          sources: [
-            "main.c",
-          ]
         ),
         .target(name: "api_test",
           dependencies: [

--- a/apps/iOS/MNNLLMChat/MNNLLMiOS.xcodeproj/project.pbxproj
+++ b/apps/iOS/MNNLLMChat/MNNLLMiOS.xcodeproj/project.pbxproj
@@ -27,6 +27,9 @@
 		3ECE19C72E9CE1BD001A4CDD /* TextFileActivityItemSource.swift in MNNChat */ = {isa = PBXBuildFile; fileRef = 3ECE19C62E9CE1BD001A4CDD /* TextFileActivityItemSource.swift */; };
 		3ECE19C92E9CE1F0001A4CDD /* BatchFileTestService.swift in MNNChat */ = {isa = PBXBuildFile; fileRef = 3ECE19C82E9CE1F0001A4CDD /* BatchFileTestService.swift */; };
 		3E000000000000000000A102 /* PresetPrompts.swift in MNNChat */ = {isa = PBXBuildFile; fileRef = 3E000000000000000000A101 /* PresetPrompts.swift */; };
+		5A000000000000000000A107 /* PresetZipformerASRService.swift in MNNChat */ = {isa = PBXBuildFile; fileRef = 5A000000000000000000A101 /* PresetZipformerASRService.swift */; };
+		5A000000000000000000A104 /* PresetZipformerASRWrapper.mm in MNNChat */ = {isa = PBXBuildFile; fileRef = 5A000000000000000000A103 /* PresetZipformerASRWrapper.mm */; };
+		5A000000000000000000A106 /* libsherpa-mnn.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A000000000000000000A105 /* libsherpa-mnn.a */; };
 		3EEAB30B2E8BD5550039DF50 /* BatchFileTestViewModel.swift in MNNChat */ = {isa = PBXBuildFile; fileRef = 3EEAB30A2E8BD5550039DF50 /* BatchFileTestViewModel.swift */; };
 		4230C2D22E7D4EB5001169DF /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4230C2A22E7D4EB5001169DF /* Preview Assets.xcassets */; };
 		4230C2DB2E7D4EB5001169DF /* mock.json in Resources */ = {isa = PBXBuildFile; fileRef = 4230C2AD2E7D4EB5001169DF /* mock.json */; };
@@ -156,6 +159,10 @@
 		3ECE19C62E9CE1BD001A4CDD /* TextFileActivityItemSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFileActivityItemSource.swift; sourceTree = "<group>"; };
 		3ECE19C82E9CE1F0001A4CDD /* BatchFileTestService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchFileTestService.swift; sourceTree = "<group>"; };
 		3E000000000000000000A101 /* PresetPrompts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetPrompts.swift; sourceTree = "<group>"; };
+		5A000000000000000000A101 /* PresetZipformerASRService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetZipformerASRService.swift; sourceTree = "<group>"; };
+		5A000000000000000000A102 /* PresetZipformerASRWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PresetZipformerASRWrapper.h; sourceTree = "<group>"; };
+		5A000000000000000000A103 /* PresetZipformerASRWrapper.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PresetZipformerASRWrapper.mm; sourceTree = "<group>"; };
+		5A000000000000000000A105 /* libsherpa-mnn.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libsherpa-mnn.a; sourceTree = "<group>"; };
 		3EEAB30A2E8BD5550039DF50 /* BatchFileTestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchFileTestViewModel.swift; sourceTree = "<group>"; };
 		4230C22C2E7D4EB5001169DF /* ChatInteractorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatInteractorProtocol.swift; sourceTree = "<group>"; };
 		4230C22D2E7D4EB5001169DF /* LLMChatInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMChatInteractor.swift; sourceTree = "<group>"; };
@@ -284,6 +291,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5A000000000000000000A106 /* libsherpa-mnn.a in Frameworks */,
 				3ECAC6062F3C62570003C496 /* ExyteChat in Frameworks */,
 				3E2F97302E89158600E61F35 /* ExyteChat in Frameworks */,
 				3E2F972F2E89158600E61F35 /* ExyteChat in Frameworks */,
@@ -303,6 +311,7 @@
 			isa = PBXGroup;
 			children = (
 				3E440F082EE2DEDE00BB15FF /* AudioPlaybackManager.swift */,
+				5A000000000000000000A101 /* PresetZipformerASRService.swift */,
 			);
 			path = Audio;
 			sourceTree = "<group>";
@@ -332,6 +341,7 @@
 			isa = PBXGroup;
 			children = (
 				3E301C682D5C84730045E5E1 /* MNN.framework */,
+				5A000000000000000000A105 /* libsherpa-mnn.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -458,6 +468,8 @@
 		4230C2522E7D4EB5001169DF /* InferenceEngine */ = {
 			isa = PBXGroup;
 			children = (
+				5A000000000000000000A102 /* PresetZipformerASRWrapper.h */,
+				5A000000000000000000A103 /* PresetZipformerASRWrapper.mm */,
 				3E2B293A2F1F7C28006DE361 /* SanaDiffusionSession.h */,
 				3E2B293B2F1F7C28006DE361 /* SanaDiffusionSession.mm */,
 				4230C24E2E7D4EB5001169DF /* DiffusionSession.h */,
@@ -890,6 +902,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5A000000000000000000A107 /* PresetZipformerASRService.swift in MNNChat */,
+				5A000000000000000000A104 /* PresetZipformerASRWrapper.mm in MNNChat */,
 				4230C2DF2E7D4EB5001169DF /* ChatInteractorProtocol.swift in MNNChat */,
 				4230C2E02E7D4EB5001169DF /* LLMChatInteractor.swift in MNNChat */,
 				4230C2E12E7D4EB5001169DF /* ThinkResultProcessor.swift in MNNChat */,
@@ -1175,6 +1189,11 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 17;
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/../../frameworks/sherpa-mnn";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+				);
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14;
@@ -1232,6 +1251,11 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 17;
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/../../frameworks/sherpa-mnn";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+				);
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14;

--- a/apps/iOS/MNNLLMChat/MNNLLMiOS/Chat/Audio/PresetZipformerASRService.swift
+++ b/apps/iOS/MNNLLMChat/MNNLLMiOS/Chat/Audio/PresetZipformerASRService.swift
@@ -1,0 +1,300 @@
+//
+//  PresetZipformerASRService.swift
+//  MNNLLMiOS
+//
+
+import AVFoundation
+import CryptoKit
+import ExyteChat
+import Foundation
+
+struct PresetASRRecognition {
+    let transcript: String
+    let recording: Recording
+    let audioDurationSeconds: Double
+    let modelInitializationSeconds: Double
+    let inferenceSeconds: Double
+
+    var realTimeFactor: Double {
+        guard audioDurationSeconds > 0 else { return 0 }
+        return inferenceSeconds / audioDurationSeconds
+    }
+
+    var realTimeMultiple: Double {
+        guard inferenceSeconds > 0 else { return 0 }
+        return audioDurationSeconds / inferenceSeconds
+    }
+
+    var displayText: String {
+        let transcriptLine = String(
+            format: NSLocalizedString("ASR 识别：%@", comment: "Preset ASR transcript"),
+            transcript
+        )
+        let speedLine = String(
+            format: NSLocalizedString(
+                "ASR %.3fs · 音频 %.3fs · RTF %.3f · %.1f× 实时",
+                comment: "Preset ASR performance summary"
+            ),
+            inferenceSeconds,
+            audioDurationSeconds,
+            realTimeFactor,
+            realTimeMultiple
+        )
+        return "\(transcriptLine)\n\(speedLine)"
+    }
+}
+
+enum PresetASRError: LocalizedError {
+    case missingAsset(String)
+    case invalidAsset(String)
+    case invalidAudio(String)
+    case initializationFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingAsset(let path):
+            return "缺少 ASR 资源：\(path)"
+        case .invalidAsset(let path):
+            return "ASR 资源校验失败：\(path)"
+        case .invalidAudio(let reason):
+            return "预设音频无法读取：\(reason)"
+        case .initializationFailed(let reason):
+            return "X-ASR 初始化失败：\(reason)"
+        }
+    }
+}
+
+final class PresetZipformerASRService: @unchecked Sendable {
+    private struct AudioSamples {
+        let pcm: Data
+        let sampleRate: Int32
+        let duration: Double
+        let waveform: [CGFloat]
+    }
+
+    private let workerQueue = DispatchQueue(label: "com.alibaba.mnnchat.preset-asr", qos: .userInitiated)
+    private let stateLock = NSLock()
+    private var wrapper: PresetZipformerASRWrapper?
+    private var assetsValidated = false
+    private var reportedInitialization = false
+
+    func recognize(audioURL: URL, expectedAudioSHA256: String) async throws -> PresetASRRecognition {
+        try await withCheckedThrowingContinuation { continuation in
+            workerQueue.async { [weak self] in
+                guard let self else {
+                    continuation.resume(throwing: PresetASRError.initializationFailed("ASR service released"))
+                    return
+                }
+                do {
+                    let result = try self.recognizeOnWorker(
+                        audioURL: audioURL,
+                        expectedAudioSHA256: expectedAudioSHA256
+                    )
+                    continuation.resume(returning: result)
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    func cancel() {
+        stateLock.lock()
+        let activeWrapper = wrapper
+        stateLock.unlock()
+        activeWrapper?.cancel()
+    }
+
+    func shutdown() {
+        stateLock.lock()
+        let activeWrapper = wrapper
+        wrapper = nil
+        assetsValidated = false
+        stateLock.unlock()
+        activeWrapper?.shutdown()
+    }
+
+    private func recognizeOnWorker(audioURL: URL, expectedAudioSHA256: String) throws -> PresetASRRecognition {
+        let audioHash = try sha256(of: audioURL)
+        guard audioHash == expectedAudioSHA256 else {
+            throw PresetASRError.invalidAsset(audioURL.lastPathComponent)
+        }
+        let audio = try loadMonoFloatPCM(from: audioURL)
+        let modelDirectory = try resolveAndValidateModelDirectory()
+        let activeWrapper = try getOrCreateWrapper(modelDirectory: modelDirectory)
+
+        var inferenceSeconds: TimeInterval = 0
+        let rawTranscript = try activeWrapper.recognizeFloatPCM(
+            audio.pcm,
+            sampleRate: audio.sampleRate,
+            inferenceSeconds: &inferenceSeconds
+        )
+        let transcript = normalizeXASRTranscript(rawTranscript)
+        let initializationSeconds: Double
+        stateLock.lock()
+        if reportedInitialization {
+            initializationSeconds = 0
+        } else {
+            reportedInitialization = true
+            initializationSeconds = activeWrapper.initializationSeconds
+        }
+        stateLock.unlock()
+
+        NSLog(
+            "[PRESET_ASR] event=recognized runtime=sherpa-mnn model=x-asr-zipformer2 " +
+                "precision=mnn-weight-int8-block64 backend=cpu " +
+                "threads=2 input_rate=%d input_samples=%d audio_sha256=%@ transcript=%@ init_ms=%.1f " +
+                "inference_ms=%.1f audio_ms=%.1f rtf=%.4f",
+            audio.sampleRate,
+            audio.pcm.count / MemoryLayout<Float>.size,
+            audioHash,
+            transcript,
+            initializationSeconds * 1000,
+            inferenceSeconds * 1000,
+            audio.duration * 1000,
+            inferenceSeconds / audio.duration
+        )
+
+        return PresetASRRecognition(
+            transcript: transcript,
+            recording: Recording(duration: audio.duration, waveformSamples: audio.waveform, url: audioURL),
+            audioDurationSeconds: audio.duration,
+            modelInitializationSeconds: initializationSeconds,
+            inferenceSeconds: inferenceSeconds
+        )
+    }
+
+    private func getOrCreateWrapper(modelDirectory: URL) throws -> PresetZipformerASRWrapper {
+        stateLock.lock()
+        if let wrapper {
+            stateLock.unlock()
+            return wrapper
+        }
+        stateLock.unlock()
+
+        let candidate = PresetZipformerASRWrapper(modelDirectory: modelDirectory.path)
+        guard candidate.isReady else {
+            throw PresetASRError.initializationFailed(candidate.initializationError ?? "unknown error")
+        }
+        stateLock.lock()
+        wrapper = candidate
+        stateLock.unlock()
+        return candidate
+    }
+
+    private func resolveAndValidateModelDirectory() throws -> URL {
+        guard let resourcePath = Bundle.main.resourceURL else {
+            throw PresetASRError.missingAsset("Bundle resource root")
+        }
+        let directory = resourcePath.appendingPathComponent("LocalModel/xasr-mnn-int8", isDirectory: true)
+
+        stateLock.lock()
+        let alreadyValidated = assetsValidated
+        stateLock.unlock()
+        if alreadyValidated {
+            return directory
+        }
+
+        let manifest: [(String, String)] = [
+            ("encoder-160ms.mnn", "5570b93b89969665c0428cc3c159e41bc71ded7a297e75b1fe09c6c6dce68c82"),
+            ("decoder-160ms.mnn", "83f4bb5fc1b28130af1823c7b20937ce2b789923ccc2beb2fbc09b81f7de2359"),
+            ("joiner-160ms.mnn", "3f71a9408890199ed3fb71b2a29bb3aada57f81281a6cfbdf753d859a1a1fa33"),
+            ("tokens.txt", "b818a60878b9aae978cbb8ad594acbd403d76d1af2e31ef4197c84e2dbdba27c"),
+        ]
+        for (file, expectedHash) in manifest {
+            let url = directory.appendingPathComponent(file)
+            guard FileManager.default.fileExists(atPath: url.path) else {
+                throw PresetASRError.missingAsset(url.path)
+            }
+            guard try sha256(of: url) == expectedHash else {
+                throw PresetASRError.invalidAsset(url.path)
+            }
+            NSLog("[PRESET_ASR] event=asset_verified file=%@ sha256=%@", url.path, expectedHash)
+        }
+        stateLock.lock()
+        assetsValidated = true
+        stateLock.unlock()
+        return directory
+    }
+
+    private func normalizeXASRTranscript(_ text: String) -> String {
+        let cjk = "\\u3400-\\u4dbf\\u4e00-\\u9fff\\uf900-\\ufaff"
+        let punctuation = "，。！？；：、（）《》〈〉【】「」『』“”‘’"
+        let patterns = [
+            "(?<=[\(cjk)])\\s+(?=[\(cjk)])",
+            "(?<=[\(cjk)])\\s+(?=[\(punctuation)])",
+            "(?<=[\(punctuation)])\\s+(?=[\(cjk)])",
+            "(?<=[\(punctuation)])\\s+(?=[\(punctuation)])",
+            "\\s+(?=[,.!?;:%)\\]}])",
+        ]
+        return patterns.reduce(text) { current, pattern in
+            current.replacingOccurrences(of: pattern, with: "", options: .regularExpression)
+        }.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func loadMonoFloatPCM(from url: URL) throws -> AudioSamples {
+        let file = try AVAudioFile(forReading: url)
+        let format = file.processingFormat
+        guard format.channelCount == 1 else {
+            throw PresetASRError.invalidAudio("expected mono, got \(format.channelCount) channels")
+        }
+        guard file.length > 0, file.length <= AVAudioFramePosition(UInt32.max) else {
+            throw PresetASRError.invalidAudio("invalid frame count \(file.length)")
+        }
+        guard let buffer = AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(file.length)
+        ) else {
+            throw PresetASRError.invalidAudio("failed to allocate PCM buffer")
+        }
+        try file.read(into: buffer)
+        guard let channel = buffer.floatChannelData?[0], buffer.frameLength > 0 else {
+            throw PresetASRError.invalidAudio("Float32 PCM is unavailable")
+        }
+        let count = Int(buffer.frameLength)
+        let pcm = Data(bytes: channel, count: count * MemoryLayout<Float>.size)
+        let duration = Double(count) / format.sampleRate
+        return AudioSamples(
+            pcm: pcm,
+            sampleRate: Int32(format.sampleRate.rounded()),
+            duration: duration,
+            waveform: waveformSamples(channel, count: count, bins: 36)
+        )
+    }
+
+    private func waveformSamples(_ samples: UnsafePointer<Float>, count: Int, bins: Int) -> [CGFloat] {
+        guard count > 0, bins > 0 else { return [] }
+        let stride = max(1, count / bins)
+        return (0..<bins).map { bin in
+            let start = min(count, bin * stride)
+            let end = min(count, start + stride)
+            guard start < end else { return 0 }
+            var peak: Float = 0
+            for index in start..<end {
+                peak = max(peak, abs(samples[index]))
+            }
+            return CGFloat(min(1, peak))
+        }
+    }
+
+    private func sha256(of url: URL) throws -> String {
+        guard let stream = InputStream(url: url) else {
+            throw PresetASRError.missingAsset(url.path)
+        }
+        stream.open()
+        defer { stream.close() }
+        var digest = SHA256()
+        var bytes = [UInt8](repeating: 0, count: 1024 * 1024)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&bytes, maxLength: bytes.count)
+            if count < 0 {
+                throw stream.streamError ?? PresetASRError.invalidAsset(url.path)
+            }
+            if count == 0 {
+                break
+            }
+            digest.update(data: Data(bytes[0..<count]))
+        }
+        return digest.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/apps/iOS/MNNLLMChat/MNNLLMiOS/Chat/Interactor/LLMChatInteractor.swift
+++ b/apps/iOS/MNNLLMChat/MNNLLMiOS/Chat/Interactor/LLMChatInteractor.swift
@@ -167,6 +167,42 @@ final class LLMChatInteractor: ChatInteractorProtocol {
         }
     }
 
+    /// Appends a prerecorded audio preset with its ASR transcript and metrics.
+    /// Audio and recognition evidence share one user bubble before LLM output.
+    func sendPresetAudioMessage(text: String, recording: Recording, expectsResponse: Bool) async {
+        let message = LLMChatMessage(
+            uid: UUID().uuidString,
+            sender: chatData.user,
+            createdAt: Date(),
+            status: .sending,
+            useMarkdown: false,
+            text: text,
+            images: [],
+            videos: [],
+            recording: recording,
+            replyMessage: nil
+        )
+
+        await MainActor.run { [weak self] in
+            self?.chatState.value.append(message)
+            if expectsResponse {
+                let assistantSender = self?.chatData.assistant ?? message.sender
+                let emptyMessage = LLMChatMessage(
+                    uid: UUID().uuidString,
+                    sender: assistantSender,
+                    createdAt: Date(),
+                    text: "",
+                    images: [],
+                    videos: [],
+                    recording: nil,
+                    replyMessage: nil
+                )
+                self?.chatState.value.append(emptyMessage)
+                self?.processor.startNewChat()
+            }
+        }
+    }
+
     func sendImage(imageURL: URL) {
         Task {
             await MainActor.run { [weak self] in

--- a/apps/iOS/MNNLLMChat/MNNLLMiOS/Chat/Services/PresetPrompts.swift
+++ b/apps/iOS/MNNLLMChat/MNNLLMiOS/Chat/Services/PresetPrompts.swift
@@ -10,8 +10,27 @@ struct PresetPrompt {
     let icon: String
     let text: String
     let imageBundlePath: String?
+    let audioBundlePath: String?
+    let audioSHA256: String?
+
+    init(
+        title: String,
+        icon: String,
+        text: String,
+        imageBundlePath: String?,
+        audioBundlePath: String? = nil,
+        audioSHA256: String? = nil
+    ) {
+        self.title = title
+        self.icon = icon
+        self.text = text
+        self.imageBundlePath = imageBundlePath
+        self.audioBundlePath = audioBundlePath
+        self.audioSHA256 = audioSHA256
+    }
 
     var isMultimodal: Bool { imageBundlePath != nil }
+    var isASRAudio: Bool { audioBundlePath != nil }
 }
 
 enum PresetPrompts {
@@ -44,6 +63,13 @@ enum PresetPrompts {
             )
         ))
 
+        if let audio = audioPreset(
+            file: "audio (1).wav",
+            title: NSLocalizedString("preset.audio", value: "音频·杭州美食", comment: "")
+        ) {
+            presets.append(audio)
+        }
+
         presets.append(PresetPrompt(
             title: NSLocalizedString("preset.code", value: "代码题", comment: ""),
             icon: "chevron.left.forwardslash.chevron.right",
@@ -59,6 +85,18 @@ enum PresetPrompts {
 
     private static func imagePreset(file: String, title: String, text: String) -> PresetPrompt {
         PresetPrompt(title: title, icon: "photo", text: text, imageBundlePath: bundlePath("LocalModel/preset_images/\(file)"))
+    }
+
+    private static func audioPreset(file: String, title: String) -> PresetPrompt? {
+        guard let path = bundlePath("LocalModel/preset_audio/\(file)") else { return nil }
+        return PresetPrompt(
+            title: title,
+            icon: "waveform",
+            text: "",
+            imageBundlePath: nil,
+            audioBundlePath: path,
+            audioSHA256: "2c9c3ab83563e058ed46e067e716beeeca8d3b50a2cd0e622dc6437714647b58"
+        )
     }
 
     private static func bundlePath(_ relative: String) -> String? {

--- a/apps/iOS/MNNLLMChat/MNNLLMiOS/Chat/ViewModels/LLMChatViewModel.swift
+++ b/apps/iOS/MNNLLMChat/MNNLLMiOS/Chat/ViewModels/LLMChatViewModel.swift
@@ -17,6 +17,8 @@ final class LLMChatViewModel: ObservableObject, StreamingMessageProvider {
     private var sanaDiffusion: SanaDiffusionSession?
     private let llmState = LLMState()
     private var audioPlaybackManager: AudioPlaybackManager?
+    private let presetASRService = PresetZipformerASRService()
+    private var presetASRGeneration: UInt64 = 0
 
     @Published var messages: [Message] = []
     @Published var isModelLoaded = false
@@ -109,6 +111,9 @@ final class LLMChatViewModel: ObservableObject, StreamingMessageProvider {
     }
 
     deinit {
+        presetASRGeneration &+= 1
+        presetASRService.cancel()
+        presetASRService.shutdown()
         // Cancel ongoing inference
         llm?.cancelInference()
         llm = nil
@@ -736,6 +741,51 @@ final class LLMChatViewModel: ObservableObject, StreamingMessageProvider {
         // prefill/decode stats attributable to this prompt alone.
         llm?.clearChatHistory()
 
+        if let audioPath = preset.audioBundlePath,
+           let expectedHash = preset.audioSHA256
+        {
+            presetASRGeneration &+= 1
+            let generation = presetASRGeneration
+            isProcessing = true
+            let audioURL = URL(fileURLWithPath: audioPath)
+
+            Task { [weak self] in
+                guard let self else { return }
+                do {
+                    let recognition = try await self.presetASRService.recognize(
+                        audioURL: audioURL,
+                        expectedAudioSHA256: expectedHash
+                    )
+                    guard generation == self.presetASRGeneration else { return }
+                    await self.interactor.sendPresetAudioMessage(
+                        text: recognition.displayText,
+                        recording: recognition.recording,
+                        expectsResponse: true
+                    )
+                    guard generation == self.presetASRGeneration else { return }
+                    await self.runLLMInference(
+                        content: recognition.transcript,
+                        images: [:],
+                        useMultimodalAPI: false
+                    )
+                } catch {
+                    guard generation == self.presetASRGeneration else { return }
+                    let failure = NSLocalizedString("ASR 识别失败：", comment: "Preset ASR failure")
+                        + error.localizedDescription
+                    let recording = Recording(duration: 0, waveformSamples: [], url: audioURL)
+                    await self.interactor.sendPresetAudioMessage(
+                        text: failure,
+                        recording: recording,
+                        expectsResponse: false
+                    )
+                    await MainActor.run {
+                        self.isProcessing = false
+                    }
+                }
+            }
+            return
+        }
+
         if let imagePath = preset.imageBundlePath {
             let imageURL = URL(fileURLWithPath: imagePath)
             let content = "<img>\(imagePath)</img>" + preset.text
@@ -949,6 +999,8 @@ final class LLMChatViewModel: ObservableObject, StreamingMessageProvider {
     }
 
     func onStop() {
+        presetASRGeneration &+= 1
+        presetASRService.cancel()
         recordModelUsage()
 
         ChatHistoryManager.shared.saveChat(

--- a/apps/iOS/MNNLLMChat/MNNLLMiOS/Chat/Views/LLMChatView.swift
+++ b/apps/iOS/MNNLLMChat/MNNLLMiOS/Chat/Views/LLMChatView.swift
@@ -276,7 +276,13 @@ struct PresetPromptBar: View {
                         onSelect(preset)
                     } label: {
                         HStack(spacing: 4) {
-                            if let path = preset.imageBundlePath, let ui = UIImage(contentsOfFile: path) {
+                            if preset.isASRAudio {
+                                Image(systemName: "waveform")
+                                    .font(.system(size: 12, weight: .semibold))
+                                    .frame(width: 18, height: 18)
+                                    .background(Color.customBlue.opacity(0.12))
+                                    .clipShape(RoundedRectangle(cornerRadius: 4))
+                            } else if let path = preset.imageBundlePath, let ui = UIImage(contentsOfFile: path) {
                                 Image(uiImage: ui)
                                     .resizable()
                                     .scaledToFill()

--- a/apps/iOS/MNNLLMChat/MNNLLMiOS/InferenceEngine/PresetZipformerASRWrapper.h
+++ b/apps/iOS/MNNLLMChat/MNNLLMiOS/InferenceEngine/PresetZipformerASRWrapper.h
@@ -1,0 +1,36 @@
+//
+//  PresetZipformerASRWrapper.h
+//  MNNLLMiOS
+//
+//  Thread-owned sherpa-mnn Zipformer wrapper for prerecorded preset audio.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PresetZipformerASRWrapper : NSObject
+
+- (instancetype)initWithModelDirectory:(NSString *)modelDirectory;
+
+@property(nonatomic, readonly, getter=isReady) BOOL ready;
+@property(nonatomic, readonly) NSTimeInterval initializationSeconds;
+@property(nonatomic, copy, readonly, nullable) NSString *initializationError;
+
+/// Recognize mono Float32 PCM normalized to [-1, 1]. The native recognizer,
+/// stream, and MNN modules live exclusively on one permanent worker thread.
+- (nullable NSString *)recognizeFloatPCM:(NSData *)pcm
+                              sampleRate:(int32_t)sampleRate
+                        inferenceSeconds:(NSTimeInterval *)inferenceSeconds
+                                   error:(NSError **)error;
+
+/// Invalidates queued/running output. Native inference may finish in the
+/// background, but a canceled result is never returned to the caller.
+- (void)cancel;
+
+/// Drains the worker and destroys the recognizer on its owning thread.
+- (void)shutdown;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/apps/iOS/MNNLLMChat/MNNLLMiOS/InferenceEngine/PresetZipformerASRWrapper.mm
+++ b/apps/iOS/MNNLLMChat/MNNLLMiOS/InferenceEngine/PresetZipformerASRWrapper.mm
@@ -1,0 +1,384 @@
+//
+//  PresetZipformerASRWrapper.mm
+//  MNNLLMiOS
+//
+
+#import "PresetZipformerASRWrapper.h"
+
+#include "sherpa-mnn/c-api/c-api.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cstring>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace {
+
+constexpr int32_t kZipformerSampleRate = 16000;
+constexpr int32_t kZipformerFeatureDimension = 80;
+// X-ASR Zipformer2 needs enough right-context frames to expose the final
+// token. This padding is decoded immediately and does not sleep in real time.
+constexpr double kTailPaddingSeconds = 1.6;
+constexpr int32_t kRecognizerThreads = 2;
+
+struct RecognitionJob {
+    std::vector<float> samples;
+    int32_t sampleRate = 0;
+    uint64_t generation = 0;
+    std::string text;
+    std::string error;
+    double inferenceSeconds = 0.0;
+    bool done = false;
+    std::mutex mutex;
+    std::condition_variable condition;
+};
+
+class ZipformerWorker {
+public:
+    explicit ZipformerWorker(std::string modelDirectory) : mModelDirectory(std::move(modelDirectory)) {
+        mThread = std::thread(&ZipformerWorker::threadMain, this);
+        std::unique_lock<std::mutex> lock(mStateMutex);
+        mStateCondition.wait(lock, [this] { return mInitialized; });
+    }
+
+    ~ZipformerWorker() {
+        shutdown();
+    }
+
+    ZipformerWorker(const ZipformerWorker&) = delete;
+    ZipformerWorker& operator=(const ZipformerWorker&) = delete;
+
+    bool ready() const {
+        std::lock_guard<std::mutex> lock(mStateMutex);
+        return mReady;
+    }
+
+    double initializationSeconds() const {
+        std::lock_guard<std::mutex> lock(mStateMutex);
+        return mInitializationSeconds;
+    }
+
+    std::string initializationError() const {
+        std::lock_guard<std::mutex> lock(mStateMutex);
+        return mInitializationError;
+    }
+
+    bool recognize(const float* samples, size_t count, int32_t sampleRate, std::string& text,
+                   double& inferenceSeconds, std::string& error) {
+        if (samples == nullptr || count == 0 || sampleRate <= 0) {
+            error = "Invalid PCM input";
+            return false;
+        }
+        if (!ready()) {
+            error = initializationError();
+            if (error.empty()) {
+                error = "X-ASR recognizer is not ready";
+            }
+            return false;
+        }
+
+        auto job = std::make_shared<RecognitionJob>();
+        job->samples.assign(samples, samples + count);
+        job->sampleRate = sampleRate;
+        {
+            std::lock_guard<std::mutex> lock(mQueueMutex);
+            if (mStopping) {
+                error = "X-ASR worker is shutting down";
+                return false;
+            }
+            job->generation = ++mGeneration;
+            mJobs.emplace_back(job);
+        }
+        mQueueCondition.notify_one();
+
+        std::unique_lock<std::mutex> jobLock(job->mutex);
+        job->condition.wait(jobLock, [&job] { return job->done; });
+        text = job->text;
+        inferenceSeconds = job->inferenceSeconds;
+        error = job->error;
+        return error.empty();
+    }
+
+    void cancel() {
+        std::lock_guard<std::mutex> lock(mQueueMutex);
+        ++mGeneration;
+    }
+
+    void shutdown() {
+        {
+            std::lock_guard<std::mutex> lock(mQueueMutex);
+            if (mStopping) {
+                return;
+            }
+            mStopping = true;
+            ++mGeneration;
+        }
+        mQueueCondition.notify_one();
+        if (mThread.joinable()) {
+            mThread.join();
+        }
+    }
+
+private:
+    void threadMain() {
+        initializeRecognizer();
+        while (true) {
+            std::shared_ptr<RecognitionJob> job;
+            {
+                std::unique_lock<std::mutex> lock(mQueueMutex);
+                mQueueCondition.wait(lock, [this] { return mStopping || !mJobs.empty(); });
+                if (mStopping && mJobs.empty()) {
+                    break;
+                }
+                job = std::move(mJobs.front());
+                mJobs.pop_front();
+            }
+
+            if (!isCurrent(job->generation)) {
+                complete(job, "Recognition canceled");
+                continue;
+            }
+            runRecognition(job);
+            if (!isCurrent(job->generation)) {
+                job->text.clear();
+                job->error = "Recognition canceled";
+            }
+            complete(job, job->error);
+        }
+
+        cancelQueuedJobs();
+        if (mRecognizer != nullptr) {
+            SherpaMnnDestroyOnlineRecognizer(mRecognizer);
+            mRecognizer = nullptr;
+        }
+    }
+
+    void initializeRecognizer() {
+        const auto start = std::chrono::steady_clock::now();
+        const std::string encoder = mModelDirectory + "/encoder-160ms.mnn";
+        const std::string decoder = mModelDirectory + "/decoder-160ms.mnn";
+        const std::string joiner = mModelDirectory + "/joiner-160ms.mnn";
+        const std::string tokens = mModelDirectory + "/tokens.txt";
+
+        SherpaMnnOnlineRecognizerConfig config;
+        std::memset(&config, 0, sizeof(config));
+        config.feat_config.sample_rate = kZipformerSampleRate;
+        config.feat_config.feature_dim = kZipformerFeatureDimension;
+        config.model_config.transducer.encoder = encoder.c_str();
+        config.model_config.transducer.decoder = decoder.c_str();
+        config.model_config.transducer.joiner = joiner.c_str();
+        config.model_config.tokens = tokens.c_str();
+        config.model_config.num_threads = kRecognizerThreads;
+        config.model_config.provider = "cpu";
+        config.model_config.debug = 0;
+        config.model_config.model_type = "zipformer2";
+        config.model_config.modeling_unit = "";
+        config.model_config.bpe_vocab = "";
+        config.model_config.tokens_buf = nullptr;
+        config.model_config.tokens_buf_size = 0;
+        config.model_config.paraformer.encoder = "";
+        config.model_config.paraformer.decoder = "";
+        config.model_config.zipformer2_ctc.model = "";
+        config.decoding_method = "greedy_search";
+        config.max_active_paths = 4;
+        config.enable_endpoint = 0;
+        config.hotwords_file = "";
+        config.hotwords_score = 1.5f;
+        config.ctc_fst_decoder_config.graph = "";
+        config.ctc_fst_decoder_config.max_active = 3000;
+        config.rule_fsts = "";
+        config.rule_fars = "";
+        config.hotwords_buf = nullptr;
+        config.hotwords_buf_size = 0;
+
+        mRecognizer = SherpaMnnCreateOnlineRecognizer(&config);
+        const auto end = std::chrono::steady_clock::now();
+        {
+            std::lock_guard<std::mutex> lock(mStateMutex);
+            mInitializationSeconds = std::chrono::duration<double>(end - start).count();
+            mReady = mRecognizer != nullptr;
+            if (!mReady) {
+                mInitializationError = "Failed to create sherpa-mnn X-ASR Zipformer2 recognizer";
+            }
+            mInitialized = true;
+        }
+        mStateCondition.notify_all();
+    }
+
+    void runRecognition(const std::shared_ptr<RecognitionJob>& job) {
+        const SherpaMnnOnlineStream* stream = SherpaMnnCreateOnlineStream(mRecognizer);
+        if (stream == nullptr) {
+            job->error = "Failed to create X-ASR stream";
+            return;
+        }
+
+        const auto start = std::chrono::steady_clock::now();
+        SherpaMnnOnlineStreamAcceptWaveform(stream, job->sampleRate, job->samples.data(),
+                                           static_cast<int32_t>(job->samples.size()));
+        const int32_t tailPaddingSamples = static_cast<int32_t>(job->sampleRate * kTailPaddingSeconds);
+        const std::vector<float> tailPadding(tailPaddingSamples, 0.0f);
+        SherpaMnnOnlineStreamAcceptWaveform(stream, job->sampleRate, tailPadding.data(), tailPaddingSamples);
+        SherpaMnnOnlineStreamInputFinished(stream);
+        while (SherpaMnnIsOnlineStreamReady(mRecognizer, stream)) {
+            SherpaMnnDecodeOnlineStream(mRecognizer, stream);
+        }
+
+        const SherpaMnnOnlineRecognizerResult* result = SherpaMnnGetOnlineStreamResult(mRecognizer, stream);
+        const auto end = std::chrono::steady_clock::now();
+        job->inferenceSeconds = std::chrono::duration<double>(end - start).count();
+        if (result != nullptr) {
+            if (result->text != nullptr) {
+                job->text = result->text;
+            }
+            SherpaMnnDestroyOnlineRecognizerResult(result);
+        } else {
+            job->error = "X-ASR returned no result";
+        }
+        SherpaMnnDestroyOnlineStream(stream);
+
+        if (job->error.empty() && job->text.empty()) {
+            job->error = "X-ASR returned an empty transcript";
+        }
+    }
+
+    bool isCurrent(uint64_t generation) const {
+        std::lock_guard<std::mutex> lock(mQueueMutex);
+        return !mStopping && generation == mGeneration;
+    }
+
+    void complete(const std::shared_ptr<RecognitionJob>& job, const std::string& error) {
+        {
+            std::lock_guard<std::mutex> lock(job->mutex);
+            job->error = error;
+            job->done = true;
+        }
+        job->condition.notify_all();
+    }
+
+    void cancelQueuedJobs() {
+        std::deque<std::shared_ptr<RecognitionJob>> jobs;
+        {
+            std::lock_guard<std::mutex> lock(mQueueMutex);
+            jobs.swap(mJobs);
+        }
+        for (const auto& job : jobs) {
+            complete(job, "Recognition canceled");
+        }
+    }
+
+private:
+    std::string mModelDirectory;
+    const SherpaMnnOnlineRecognizer* mRecognizer = nullptr;
+    std::thread mThread;
+
+    mutable std::mutex mStateMutex;
+    std::condition_variable mStateCondition;
+    bool mInitialized = false;
+    bool mReady = false;
+    double mInitializationSeconds = 0.0;
+    std::string mInitializationError;
+
+    mutable std::mutex mQueueMutex;
+    std::condition_variable mQueueCondition;
+    std::deque<std::shared_ptr<RecognitionJob>> mJobs;
+    uint64_t mGeneration = 0;
+    bool mStopping = false;
+};
+
+NSError* MakeASRError(NSString* description) {
+    return [NSError errorWithDomain:@"com.alibaba.mnnchat.preset-asr"
+                               code:1
+                           userInfo:@{NSLocalizedDescriptionKey : description ?: @"X-ASR failed"}];
+}
+
+}  // namespace
+
+@implementation PresetZipformerASRWrapper {
+    std::unique_ptr<ZipformerWorker> _worker;
+}
+
+- (instancetype)initWithModelDirectory:(NSString *)modelDirectory {
+    self = [super init];
+    if (self) {
+        _worker.reset(new ZipformerWorker(modelDirectory.UTF8String));
+    }
+    return self;
+}
+
+- (BOOL)isReady {
+    return _worker != nullptr && _worker->ready();
+}
+
+- (NSTimeInterval)initializationSeconds {
+    return _worker != nullptr ? _worker->initializationSeconds() : 0.0;
+}
+
+- (NSString *)initializationError {
+    if (_worker == nullptr) {
+        return @"X-ASR worker is unavailable";
+    }
+    const std::string error = _worker->initializationError();
+    return error.empty() ? nil : [NSString stringWithUTF8String:error.c_str()];
+}
+
+- (nullable NSString *)recognizeFloatPCM:(NSData *)pcm
+                              sampleRate:(int32_t)sampleRate
+                        inferenceSeconds:(NSTimeInterval *)inferenceSeconds
+                                   error:(NSError **)error {
+    if (_worker == nullptr || !self.isReady) {
+        if (error != nullptr) {
+            *error = MakeASRError(self.initializationError ?: @"X-ASR recognizer is not ready");
+        }
+        return nil;
+    }
+    if (pcm.length == 0 || pcm.length % sizeof(float) != 0) {
+        if (error != nullptr) {
+            *error = MakeASRError(@"Invalid Float32 PCM buffer");
+        }
+        return nil;
+    }
+
+    std::string text;
+    std::string nativeError;
+    double nativeInferenceSeconds = 0.0;
+    const bool success = _worker->recognize(static_cast<const float*>(pcm.bytes), pcm.length / sizeof(float),
+                                            sampleRate, text, nativeInferenceSeconds, nativeError);
+    if (inferenceSeconds != nullptr) {
+        *inferenceSeconds = nativeInferenceSeconds;
+    }
+    if (!success) {
+        if (error != nullptr) {
+            NSString *description = [NSString stringWithUTF8String:nativeError.c_str()];
+            *error = MakeASRError(description);
+        }
+        return nil;
+    }
+    return [NSString stringWithUTF8String:text.c_str()];
+}
+
+- (void)cancel {
+    if (_worker != nullptr) {
+        _worker->cancel();
+    }
+}
+
+- (void)shutdown {
+    if (_worker != nullptr) {
+        _worker->shutdown();
+        _worker.reset();
+    }
+}
+
+- (void)dealloc {
+    [self shutdown];
+}
+
+@end

--- a/apps/iOS/MNNLLMChat/MNNLLMiOS/MNNLLMiOS-Bridging-Header.h
+++ b/apps/iOS/MNNLLMChat/MNNLLMiOS/MNNLLMiOS-Bridging-Header.h
@@ -11,5 +11,6 @@
 #import "LLMInferenceEngineWrapper.h"
 #import "DiffusionSession.h"
 #import "SanaDiffusionSession.h"
+#import "PresetZipformerASRWrapper.h"
 
 #endif /* MNNLLMiOS_Bridging_Header_h */

--- a/apps/iOS/MNNLLMChat/MNNLLMiOS/MNNLLMiOSApp.swift
+++ b/apps/iOS/MNNLLMChat/MNNLLMiOS/MNNLLMiOSApp.swift
@@ -19,7 +19,62 @@ struct MNNLLMiOSApp: App {
 
     var body: some Scene {
         WindowGroup {
-            MainTabView()
+            if CommandLine.arguments.contains("--preset-asr-silent-probe") {
+                PresetASRSilentProbeView()
+            } else {
+                MainTabView()
+            }
         }
+    }
+}
+
+private struct PresetASRSilentProbeView: View {
+    @State private var status = "X-ASR silent probe"
+
+    var body: some View {
+        Text(status).task {
+            status = await Task.detached(priority: .userInitiated) {
+                await Self.runProbe()
+            }.value
+        }
+    }
+
+    private static func runProbe() async -> String {
+        let reportURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("qwen-xasr-device-probe.json")
+        let audioURL = Bundle.main.resourceURL?
+            .appendingPathComponent("LocalModel/preset_audio/audio (1).wav")
+        var report: [String: Any] = [
+            "runtime": "sherpa-mnn",
+            "model": "x-asr-zipformer2",
+            "precision": "mnn-weight-int8-block64",
+            "backend": "cpu",
+            "threads": 2,
+        ]
+        let service = PresetZipformerASRService()
+        do {
+            guard let audioURL else {
+                throw PresetASRError.missingAsset("LocalModel/preset_audio/audio (1).wav")
+            }
+            let recognition = try await service.recognize(
+                audioURL: audioURL,
+                expectedAudioSHA256: "2c9c3ab83563e058ed46e067e716beeeca8d3b50a2cd0e622dc6437714647b58"
+            )
+            report["transcript"] = recognition.transcript
+            report["audio_seconds"] = recognition.audioDurationSeconds
+            report["initialization_seconds"] = recognition.modelInitializationSeconds
+            report["inference_seconds"] = recognition.inferenceSeconds
+            report["rtf"] = recognition.realTimeFactor
+            report["realtime_multiple"] = recognition.realTimeMultiple
+        } catch {
+            report["error"] = error.localizedDescription
+        }
+        service.shutdown()
+        if let data = try? JSONSerialization.data(
+            withJSONObject: report, options: [.prettyPrinted, .sortedKeys]
+        ) {
+            try? data.write(to: reportURL, options: .atomic)
+        }
+        return report["error"] == nil ? "X-ASR silent probe complete" : "X-ASR silent probe failed"
     }
 }

--- a/apps/iOS/MNNLLMChat/PRESET_ASR.md
+++ b/apps/iOS/MNNLLMChat/PRESET_ASR.md
@@ -1,0 +1,62 @@
+# Preset X-ASR demo assets
+
+The preset-audio path runs X-ASR through the in-tree `sherpa-mnn` runtime,
+then submits the recognized text to Qwen3.5-2B. Model weights, the sample
+recording, and generated static libraries are deliberately kept out of Git.
+
+## Internal test package
+
+Request `mnn-ios-xasr-int8-test-assets-v1.zip` through the approved internal
+artifact channel. Do not upload this package to a public pull request or
+release until the model and recording redistribution rights are confirmed.
+
+Extract the archive at the repository root:
+
+```bash
+ditto -x -k mnn-ios-xasr-int8-test-assets-v1.zip /path/to/MNN
+cd /path/to/MNN
+shasum -a 256 -c apps/iOS/MNNLLMChat/PRESET_ASR_ASSETS.sha256
+```
+
+The archive installs the following ignored files:
+
+```text
+apps/iOS/MNNLLMChat/
+├── libsherpa-mnn.a
+└── MNNLLMiOS/LocalModel/
+    ├── preset_audio/audio (1).wav
+    └── xasr-mnn-int8/
+        ├── encoder-160ms.mnn
+        ├── decoder-160ms.mnn
+        ├── joiner-160ms.mnn
+        └── tokens.txt
+```
+
+`libsherpa-mnn.a` in package v1 is an arm64 iOS archive. A universal local
+replacement can be generated from `apps/frameworks/sherpa-mnn/build-ios.sh`
+and linked through an XCFramework in the Xcode project.
+
+## Build and silent verification
+
+Open `apps/iOS/MNNLLMChat/MNNLLMiOS.xcodeproj`, select the `MNNLLMiOS`
+scheme and a signed iOS device, then build and run. The X-ASR preset appears
+only when the sample recording is present.
+
+To exercise the production ASR wrapper without opening the microphone or
+playing audio, launch the app with:
+
+```text
+--preset-asr-silent-probe
+```
+
+The probe writes `qwen-xasr-device-probe.json` to the app Documents directory.
+For the supplied 2.136875-second Mandarin sample, the expected normalized
+transcript is:
+
+```text
+给我介绍一下杭州市的美食
+```
+
+The UI reports ASR inference time, audio duration, RTF, and real-time multiple.
+Model initialization time is logged for diagnostics but intentionally omitted
+from the chat bubble.

--- a/apps/iOS/MNNLLMChat/PRESET_ASR_ASSETS.sha256
+++ b/apps/iOS/MNNLLMChat/PRESET_ASR_ASSETS.sha256
@@ -1,0 +1,6 @@
+851faba1d21764c05bfa66e6d931acd37a03df87da42672acbcfdc0765b3a9ee  apps/iOS/MNNLLMChat/libsherpa-mnn.a
+2c9c3ab83563e058ed46e067e716beeeca8d3b50a2cd0e622dc6437714647b58  apps/iOS/MNNLLMChat/MNNLLMiOS/LocalModel/preset_audio/audio (1).wav
+83f4bb5fc1b28130af1823c7b20937ce2b789923ccc2beb2fbc09b81f7de2359  apps/iOS/MNNLLMChat/MNNLLMiOS/LocalModel/xasr-mnn-int8/decoder-160ms.mnn
+5570b93b89969665c0428cc3c159e41bc71ded7a297e75b1fe09c6c6dce68c82  apps/iOS/MNNLLMChat/MNNLLMiOS/LocalModel/xasr-mnn-int8/encoder-160ms.mnn
+3f71a9408890199ed3fb71b2a29bb3aada57f81281a6cfbdf753d859a1a1fa33  apps/iOS/MNNLLMChat/MNNLLMiOS/LocalModel/xasr-mnn-int8/joiner-160ms.mnn
+b818a60878b9aae978cbb8ad594acbd403d76d1af2e31ef4197c84e2dbdba27c  apps/iOS/MNNLLMChat/MNNLLMiOS/LocalModel/xasr-mnn-int8/tokens.txt


### PR DESCRIPTION
## Summary

- add a preset audio chip beside the existing image presets in the Qwen3.5-2B demo
- run the bundled sample through X-ASR (Zipformer2, MNN weight INT8 block64) on CPU before submitting the normalized transcript to the LLM
- show the playable waveform first, then the transcript and ASR-only latency/RTF in compact text
- keep model initialization time out of the user-visible metric while retaining it in diagnostics
- add generation-based result invalidation, a permanent native worker thread, asset SHA-256 validation, and a silent signed-device probe

## Asset delivery

Model weights, the sample recording, and the generated arm64 `libsherpa-mnn.a` are intentionally excluded from Git. The internal test package is:

`mnn-ios-xasr-int8-test-assets-v1-final.zip`

SHA-256:

`a8eb55870620a5195b458aa9c316e1cbee0a1af600002239095eade64aeffdcf`

Please confirm redistribution rights for X-ASR and the sample recording before publishing the archive. `apps/iOS/MNNLLMChat/PRESET_ASR.md` documents installation and exact per-file hashes.

## Verification

- clean signed-device Debug build: PASS
- device: iPhone 13 Pro (`iPhone14,2`)
- silent production-path probe: PASS; no microphone capture or speaker playback
- sample duration: 2.136875 s
- normalized transcript: `给我介绍一下杭州市的美食`
- X-ASR inference: approximately 0.294 s
- RTF: approximately 0.138 (approximately 7.3x real time)
- interactive audio/transcript/LLM flow: manually accepted on device
- package extract + six-file SHA-256 verification: PASS

Not tested: corpus-level CER/WER, repeated-turn/cancellation stress matrix, memory peak/Jetsam headroom, simulator or iPad.

## Notes

The first commit removes the unavailable `cmark-gfm-bin` target from the vendored SwiftPM manifest. The branch does not contain its declared `bin` directory, so a clean dependency resolution otherwise fails before the app target is built.
