### PR TITLE
[OpenCL:Bugfix] Report dynamic pool memory in getSessionInfo(MEMORY)

### DIFF
--- a/source/backend/opencl/core/BufferPool.cpp
+++ b/source/backend/opencl/core/BufferPool.cpp
@@ -60,6 +60,14 @@ void BufferPool::releaseFreeList() {
     mFreeList.clear();
 }
 
+size_t BufferPool::residentSize() const {
+    size_t total = 0;
+    for (const auto& iter : mAllBuffer) {
+        total += iter.second->size;
+    }
+    return total;
+}
+
 std::shared_ptr<OpenCLBufferNode> BufferExecutionPool::alloc(size_t size, bool separate) {
     if (!separate) {
         auto iter = mFreeList.lower_bound(size);
@@ -124,6 +132,14 @@ void BufferExecutionPool::releaseFreeList() {
         }
     }
     mFreeList.clear();
+}
+
+size_t BufferExecutionPool::residentSize() const {
+    size_t total = 0;
+    for (const auto& node : mAllBuffer) {
+        total += node->size;
+    }
+    return total;
 }
 } // namespace OpenCL
 } // namespace MNN

--- a/source/backend/opencl/core/BufferPool.hpp
+++ b/source/backend/opencl/core/BufferPool.hpp
@@ -35,6 +35,10 @@ public:
     void clear();
     void releaseFreeList();
     size_t totalSize() { return mTotalSize; }
+    // Bytes still held by the driver, recycled buffers included: they stay alive until
+    // releaseFreeList or clear. Unlike mTotalSize this shrinks when memory is handed back,
+    // so it is what getSessionInfo(MEMORY) should report.
+    size_t residentSize() const;
 
 private:
     std::map<cl::Buffer*, std::shared_ptr<OpenCLBufferNode>> mAllBuffer;
@@ -56,6 +60,7 @@ public:
     void clear();
     void releaseFreeList();
     size_t totalSize() { return mTotalSize; }
+    size_t residentSize() const;
 private:
     std::set<std::shared_ptr<OpenCLBufferNode>> mAllBuffer;
     std::multimap<size_t, std::shared_ptr<OpenCLBufferNode>> mFreeList;

--- a/source/backend/opencl/core/ImagePool.cpp
+++ b/source/backend/opencl/core/ImagePool.cpp
@@ -71,5 +71,16 @@ void ImagePool::releaseFreeList() {
     }
     mFreeList.clear();
 }
+
+size_t ImagePool::residentSize() const {
+    size_t total = 0;
+    for (const auto& iter : mAllImage) {
+        const auto& node = iter.second;
+        // Always CL_RGBA, so four channels per pixel.
+        size_t channelBytes = (CL_FLOAT == node->type) ? 4 : 2;
+        total += (size_t)node->w * node->h * 4 * channelBytes;
+    }
+    return total;
+}
 } // namespace OpenCL
 } // namespace MNN

--- a/source/backend/opencl/core/ImagePool.hpp
+++ b/source/backend/opencl/core/ImagePool.hpp
@@ -25,6 +25,9 @@ public:
     void recycle(cl::Image* image, bool release = false);
     void clear();
     void releaseFreeList();
+    // Bytes still held by the driver, recycled images included: they stay alive until
+    // releaseFreeList or clear. Used to report GPU memory through getSessionInfo(MEMORY).
+    size_t residentSize() const;
 
     struct Node {
         int w;

--- a/source/backend/opencl/core/OpenCLBackend.cpp
+++ b/source/backend/opencl/core/OpenCLBackend.cpp
@@ -283,9 +283,31 @@ void CLRuntime::onGabageCollect(int level) {
     }
 }
 
+void CLRuntime::onBackendCreate(OpenCLBackend* backend) const {
+    std::lock_guard<std::mutex> lock(mBackendMutex);
+    mBackends.insert(backend);
+}
+
+void CLRuntime::onBackendRelease(OpenCLBackend* backend) const {
+    std::lock_guard<std::mutex> lock(mBackendMutex);
+    mBackends.erase(backend);
+}
+
 float CLRuntime::onGetMemoryInMB() {
-    auto staticMemoryInMB = mBufferPool->totalSize() / 1024.0f / 1024.0f;
-    return staticMemoryInMB;
+    // Static pool holds the weights; the dynamic pools that hold activations belong to each
+    // OpenCLBackend. Reporting only the former makes a session look two orders of magnitude
+    // smaller than it is, and hides exactly the kind of blowup issue #4782 ran into.
+    size_t total = mBufferPool->residentSize() + mImagePool->residentSize();
+    if (nullptr != mMmapPool.get()) {
+        total += mMmapPool->totalSize();
+    }
+    {
+        std::lock_guard<std::mutex> lock(mBackendMutex);
+        for (auto backend : mBackends) {
+            total += backend->dynamicMemorySize();
+        }
+    }
+    return total / 1024.0f / 1024.0f;
 }
 
 bool CLRuntime::isCLRuntimeError() {
@@ -332,12 +354,34 @@ OpenCLBackend::OpenCLBackend(BackendConfig::PrecisionMode precision, BackendConf
         mBufferPool = mBufferPoolFirst.get();
     }
     mMapMem = std::make_pair(0, nullptr);
+    mCLRuntime->onBackendCreate(this);
+}
+
+size_t OpenCLBackend::dynamicMemorySize() const {
+    size_t total = 0;
+    if (nullptr != mBufferPoolFirst.get()) {
+        total += mBufferPoolFirst->residentSize();
+    }
+    if (nullptr != mBufferPoolSecond.get()) {
+        total += mBufferPoolSecond->residentSize();
+    }
+    if (nullptr != mImagePoolFirst.get()) {
+        total += mImagePoolFirst->residentSize();
+    }
+    if (nullptr != mImagePoolSecond.get()) {
+        total += mImagePoolSecond->residentSize();
+    }
+    if (nullptr != mExecutionBufferPool.get()) {
+        total += mExecutionBufferPool->residentSize();
+    }
+    return total;
 }
 
 OpenCLBackend::~OpenCLBackend() {
 #ifdef LOG_VERBOSE
     MNN_PRINT("enter OpenCLBackend::~OpenCLBackend \n");
 #endif
+    mCLRuntime->onBackendRelease(this);
     releaseRecord();
     mRecordings.clear();
     mImagePool = nullptr;

--- a/source/backend/opencl/core/OpenCLBackend.hpp
+++ b/source/backend/opencl/core/OpenCLBackend.hpp
@@ -14,6 +14,8 @@
 #include <MNN/ErrorCode.hpp>
 
 #include <list>
+#include <mutex>
+#include <set>
 #include <vector>
 #include "core/BufferAllocator.hpp"
 #include "backend/opencl/core/BufferPool.hpp"
@@ -44,6 +46,8 @@ struct RecordInfo{
     cl_recording_qcom record;
     std::vector<RecordUpdateInfo*> updateInfo;
 };
+class OpenCLBackend;
+
 class CLRuntime : public Runtime {
 public:
     CLRuntime(const Backend::Info& info);
@@ -62,6 +66,10 @@ public:
                            const MNN::Op* op, OpInfo& dstInfo) const override;
     virtual void onMaskOpReady(const std::vector<Tensor*>& inputs, const std::vector<Tensor*>& outputs,
                                const MNN::Op* op) override;
+    // The dynamic pools live on OpenCLBackend, not here, so onGetMemoryInMB has to ask the live
+    // backends for them. Backends register on construction and drop out on destruction.
+    void onBackendCreate(OpenCLBackend* backend) const;
+    void onBackendRelease(OpenCLBackend* backend) const;
     void convertToDevice(const Tensor* srcTensor, const Tensor* dstTensor, MNN_DATA_FORMAT data_format, int precision, int backend_memtype, bool svmFlag = false, int memtype = MNN_FORWARD_CPU) const;
     void convertFromDevice(const Tensor* srcTensor, const Tensor* dstTensor, MNN_DATA_FORMAT data_format, int precision, int backend_memtype, bool svmFlag = false, int memtype = MNN_FORWARD_CPU) const;
     void copyBetweenDevice(const Tensor* srcTensor, const Tensor* dstTensor, int precision, int backend_memtype) const;
@@ -77,6 +85,8 @@ private:
     BackendConfig::MemoryMode mMemory;
     bool mCLRuntimeError = false;
     mutable float mLastGpuTimeMs = -1.0f;
+    mutable std::set<OpenCLBackend*> mBackends;
+    mutable std::mutex mBackendMutex;
 
     friend class OpenCLBackend;
     TuneInfo* mTunedInfo;
@@ -116,7 +126,11 @@ public:
     BufferPool *getBufferPool() const {
         return mBufferPool;
     }
-    
+
+    // Bytes held by this backend's dynamic pools. Reported through CLRuntime::onGetMemoryInMB,
+    // which otherwise only sees the static weight pool it owns.
+    size_t dynamicMemorySize() const;
+
     std::shared_ptr<MmapPool> getStaticAllocatorMMap() const {
         if(mCLRuntime->mUseMmapPool){
             return mCLRuntime->mMmapPool;


### PR DESCRIPTION
Found while investigating #4782. Independent of #4783 — either can land alone.

## The bug

`CLRuntime::onGetMemoryInMB` reported only the static weight pool:

```cpp
float CLRuntime::onGetMemoryInMB() {
    auto staticMemoryInMB = mBufferPool->totalSize() / 1024.0f / 1024.0f;
    return staticMemoryInMB;
}
```

The dynamic pools that hold activations (`mBufferPoolFirst/Second`, `mImagePoolFirst/Second`, `mExecutionBufferPool`) belong to each `OpenCLBackend`, not to the runtime, so they were never counted. `CPURuntime::onGetMemoryInMB` already sums static + dynamic, so OpenCL was also inconsistent with CPU.

Measured on an SDXL-VAE-decoder-shaped graph (640x640 output, buffer mode):

| | reported | actually resident |
|---|---|---|
| before | 327.76 MB | 6393 MB dynamic + 328 MB static |
| after | **6721.42 MB** | same |

Off by 20x, and it hid exactly the blowup #4782 was reporting.

## Fix

`CLRuntime` keeps a registry of live backends — they register in their constructor and drop out in their destructor — and sums their dynamic pools alongside the static buffer, image and mmap pools it owns.

Two supporting changes:

- `BufferPool` / `BufferExecutionPool` / `ImagePool` gain `residentSize()`. `mTotalSize` only ever grows (neither `recycle` nor `releaseFreeList` walks it back), so it cannot answer how much the driver still holds. `ImagePool` tracked no size at all, which is why image mode reported nothing but weights.
- The static pool is now reported via `residentSize()` too, so memory handed back is visible.

## Why a backend registry

This is the part of the change I'd most want scrutinised, so here is the reasoning.

**The reporting API is runtime-scoped, not backend-scoped.** `Session::getInfo(MEMORY)` (`source/core/Session.cpp:409-417`) walks *runtimes*:

```cpp
float summer = mRuntime.second->onGetMemoryInMB();
for (auto& r : mRuntime.first) {
    if (r.second.get() != mRuntime.second.get()) {
        summer += r.second->onGetMemoryInMB();
    }
}
```

`Session` does hold the backends, but there is no path to feed them in, so a `Runtime` has to be able to answer for every backend it created.

**Why OpenCL needs this and CPU/Metal don't.** It is an ownership asymmetry: `CPURuntime` and `MetalRuntime` own their dynamic allocators (`mDynamic`) directly, and each backend merely borrows a view of them via `createDynamicAllocator`, so their `onGetMemoryInMB` just reads its own members. OpenCL's five dynamic pools are owned by `OpenCLBackend`.

The properly aligned fix is to move those pools onto `CLRuntime` so OpenCL matches CPU and Metal. I deliberately did not do that here: it means reworking the raw `mBufferPool` pointer that swaps between the First/Second pools during resize, which is a real regression risk in exchange for no behaviour change. I'd rather that be its own PR, on top of a fix that makes the number honest first. Happy to follow up with it if you'd prefer that shape.

**Why `mutable`.** `Runtime::onCreate` is `const` in the base API (`source/core/Backend.hpp:319`), so `OpenCLBackend` only ever holds a `const CLRuntime*`. Registration therefore has to happen through a `const` method, which forces the container to be `mutable`. `CLRuntime` already carries `mMmapPool`, `mUseMmapPool` and `mLastGpuTimeMs` as `mutable` for the same reason, so this follows existing practice in the class rather than introducing it.

**Why a set rather than a single pointer.** One runtime serves many backends: multiple sessions can share a runtime, and `onCreate(config, origin)` produces backup backends too. A single pointer would silently miss every pool but the last one's.

**Why not an incrementally-maintained counter.** A running total on the runtime would have to be updated at every alloc / recycle / clear site, and any missed site produces a silently wrong number — which is precisely the bug being fixed here (one un-summed term, 20x off). Walking the live pools on demand reads the real state and cannot drift out of sync.

**The mutex** is there because `onCreate` can be called concurrently on a shared runtime from several threads; `expr/MultiThreadLoad` exercises that path.

## Testing

This **repairs `expr/MemeoryUsageTest`**, which fails on `master` under OpenCL precisely because the reported number ignored the dynamic pools — independent confirmation that the new number is the correct one. (The same test still fails on #4783 alone, which does not touch reporting; that is expected and not a regression there.)

Full OpenCL op suite on Apple M4 Pro (OpenCL 1.2):

| config | before (clean master) | after |
|---|---|---|
| buffer + `Memory_Low` | 383 passed / 2 failed | **384 / 1** |
| buffer + `Memory_Normal` | 383 / 2 | **384 / 1** |
| image + `Memory_Low` | 384 / 1 | **385 / 0** |
| CPU (regression check) | 385 / 0 | 385 / 0 |

The remaining `op/col2im` failure reproduces on clean `master` on this platform and is unrelated to this change.

## Note

`residentSize()` walks the pool maps, so it is O(number of live buffers) rather than O(1). That is a handful of entries in practice, and the call sites are `getSessionInfo` and the `MNN_PIPELINE_DEBUG` path, neither of which is hot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
