### PR TITLE
[LLM:Bugfix] Pass calibration input IDs to AWQ position IDs

### DIFF
--- a/transformers/llm/export/utils/awq_quantizer.py
+++ b/transformers/llm/export/utils/awq_quantizer.py
@@ -823,7 +823,7 @@ class AwqQuantizer:
         new_tokens = 0
         best_device = AwqQuantizer.get_best_device()
         inps = self.model.embedding(samples).to(best_device)
-        position_ids = self.model.get_position_ids(seq_len, new_tokens)
+        position_ids = self.model.get_position_ids(seq_len, new_tokens, input_ids=samples)
         rotary_pos_emb = self.model.rotary(position_ids)
         attention_mask = self.model.get_attention_mask(seq_len, new_tokens)
         layer_kwargs["rotary_pos_emb"] = rotary_pos_emb.to(best_device)


### PR DESCRIPTION
## Description

- Forward the existing calibration token IDs to get_position_ids during AWQ initialization.
- This lets multimodal visual position-ID logic inspect the calibration input instead of receiving None, fixing the initial None.flatten crash reported in #4804.
- Keep the change narrowly scoped; the separate hybrid linear-attention limitation described in the issue is not addressed here.

Fixes #4804

## Module

LLM

## Type

- [ ] Feature
- [x] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Validation

- Ran a focused Python regression harness with a multimodal-style get_position_ids implementation. It reproduced the original None.flatten failure before the change, then verified that the exact calibration input IDs are forwarded and AWQ initialization completes after the change.
- python -m py_compile transformers/llm/export/utils/awq_quantizer.py
- git diff --check

A full Qwen2.5-VL AWQ export was not run locally; this PR only claims the initial missing-input fix above.

## Checklist

- [x] Commit message follows [Module:Type] Description format
- [x] Code compiles without errors
- [x] Tested on relevant platform(s)
- [x] No unrelated format or style changes included