### PR TITLE
[LLM:Doc] Fix Web LLM demo source path

### DIFF
--- a/transformers/README.md
+++ b/transformers/README.md
@@ -163,7 +163,7 @@ make -j16
 To compile the demo:
 
 ```
-emcc ../transformers/llm/engine/llm_demo.cpp -DCMAKE_CXX_FLAGS="-msimd128 -msse4.1" -I ../include -I ../transformers/llm/engine/include libMNN.a libllm.a express/libMNN_Express.a -o llm_demo.js --preload-file ~/qwen2.0_1.5b/ -s ALLOW_MEMORY_GROWTH=1 -o llm_demo.js
+emcc ../transformers/llm/engine/demo/llm_demo.cpp -DCMAKE_CXX_FLAGS="-msimd128 -msse4.1" -I ../include -I ../transformers/llm/engine/include libMNN.a libllm.a express/libMNN_Express.a -o llm_demo.js --preload-file ~/qwen2.0_1.5b/ -s ALLOW_MEMORY_GROWTH=1 -o llm_demo.js
 ```
 
 To test the compiled demo, use the following command:


### PR DESCRIPTION
## Summary

- update the Web LLM demo compile command to reference `llm_demo.cpp` in its current `engine/demo` directory
- prevent the documented Emscripten command from failing because the old source path no longer exists

## Verification

- confirmed `transformers/llm/engine/demo/llm_demo.cpp` exists
- confirmed the old `transformers/llm/engine/llm_demo.cpp` path does not exist
- ran `git diff --check`
