### PR TITLE
[OpenCL:Bugfix] Cap Winograd transform buffers under Memory_Low (fix issue #4782)

### DIFF
--- a/source/backend/opencl/core/OpenCLRunningUtils.hpp
+++ b/source/backend/opencl/core/OpenCLRunningUtils.hpp
@@ -140,6 +140,22 @@ void setTunedInfo(const std::string kernelName, const std::vector<uint32_t> &gws
 
 void copyBufferToImage(OpenCLRuntime *runtime, const cl::Buffer &buffer, const cl::Image &image, int w, int h, int precision);
 
+// Byte budget for one conv's Winograd transform pair (source + dest) under Memory_Low, shared by
+// the buffer and image convolution paths so both gate on the same number.
+//
+// Winograd trades ~2.25x fewer multiplies for 4x the tensor in each transform buffer (a 4x4 input
+// tile per 2x2 output tile), and source and dest are alive at once. That is a good deal until the
+// tensor itself is large: one 640x640x256 fp16 conv wants 1.6GB for the pair, where direct
+// convolution needs no staging buffer at all.
+//
+// 256MB was measured on an SDXL-VAE-decoder-shaped graph (80x80 latent -> 640x640, channels
+// 512/512/256/128, 3 resnets per stage, fp32, buffer mode). Peak dynamic memory there is 5200MB
+// unguarded, of which ~3600MB is transform buffers. Every budget from 32MB to 512MB brings the
+// peak to 1600MB -- the graph's genuine working set -- so the whole range is equivalent on memory
+// and the choice is about bounding the worst-case single-conv spike. Runtime differences across
+// that range were inside run-to-run variance (~8%) on the GPU tested (Apple M4 Pro).
+#define WINOGRAD_TRANSFORM_BUDGET ((size_t)256 * 1024 * 1024)
+
 } // namespace OpenCL
 } // namespace MNN
 #endif /* OpenCLRunningUtils_hpp */

--- a/source/backend/opencl/execution/buffer/ConvBufExecution.cpp
+++ b/source/backend/opencl/execution/buffer/ConvBufExecution.cpp
@@ -947,7 +947,10 @@ public:
         }
 #endif
 
-        if (ConvBufWinograd::valid(conv2D->common(), inputs[0], outputs[0], static_cast<OpenCLBackend *>(backend)->getOpenCLRuntime()->getGpuType() == INTEL)) {
+        auto clBackend = static_cast<OpenCLBackend *>(backend);
+        if (ConvBufWinograd::valid(conv2D->common(), inputs[0], outputs[0],
+                                   clBackend->getOpenCLRuntime()->getGpuType() == INTEL, 8192, clBackend->fpBytes(),
+                                   clBackend->getMemory())) {
 #ifdef MNN_SUPPORT_INTEL_SUBGROUP
             if(static_cast<OpenCLBackend *>(backend)->getOpenCLRuntime()->isSupportedIntelSubgroup()){
                 std::vector<int> inputShape = tensorShapeFormat(input);

--- a/source/backend/opencl/execution/buffer/ConvBufWinograd.cpp
+++ b/source/backend/opencl/execution/buffer/ConvBufWinograd.cpp
@@ -16,19 +16,6 @@
 #define INTERP 1
 namespace MNN {
 namespace OpenCL {
-// Budget for one conv's mSource + mDest under Memory_Low. Winograd trades ~2.25x fewer
-// multiplies for 4x the tensor in each transform buffer, which is a good deal until the
-// tensor itself is large: a 640x640x256 fp16 conv wants 1.6GB for the pair. Convs above the
-// budget fall back to direct convolution, which needs no staging buffer at all.
-//
-// 256MB was picked on an SDXL-VAE-decoder-shaped graph (80x80 latent -> 640x640, fp32, see
-// tools/cpp/openclPoolProfile.cpp). Peak dynamic memory there is 5200MB unguarded; every
-// budget from 32MB to 512MB brings it to 1600MB, which is the graph's genuine working set,
-// so anything in that range is equivalent on memory and the choice is about bounding the
-// worst-case single-conv spike. Runtime differences across that range were inside run-to-run
-// variance (~8%) on the GPU tested. Override with MNN_OPENCL_WINOGRAD_LIMIT_MB to retune.
-#define WINOGRAD_LOW_MEMORY_TRANSFORM_LIMIT (256 * 1024 * 1024)
-
 int ConvBufWinograd::transformAlignN(int outputChannel) {
     if (outputChannel > 1024) {
         return 128;
@@ -78,19 +65,21 @@ bool ConvBufWinograd::valid(const Convolution2DCommon* common, const Tensor* inp
     if (!valid) {
         return false;
     }
+    const int alpha  = common->kernelX() + UNIT - 1;
+    const int units  = UP_DIV(output->width(), UNIT) * UP_DIV(output->height(), UNIT);
+    const int alignN = transformAlignN(output->channel());
+    int alignM       = 0;
+    size_t srcElem = 0, dstElem = 0;
+    // alignK is fixed at 4 for the transform layout, see the ctor.
+    transformElements(alpha, units, input->channel(), output->channel(), 4, alignN, &alignM, &srcElem, &dstElem);
+    // onEncode hands these counts to Tensor::createDevice as int, so a conv whose transform
+    // buffer overflows int would silently get a truncated allocation and read out of bounds.
+    // Checked in every memory mode: the old int arithmetic here could wrap just as easily.
+    if (srcElem > (size_t)INT_MAX || dstElem > (size_t)INT_MAX) {
+        return false;
+    }
     if (BackendConfig::Memory_Low == memory) {
-        const int alpha  = common->kernelX() + UNIT - 1;
-        const int units  = UP_DIV(output->width(), UNIT) * UP_DIV(output->height(), UNIT);
-        const int alignN = transformAlignN(output->channel());
-        int alignM       = 0;
-        size_t srcElem = 0, dstElem = 0;
-        // alignK is fixed at 4 for the transform layout, see the ctor.
-        transformElements(alpha, units, input->channel(), output->channel(), 4, alignN, &alignM, &srcElem, &dstElem);
-        static const size_t budget =
-            getenv("MNN_OPENCL_WINOGRAD_LIMIT_MB")
-                ? (size_t)atoi(getenv("MNN_OPENCL_WINOGRAD_LIMIT_MB")) * 1024 * 1024
-                : (size_t)WINOGRAD_LOW_MEMORY_TRANSFORM_LIMIT;
-        if ((srcElem + dstElem) * (size_t)fpBytes > budget) {
+        if ((srcElem + dstElem) * (size_t)fpBytes > WINOGRAD_TRANSFORM_BUDGET) {
             return false;
         }
     }

--- a/source/backend/opencl/execution/buffer/ConvBufWinograd.cpp
+++ b/source/backend/opencl/execution/buffer/ConvBufWinograd.cpp
@@ -16,7 +16,50 @@
 #define INTERP 1
 namespace MNN {
 namespace OpenCL {
-bool ConvBufWinograd::valid(const Convolution2DCommon* common, const Tensor* input, const Tensor* output, bool isIntel, int limit) {
+// Budget for one conv's mSource + mDest under Memory_Low. Winograd trades ~2.25x fewer
+// multiplies for 4x the tensor in each transform buffer, which is a good deal until the
+// tensor itself is large: a 640x640x256 fp16 conv wants 1.6GB for the pair. Convs above the
+// budget fall back to direct convolution, which needs no staging buffer at all.
+//
+// 256MB was picked on an SDXL-VAE-decoder-shaped graph (80x80 latent -> 640x640, fp32, see
+// tools/cpp/openclPoolProfile.cpp). Peak dynamic memory there is 5200MB unguarded; every
+// budget from 32MB to 512MB brings it to 1600MB, which is the graph's genuine working set,
+// so anything in that range is equivalent on memory and the choice is about bounding the
+// worst-case single-conv spike. Runtime differences across that range were inside run-to-run
+// variance (~8%) on the GPU tested. Override with MNN_OPENCL_WINOGRAD_LIMIT_MB to retune.
+#define WINOGRAD_LOW_MEMORY_TRANSFORM_LIMIT (256 * 1024 * 1024)
+
+int ConvBufWinograd::transformAlignN(int outputChannel) {
+    if (outputChannel > 1024) {
+        return 128;
+    }
+    if (outputChannel > 256) {
+        return 64;
+    }
+    if (outputChannel > 64) {
+        return 32;
+    }
+    return 16;
+}
+
+void ConvBufWinograd::transformElements(int alpha, int units, int inputChannel, int outputChannel, int alignK,
+                                        int alignN, int* alignM, size_t* sourceElements, size_t* destElements) {
+    int m       = 16;
+    float ratio = 1.0 * alpha * alpha * units / 1024.0 * inputChannel / 1024.0 * outputChannel / 1024.0;
+    if (units > 512 && ratio > 1.0) {
+        m = 128;
+    } else if (units > 256 && ratio > 0.1) {
+        m = 64;
+    } else if (units > 64) {
+        m = 32;
+    }
+    *alignM         = m;
+    *sourceElements = (size_t)alpha * alpha * ROUND_UP(inputChannel, alignK) * ROUND_UP(units, m);
+    *destElements   = (size_t)alpha * alpha * ROUND_UP(units, m) * ROUND_UP(outputChannel, alignN);
+}
+
+bool ConvBufWinograd::valid(const Convolution2DCommon* common, const Tensor* input, const Tensor* output, bool isIntel,
+                            int limit, int fpBytes, BackendConfig::MemoryMode memory) {
     if (common->strideX() != 1 || common->strideY() != 1) {
         return false;
     }
@@ -32,7 +75,26 @@ bool ConvBufWinograd::valid(const Convolution2DCommon* common, const Tensor* inp
 
     bool valid = input->channel() >= 32 && output->channel() >= 32 && input->width() < output->channel();
     valid = valid || (input->channel() >= 64 && output->channel() >= 64);
-    return valid;
+    if (!valid) {
+        return false;
+    }
+    if (BackendConfig::Memory_Low == memory) {
+        const int alpha  = common->kernelX() + UNIT - 1;
+        const int units  = UP_DIV(output->width(), UNIT) * UP_DIV(output->height(), UNIT);
+        const int alignN = transformAlignN(output->channel());
+        int alignM       = 0;
+        size_t srcElem = 0, dstElem = 0;
+        // alignK is fixed at 4 for the transform layout, see the ctor.
+        transformElements(alpha, units, input->channel(), output->channel(), 4, alignN, &alignM, &srcElem, &dstElem);
+        static const size_t budget =
+            getenv("MNN_OPENCL_WINOGRAD_LIMIT_MB")
+                ? (size_t)atoi(getenv("MNN_OPENCL_WINOGRAD_LIMIT_MB")) * 1024 * 1024
+                : (size_t)WINOGRAD_LOW_MEMORY_TRANSFORM_LIMIT;
+        if ((srcElem + dstElem) * (size_t)fpBytes > budget) {
+            return false;
+        }
+    }
+    return true;
 }
     
 void ConvBufWinograd::convertWeightFormat(cl::Buffer& buffer, const int alignK, const int alignN) {
@@ -209,14 +271,7 @@ ConvBufWinograd::ConvBufWinograd(const MNN::Op* op, Backend* backend) : CommonEx
         int alpha       = unit + kernelSize - 1;
         
         mResource->mAlignK = 4;
-        mResource->mAlignN = 16;
-        if(mCo > 1024) {
-            mResource->mAlignN = 128;
-        } else if(mCo > 256) {
-            mResource->mAlignN = 64;
-        } else if(mCo > 64) {
-            mResource->mAlignN = 32;
-        }
+        mResource->mAlignN = transformAlignN(mCo);
 
         std::shared_ptr<Tensor> tmpFilterTensor;
         tmpFilterTensor.reset(Tensor::createDevice<int32_t>({mCo * mCi * ky * kx}));
@@ -472,21 +527,13 @@ ErrorCode ConvBufWinograd::onEncode(const std::vector<Tensor*>& inputs, const st
     } else
 #endif /* MNN_SUPPORT_INTEL_SUBGROUP */    
     {
-        mAlignM = 16;
-        float ratio = 1.0 * alpha * alpha * wUnit * hUnit / 1024.0 * input->channel() / 1024.0 * output->channel() / 1024.0;
-        if (wUnit * hUnit > 512 && ratio > 1.0) {
-            mAlignM = 128;
-        } else if (wUnit * hUnit > 256 && ratio > 0.1) {
-            mAlignM = 64;
-        } else if (wUnit * hUnit > 64) {
-            mAlignM = 32;
-        }
-        int mAlignK = mResource->mAlignK;
-        int mAlignN = mResource->mAlignN;
-        mSource.reset(Tensor::createDevice<float>(
-            std::vector<int>{alpha * alpha * ROUND_UP(input->channel(), mAlignK) * ROUND_UP(wUnit * hUnit, mAlignM)}));
-        mDest.reset(Tensor::createDevice<float>(
-            std::vector<int>{alpha * alpha * ROUND_UP(wUnit * hUnit, mAlignM) * ROUND_UP(output->channel(), mAlignN)}));
+        const int mAlignK = mResource->mAlignK;
+        const int mAlignN = mResource->mAlignN;
+        size_t sourceElements = 0, destElements = 0;
+        transformElements(alpha, wUnit * hUnit, input->channel(), output->channel(), mAlignK, mAlignN, &mAlignM,
+                          &sourceElements, &destElements);
+        mSource.reset(Tensor::createDevice<float>(std::vector<int>{(int)sourceElements}));
+        mDest.reset(Tensor::createDevice<float>(std::vector<int>{(int)destElements}));
 
         mOpenCLBackend->onAcquireBuffer(mSource.get(), Backend::DYNAMIC);
         mOpenCLBackend->onAcquireBuffer(mDest.get(), Backend::DYNAMIC);

--- a/source/backend/opencl/execution/buffer/ConvBufWinograd.hpp
+++ b/source/backend/opencl/execution/buffer/ConvBufWinograd.hpp
@@ -34,7 +34,18 @@ public:
 
     virtual ErrorCode onEncode(const std::vector<Tensor*>& inputs, const std::vector<Tensor*>& outputs) override;
     virtual bool onClone(Backend* bn, const Op* op, Execution** dst) override;
-    static bool valid(const Convolution2DCommon* common, const Tensor* input, const Tensor* output, bool isIntel = false, int limit = 8192);
+    // fpBytes / memory let valid() price the transform buffers this conv would need: they run
+    // alpha^2/UNIT^2 = 4x the tensor each, which dominates memory at high resolution. Under
+    // Memory_Low a conv whose pair exceeds the budget falls back to direct convolution.
+    static bool valid(const Convolution2DCommon* common, const Tensor* input, const Tensor* output,
+                      bool isIntel = false, int limit = 8192, int fpBytes = 4,
+                      BackendConfig::MemoryMode memory = BackendConfig::Memory_Normal);
+    // N-alignment of the transform buffers, shared with the weight layout built in the ctor.
+    static int transformAlignN(int outputChannel);
+    // Element counts onEncode will allocate for mSource / mDest. Kept here so valid() prices
+    // exactly what onEncode allocates instead of re-deriving it.
+    static void transformElements(int alpha, int units, int inputChannel, int outputChannel, int alignK,
+                                  int alignN, int* alignM, size_t* sourceElements, size_t* destElements);
     std::vector<uint32_t> getLocalWS(std::string kernelName, int index, std::vector<uint32_t> &gws, const uint32_t maxWorkGroupSize, cl::Kernel mKernel);
     virtual ErrorCode onExecute(const std::vector<Tensor*>& inputs, const std::vector<Tensor*>& outputs) override;
 

--- a/source/backend/opencl/execution/image/ConvExecution.cpp
+++ b/source/backend/opencl/execution/image/ConvExecution.cpp
@@ -628,9 +628,11 @@ public:
                 }
             }
         }
-        int maxWidth  = static_cast<OpenCLBackend *>(backend)->getOpenCLRuntime()->getMaxImage2DSize()[0];
-        int maxHeight = static_cast<OpenCLBackend *>(backend)->getOpenCLRuntime()->getMaxImage2DSize()[1];
-        if (ConvWinograd::valid(conv2D->common(), inputs[0], outputs[0], maxWidth, maxHeight)) {
+        auto clBackend = static_cast<OpenCLBackend *>(backend);
+        int maxWidth  = clBackend->getOpenCLRuntime()->getMaxImage2DSize()[0];
+        int maxHeight = clBackend->getOpenCLRuntime()->getMaxImage2DSize()[1];
+        if (ConvWinograd::valid(conv2D->common(), inputs[0], outputs[0], maxWidth, maxHeight, 8192,
+                                clBackend->fpBytes(), clBackend->getMemory())) {
             OPENCL_CREATOR_CHECK(new ConvWinograd(op, backend));
         }
         

--- a/source/backend/opencl/execution/image/ConvWinograd.cpp
+++ b/source/backend/opencl/execution/image/ConvWinograd.cpp
@@ -13,7 +13,17 @@
 #define INTERP 1
 namespace MNN {
 namespace OpenCL {
-bool ConvWinograd::valid(const Convolution2DCommon* common, const Tensor* input, const Tensor* output, int maxWidth, int maxHeight, int limit) {
+size_t ConvWinograd::transformImageBytes(int alpha, int wUnit, int hUnit, int inputChannel, int outputChannel,
+                                        int fpBytes) {
+    // Prices the pair onEncode allocates. MNN maps a CAFFE_C4 tensor to an image of
+    // width UP_DIV(C, 4) * W and height N * H, always CL_RGBA, so four channels per pixel.
+    // mSource is {alpha*alpha, ic, hUnit, wUnit}; mDest is {UP_DIV(oc, 4), wUnit*4, hUnit, alpha*alpha}.
+    size_t sourcePixels = (size_t)UP_DIV(inputChannel, 4) * wUnit * ((size_t)alpha * alpha * hUnit);
+    size_t destPixels   = (size_t)wUnit * alpha * alpha * ((size_t)UP_DIV(outputChannel, 4) * hUnit);
+    return (sourcePixels + destPixels) * 4 * (size_t)fpBytes;
+}
+
+bool ConvWinograd::valid(const Convolution2DCommon* common, const Tensor* input, const Tensor* output, int maxWidth, int maxHeight, int limit, int fpBytes, BackendConfig::MemoryMode memory) {
     if (common->strideX() != 1 || common->strideY() != 1) {
         return false;
     }
@@ -41,6 +51,13 @@ bool ConvWinograd::valid(const Convolution2DCommon* common, const Tensor* input,
     int destHeight = UP_DIV(ic, 4) * hUnit;
 
     if(sourceWidth > maxWidth || sourceHeight > maxHeight || destWidth > maxWidth || destHeight > maxHeight){
+        return false;
+    }
+    // The image-dimension bounds above are not a memory bound: they reject issue #4782's
+    // 640x640x256 conv, but a 512x512 ic64 -> oc512 conv passes them and still wants ~1.2GB for
+    // the transform pair. Gate on the same budget the buffer path uses, see ConvBufWinograd.
+    if (BackendConfig::Memory_Low == memory &&
+        transformImageBytes(alpha, wUnit, hUnit, ic, oc, fpBytes) > WINOGRAD_TRANSFORM_BUDGET) {
         return false;
     }
     if(ic >= 32 && oc >= 32){

--- a/source/backend/opencl/execution/image/ConvWinograd.hpp
+++ b/source/backend/opencl/execution/image/ConvWinograd.hpp
@@ -27,7 +27,16 @@ public:
 
     virtual ErrorCode onEncode(const std::vector<Tensor*>& inputs, const std::vector<Tensor*>& outputs) override;
     virtual bool onClone(Backend* bn, const Op* op, Execution** dst) override;
-    static bool valid(const Convolution2DCommon* common, const Tensor* input, const Tensor* output, int maxWidth, int maxHeight, int limit = 8192);
+    // maxWidth / maxHeight bound the image dimensions the driver accepts; fpBytes / memory let
+    // valid() additionally price the transform images this conv would need, which the dimension
+    // bounds do not constrain tightly. Under Memory_Low a conv over budget falls back to direct
+    // convolution. See ConvBufWinograd::valid for the buffer-mode equivalent.
+    static bool valid(const Convolution2DCommon* common, const Tensor* input, const Tensor* output, int maxWidth,
+                      int maxHeight, int limit = 8192, int fpBytes = 4,
+                      BackendConfig::MemoryMode memory = BackendConfig::Memory_Normal);
+    // Bytes onEncode will allocate for the mSource / mDest image pair.
+    static size_t transformImageBytes(int alpha, int wUnit, int hUnit, int inputChannel, int outputChannel,
+                                     int fpBytes);
 
 private:
     OpenCLBackend* mOpenCLBackend;


### PR DESCRIPTION
Fixes #4782.

## Root cause

`ConvBufWinograd::valid` bounds nothing on the non-Intel path — any 3x3 stride-1 conv with in/out channels >= 64 takes Winograd regardless of resolution, and the check never looks at the memory mode:

```cpp
if (isIntel) {
    return input->width() * input->height() <= 4096;   // Intel has a cap
}
bool valid = input->channel() >= 32 && output->channel() >= 32 && input->width() < output->channel();
valid = valid || (input->channel() >= 64 && output->channel() >= 64);
return valid;                                          // Mali / Adreno: no bound at all
```

Winograd's transform buffers are the problem. From `onEncode`:

```
mSource = alpha^2 * ROUND_UP(iC, alignK) * ROUND_UP(wUnit*hUnit, alignM)
mDest   = alpha^2 * ROUND_UP(wUnit*hUnit, alignM) * ROUND_UP(oC, alignN)
```

With `UNIT 2` and a 3x3 kernel, `alpha = 4`, and the tile count is `W*H/4`, so each buffer holds `alpha^2/UNIT^2 = 4x` the tensor. Both are alive at once. A 640x640x256 fp16 conv therefore asks for ~1.6GB of staging, where direct convolution needs none — the `mConvGemmInp/OutTensor` staging in `ConvBufExecution` is gated on `isConv1x1`, so a plain 3x3 conv allocates no extra buffer at all.

This is invisible in normal workloads: it only bites when `W*H` is large. Classifier convs are small and LLM convs are all 1x1. A VAE decoder is 3x3 all the way up to 640x640, which is why #4782 sees ~3.8GB for a decoder whose weights are 99MB.

## Measurement

Measured on an SDXL-VAE-decoder-shaped graph (80x80 latent -> 640x640, reversed channels 512/512/256/128, 3 resnets per stage), OpenCL buffer mode, fp32:

| | peak dynamic memory |
|---|---|
| `Memory_Normal` (unchanged) | 5200 MB |
| `Memory_Low` (this PR) | **1600 MB** |

1600MB is the graph's genuine working set — every budget from 32MB to 512MB lands there, so above that range Winograd is no longer what dominates.

Buffer-pool reuse was checked and is *not* the issue: 190 reuse hits vs 18 fresh allocations, resident/peak overhead only 1.23x.

### On-device validation

@Mr-J-369 tested this branch at `7375b00e` inside a vendored 3.6.1 runtime, 1024px SDXL, `Memory_Low`, buffer mode, default 256MB budget:

| | before | with this PR |
|---|---:|---:|
| Adreno 830 (SM-S938B), UNet | 2,532,130,816 B | 2,533,740,544 B |
| Adreno 830, VAE | 3,803,688,960 B | **1,694,744,576 B** |

VAE allocation fell ~55% and stayed flat across all four tiles. On the device that originally failed (Xiaomi MT6897, 7319MB) 6-8 step generation was previously killed at the VAE transition; with this PR it completed two consecutive 8-step images. The tester rated the speed difference small.

## Image mode

The image path needed the same gate. Its `CL_DEVICE_IMAGE2D_MAX_*` bounds are *not* a memory bound — they reject #4782's own 640x640x256 conv, which is why the issue never showed up in image mode, but they let other large convs through. `ConvWinograd::valid` also derives `destHeight` from `ic` where `onEncode` allocates from `oc`, so it under-estimates whenever `oc > ic`. (Left alone here: correcting it would change `Memory_Normal` behaviour, which this PR deliberately does not touch.)

Verified end to end on a 512x512 ic64 -> oc128 conv, image mode, by logging every `ImagePool` allocation:

| | total image bytes | transform pair |
|---|---:|---:|
| `Memory_Normal` | 960 MB | 256 + 512 = **768 MB** |
| `Memory_Low` | 192 MB | **0** |

`transformImageBytes()` predicted 768 MB and the driver allocated exactly 768 MB, so the gate prices the real allocation rather than an approximation of it.

## Scope

`Memory_Normal` is untouched. The gate also does not trigger at low resolution — the same graph at 160x160 output peaks at 318MB under both memory modes, so classifiers and LLMs are unaffected.

The cost where it does trigger is real: that graph goes from ~1350ms to ~1800ms per iteration on the GPU tested. This is fp32, so the fp16 penalty on device should be smaller (same conv prices at half the bytes, so more convs keep Winograd).

## Implementation notes

The transform sizing is factored into `transformAlignN` / `transformElements` (buffer) and `transformImageBytes` (image), shared by `valid()` and `onEncode()`. The gate prices exactly what `onEncode` allocates rather than duplicating the formula, so the two cannot drift apart. The budget is a single constant in `OpenCLRunningUtils.hpp` used by both paths.

`valid()` now also rejects transform buffers whose element count overflows `int`, in every memory mode: `onEncode` passes those counts to `Tensor::createDevice` as `int`, so an oversized conv would otherwise get a silently truncated allocation. The `int` arithmetic this replaced could wrap just as easily.

The 256MB default was chosen for memory safety, not speed: the memory floor is reached anywhere in 32MB-512MB, and runtime differences across that range were inside run-to-run variance (~8%) on the GPU tested, so 256MB bounds the worst-case single-conv spike without a measurable speed cost relative to a looser budget.

## Testing

Full OpenCL op suite on Apple M4 Pro (OpenCL 1.2): **384 passed / 1 failed**.

The one failure, `expr/MemeoryUsageTest`, reproduces identically on this branch with the changes stashed — it is the `CLRuntime::onGetMemoryInMB` bug that #4784 fixes (the static-only figure returns 0 here), not a regression from this PR.

Field-validated on Adreno 830 and MT6897 as above. Not yet validated on Mali beyond that MT6897 report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
