### PR TITLE
[Metal:Bugfix] Restrict prefill_qk causal tile skip to DEFAULT_MASK, fix rank-3 mask_q_len

### DIFF
--- a/skills/general-debug/SKILL.md
+++ b/skills/general-debug/SKILL.md
@@ -653,6 +653,8 @@ assert (table_out - ref).abs().max() < 1e-6
 | Kernel / 路径 | 隐式假设 | 违反后现象 | 相关开关 |
 |---|---|---|---|
 | `prefill_qk[_tensor]` CAUSAL_TRI 分支 + host 侧梯形 dispatch | mask 是 causal lower-triangular（下三角内 mask=0/pass，上三角内 mask=-inf/0） | 上三角"应参与"的位置被 host 侧完全跳过 dispatch，QK 值为脏值/未初始化 → softmax 归约错误 | `MNN_METAL_QK_CAUSAL_TRI=0` 完全回退 |
+| `prefill_qk` simdgroup-matrix 整 tile causal skip（`!CAUSAL_TRI` 分支） | 门控曾写成 `DEFAULT_MASK \|\| ADD_MASK \|\| SET_MASK`，即"有 mask 输入就假定 causal" | 非 causal 张量 mask（ViT 全可见 mask）被静默改成 causal：q 的前 16 行 tile 看不到后面的 key | 已修：收窄为仅 `DEFAULT_MASK` |
+| `attention_mask_offset` 的 `mask_q_len`（`MetalAttention.mm::_writeQKVParam`） | 曾从固定下标取 q 长度，即假定张量 mask 一定是 rank-4 `[b,h,q,k]` | rank-3 `[b,q,k]` 拿到 `mask_q_len=1` ⇒ 所有 q 行都读 mask 第 0 行；全零 mask 无害，逐行变化的 mask 静默错 | 已修：改取 mask 末两维 |
 | softmax `softmax_plane[_sg]` CAUSAL_BOUND 分支 | 每行 q 只归约 `[0, causal_base + q_local)` valid prefix，之后 zero-pad 32-align | 若实际语义中 `k > q + kv_off` 处仍应 valid，其归约值为 0 → attention 分布偏移 | 同上 |
 | `prefill_qkv[_tensor]` `av_k_upper` 早退 | AV K 循环截断到 tile 内最大 valid q 对应的 causal 上界 | k 超出 av_k_upper 位置的 P·V 贡献被忽略 | 同上 |
 | Fused `prefill_flash_attn`（MetalFlashAttnShader.hpp） | `in_bounds = (kv_col_abs <= q_abs + kv_valid_offset)` 硬编码 causal | 非 causal 位置直接被 `-INFINITY` mask 掉 | `MNN_ENABLE_FLASH_ATTN_PREFILL=0` 也无用 —— **FA 本身就有此假设** |

--- a/source/backend/metal/MetalAttention.mm
+++ b/source/backend/metal/MetalAttention.mm
@@ -920,7 +920,8 @@ void AttentionBufExecution::_writeQKVParam(const std::vector<Tensor*>& inputs, i
     param->kv_align_len = mKvAlignNum;
     param->mask_batch = mHasTensorMask ? inputs[3]->length(0) : 1;
     param->mask_head_num = (mHasTensorMask && inputs[3]->dimensions() > 3) ? inputs[3]->length(1) : 1;
-    param->mask_q_len = (mHasTensorMask && inputs[3]->dimensions() > 3) ? inputs[3]->length(2) : 1;
+    // q/k are the mask's two trailing dims at any rank: [b,h,q,k] / [b,q,k] / [q,k].
+    param->mask_q_len = (mHasTensorMask && inputs[3]->dimensions() > 2) ? inputs[3]->length(inputs[3]->dimensions() - 2) : 1;
     param->mask_k_len = (mHasTensorMask && inputs[3]->dimensions() > 0) ? inputs[3]->length(inputs[3]->dimensions() - 1) : 1;
     if (mQuantValue && mKVQuantParameter != nullptr) {
         param->v_scale = mKVQuantParameter->vScale;

--- a/source/backend/metal/MetalAttentionShader.hpp
+++ b/source/backend/metal/MetalAttentionShader.hpp
@@ -550,7 +550,7 @@ kernel void prefill_qk(const device ftype* input0 [[buffer(0)]],
     const int hn = z % head_num;
     int zin = hn / param.group;
 
-#if !defined(CAUSAL_TRI) && (defined(DEFAULT_MASK) || defined(ADD_MASK) || defined(SET_MASK))
+#if !defined(CAUSAL_TRI) && defined(DEFAULT_MASK)
     // Causal skip: if this M16xN16 tile lies entirely above the diagonal in the
     // causal-mask sense, the whole tile ends up as -FLT_MAX after masking anyway.
     // Write -FLT_MAX directly and exit to save all the QK matmul work on the upper
@@ -558,9 +558,11 @@ kernel void prefill_qk(const device ftype* input0 [[buffer(0)]],
     // (With CAUSAL_TRI the host never launches these tiles and the CAUSAL_BOUND
     // softmax never reads the upper region, so this check is compiled out.)
     //
-    // Assumption: the mask provided by the LLM engine is causal-lower-triangular
-    // (which is always the case for standard causal LLM prefill).  For non-causal
-    // custom masks this optimization would over-mask.
+    // DEFAULT_MASK only: its semantics (no mask input + kv-cache) really are
+    // causal. ADD_MASK / SET_MASK carry an arbitrary per-element tensor mask --
+    // a vision encoder feeds an all-visible one and is fully bidirectional --
+    // so they must fall through to the per-element masked path below, otherwise
+    // every above-diagonal tile is silently dropped.
     {
         int tile_min_k_global = kv_start + slk * 16;
         int tile_max_q_absolute = (k_seq_len - q_seq_len) + seq_idx * q_seq_piece_len + slq * 16 + 15;

--- a/test/op/AttentionTest.cpp
+++ b/test/op/AttentionTest.cpp
@@ -626,6 +626,122 @@ SpeedAttentionTest() = default;
 
 MNNTestSuiteRegister(AttentionTest, "op/attention");
 
+// Non-causal attention with kv_cache=false driven by an explicit tensor mask --
+// the shape a ViT / vision-encoder export emits. AttentionTest's unit test 3
+// pairs kv_cache=false with *no* mask input, so this combination was previously
+// uncovered. Covers both an all-visible (all-zero ADD) mask and a row-varying
+// (causal ADD) mask, at mask rank 3 and 4.
+class AttentionNoCacheMaskTest : public MNNTestCase {
+public:
+    virtual bool run(int precision) {
+        const float tol = (precision == 2) ? 0.05f : 0.01f;
+        bool pass = true;
+        for (int seqLen : {64, 100, 128, 660}) {
+            float vis3 = maxRelError(seqLen, 12, 12, 64, 3, false);
+            float vis4 = maxRelError(seqLen, 12, 12, 64, 4, false);
+            float row3 = maxRelError(seqLen, 12, 12, 64, 3, true);
+            float row4 = maxRelError(seqLen, 12, 12, 64, 4, true);
+            MNN_PRINT("[attention_nocache_mask] seq=%4d allvisible(3d/4d)=%.6f/%.6f rowvarying(3d/4d)=%.6f/%.6f "
+                      "(tol %.3f)\n",
+                      seqLen, vis3, vis4, row3, row4, tol);
+            if (!(vis3 < tol) || !(vis4 < tol) || !(row3 < tol) || !(row4 < tol)) {
+                pass = false;
+            }
+        }
+        return pass;
+    }
+
+private:
+    // maskRank: 3 = [1,seq,seq], 4 = [1,1,seq,seq]. The no-mask form is covered by
+    // AttentionTest unit test 3; CPUAttention does not support it yet.
+    // rowVarying: false = all-zero (fully visible) ADD mask; true = causal ADD mask,
+    // which only matches if the kernel reads the mask row belonging to each query.
+    static float maxRelError(int seqLen, int numHead, int kvNumHead, int headDim, int maskRank, bool rowVarying) {
+        const int group = numHead / kvNumHead;
+        const float scale = 1.0f / sqrtf((float)headDim);
+        const float kMaskNegative = -1e9f;
+
+        uint32_t state = 12345;
+        auto next = [&state]() {
+            state = state * 1103515245u + 12345u;
+            return (float)((state >> 16) % 2000) / 1000.0f - 1.0f;
+        };
+
+        auto Q = _Input({1, seqLen, numHead, headDim}, NCHW, halide_type_of<float>());
+        auto K = _Input({1, seqLen, kvNumHead, headDim}, NCHW, halide_type_of<float>());
+        auto V = _Input({1, seqLen, kvNumHead, headDim}, NCHW, halide_type_of<float>());
+
+        std::vector<float> q(seqLen * numHead * headDim), k(seqLen * kvNumHead * headDim),
+            v(seqLen * kvNumHead * headDim);
+        for (auto& x : q) x = next();
+        for (auto& x : k) x = next();
+        for (auto& x : v) x = next();
+        ::memcpy(Q->writeMap<float>(), q.data(), q.size() * sizeof(float));
+        ::memcpy(K->writeMap<float>(), k.data(), k.size() * sizeof(float));
+        ::memcpy(V->writeMap<float>(), v.data(), v.size() * sizeof(float));
+
+        std::shared_ptr<MNN::OpT> attention(new MNN::OpT);
+        attention->type = MNN::OpType_Attention;
+        attention->main.type = MNN::OpParameter_AttentionParam;
+        attention->main.value = new MNN::AttentionParamT;
+        attention->main.AsAttentionParam()->kv_cache = false;
+
+        VARP Output;
+        {
+            auto Mask = (3 == maskRank) ? _Input({1, seqLen, seqLen}, NCHW, halide_type_of<float>())
+                                        : _Input({1, 1, seqLen, seqLen}, NCHW, halide_type_of<float>());
+            auto maskPtr = Mask->writeMap<float>();
+            for (int i = 0; i < seqLen; ++i) {
+                for (int j = 0; j < seqLen; ++j) {
+                    maskPtr[i * seqLen + j] = (rowVarying && j > i) ? kMaskNegative : 0.0f;
+                }
+            }
+            Output = Variable::create(Expr::create(attention.get(), {Q, K, V, Mask}));
+        }
+        auto got = Output->readMap<float>();
+        if (nullptr == got) {
+            MNN_ERROR("attention_nocache_mask: failed to map output\n");
+            return std::numeric_limits<float>::max();
+        }
+
+        std::vector<float> scores(seqLen);
+        float maxRel = 0.0f;
+        for (int h = 0; h < numHead; ++h) {
+            const int kvh = h / group;
+            for (int i = 0; i < seqLen; ++i) {
+                const int kEnd = rowVarying ? (i + 1) : seqLen;
+                float maxScore = -std::numeric_limits<float>::max();
+                for (int j = 0; j < kEnd; ++j) {
+                    float dot = 0.0f;
+                    for (int d = 0; d < headDim; ++d) {
+                        dot += q[(i * numHead + h) * headDim + d] * k[(j * kvNumHead + kvh) * headDim + d];
+                    }
+                    scores[j] = dot * scale;
+                    maxScore = std::max(maxScore, scores[j]);
+                }
+                float sum = 0.0f;
+                for (int j = 0; j < kEnd; ++j) {
+                    scores[j] = expf(scores[j] - maxScore);
+                    sum += scores[j];
+                }
+                for (int d = 0; d < headDim; ++d) {
+                    float acc = 0.0f;
+                    for (int j = 0; j < kEnd; ++j) {
+                        acc += scores[j] * v[(j * kvNumHead + kvh) * headDim + d];
+                    }
+                    acc /= sum;
+                    float out = got[(i * numHead + h) * headDim + d];
+                    float denom = std::max(fabsf(acc), 0.05f);
+                    maxRel = std::max(maxRel, fabsf(out - acc) / denom);
+                }
+            }
+        }
+        return maxRel;
+    }
+};
+
+MNNTestSuiteRegister(AttentionNoCacheMaskTest, "op/attention_nocache_mask");
+
 class AttentionC4Test : public AttentionTest {
 public:
     AttentionC4Test() = default;

--- a/transformers/llm/engine/src/omni.cpp
+++ b/transformers/llm/engine/src/omni.cpp
@@ -939,13 +939,22 @@ std::vector<int> Omni::qwen2VisionProcess(VARP image) {
         moduleInputs.push_back(weight_tensor);
     }
 #ifdef DEBUG_IMAGE
-    patches.fix(MNN::Express::VARP::CONSTANT);
-    patches->setName("patches");
-    position_ids.fix(MNN::Express::VARP::CONSTANT);
-    position_ids->setName("position_ids");
-    attention_mask.fix(MNN::Express::VARP::CONSTANT);
-    attention_mask->setName("attention_mask");
-    MNN::Express::Variable::save({patches, position_ids, attention_mask}, "input.mnn");
+    {
+        std::vector<MNN::Express::VARP> saveInputs;
+        for (int i = 0; i < (int)moduleInputs.size(); ++i) {
+            auto v = moduleInputs[i];
+            if (!v.fix(MNN::Express::VARP::CONSTANT)) {
+                MNN_ERROR("DEBUG_IMAGE: cannot materialize input %s, skip saving input.mnn\n", inputNames[i].c_str());
+                saveInputs.clear();
+                break;
+            }
+            v->setName(inputNames[i]);
+            saveInputs.push_back(v);
+        }
+        if (!saveInputs.empty()) {
+            MNN::Express::Variable::save(saveInputs, "input.mnn");
+        }
+    }
 #endif
     auto outputs = mVisionModule->onForward(moduleInputs);
     auto imageEmbedding = outputs[0];


### PR DESCRIPTION
Automated sync from the internal MNN development repository.

- Pending commits: 1
- Head branch: `sync/ali-to-github`
- Commit authors are preserved from the source commits.

### Commits

- `c6d72a031a` [Metal:Bugfix] Restrict prefill_qk causal tile skip to DEFAULT_MASK, fix rank-3 mask_q_len — jingbang.yjb <jingbang.yjb@alibaba-inc.com>