### PR TITLE
[LLM:Bugfix] Size DFlash verify module pool from dflash_block_size

### DIFF
--- a/transformers/llm/engine/src/llm.cpp
+++ b/transformers/llm/engine/src/llm.cpp
@@ -299,7 +299,19 @@ void Llm::setSpeculativeConfig() {
             mInSpec = false;
             return;
         }
-        mDraftLength = mConfig->draft_predict_length();
+        if (specultive_type == "dflash") {
+            // DFlash verifies a full dflash_block_size block; pool/mask/tuning
+            // key off (mDraftLength+1, all_logits), so this must be block-1.
+            int block = mConfig->dflash_block_size();
+            mDraftLength = block > 1 ? block - 1 : 1;
+            if (mConfig->config_.contains("draft_predict_length") &&
+                mConfig->draft_predict_length() != mDraftLength) {
+                MNN_PRINT("Warning: draft_predict_length is ignored for DFlash; "
+                          "verify length is dflash_block_size=%d.\n", block);
+            }
+        } else {
+            mDraftLength = mConfig->draft_predict_length();
+        }
         mInSpec = true;
     }
 }


### PR DESCRIPTION
## Description

<!-- Brief description of the changes -->

DFlash verifies a full `dflash_block_size` block in one `forwardVec`, but `setSpeculativeConfig()` set `mDraftLength` from `draft_predict_length` (default 3). Load then pre-cloned the verify module at `(4, true)`, while the first DFlash verify used `(dflash_block_size, true)` and hit:

```
Warning: module need new clone, cloning now.
```

For `speculative_type=dflash`, set `mDraftLength = dflash_block_size - 1` (e.g. block 16 → 15). `forwardVec` still verifies 16 tokens (current + 15 drafts). Downstream already uses `mDraftLength + 1` as the verify seq_len:

- module pool in `Llm::load()`
- mask / position cache in `gen_attention_mask` / `gen_position_ids`
- `Llm::tuning()`

so they align to the real block length without additional changes. DFlash generation itself uses `mBlockSize` and does not read `mDraftLength`. `draft_predict_length` remains the MTP / lookahead knob; if it is explicitly set for DFlash, it is ignored with a warning. 

This change does not affect generated text; greedy outputs match before/after.

For reference, speed before and after the change (with target `Qwen/Qwen3-4B` and draft `z-lab/Qwen3-4B-DFlash-b16`, greedy sampling, on CPU backend):

|  ID | Prompt                                                                      | Pre Prefill (tok/s) | Pre Decode (tok/s) | After Prefill (tok/s) | After Decode (tok/s) | Δ Prefill | Δ Decode |
| :-: | --------------------------------------------------------------------------- | :-----------------: | :----------------: | :-------------------: | :------------------: | :-------: | :------: |
|  01 | Write a quicksort algorithm in Python. Write code only.                     |         4.60        |        1.08        |          4.58         |         1.13         |   -0.02   |   +0.05  |
|  02 | Explain the Pythagorean theorem                                             |         3.67        |        1.13        |          3.66         |         1.13         |   -0.01   |   0.00   |
|  03 | Plan a 1 day trip to DC                                                     |         3.83        |        1.12        |          3.84         |         1.13         |   +0.01   |   +0.01  |
|  04 | Explain what a binary search tree is in 3 sentences.                        |         4.85        |        1.06        |          4.86         |         1.12         |   +0.01   |   +0.06  |
|  05 | Write a Python function that checks if a string is a palindrome. Code only. |         5.33        |        0.91        |          5.27         |         1.16         |   -0.06   |   +0.25  |
|  06 | Summarize the difference between TCP and UDP in 5 bullet points.            |         5.17        |        1.09        |          5.09         |         1.11         |   -0.08   |   +0.02  |
|  07 | Write a Fibonacci function in Python using memoization. Code only.          |         4.84        |        1.08        |          4.83         |         1.11         |   -0.01   |   +0.03  |


## Module

<!-- Which module does this PR affect? e.g. LLM, CPU, Metal, CUDA, OpenCL, Core, Infra -->

LLM

## Type

- [ ] Feature
- [x] Bugfix
- [ ] Perf
- [ ] Refact
- [ ] Style
- [ ] Doc
- [ ] Test
- [ ] Chore

## Checklist

- [x] Commit message follows `[Module:Type] Description` format
- [x] Code compiles without errors
- [x] Tested on relevant platform(s)
- [x] No unrelated format or style changes included
