### PR TITLE
[CPU:Perf] Normalize fp16 C4 LayerNorm in the packed domain instead of transposing

### DIFF
--- a/source/backend/arm82/Arm82Functions.cpp
+++ b/source/backend/arm82/Arm82Functions.cpp
@@ -257,6 +257,191 @@ static void MNNDecayRankOneUpdateFp16_Fp32Accum(float* S_, const float* k_, cons
         }
     }
 }
+
+// fp16 counterpart of MNNNormPackedFloat<Pack>, pack = 8.  Pointers are typed
+// `float*` for ABI uniformity with the fp32 slot; the memory is fp16 except for
+// gamma/beta, which CPULayerNorm keeps fp32 in every precision mode.
+//   source, residual  [UP_DIV(channels,8), batch, 8] fp16  addends, inputs[0..1]
+//   sumOut            [UP_DIV(channels,8), batch, 8] fp16  their sum, outputs[0]
+//   normOut           [UP_DIV(channels,8), batch, 8] fp16  normalized, outputs[1]
+//   gamma, beta       [channels]                    fp32  optional affine pair
+// residual/sumOut are an optional pair: both null for the plain 1-in/1-out form,
+// where source is normalized straight into normOut.
+//
+// sumOut is write-only: every statistic and normOut itself come from the fp32
+// sum recomputed by loadExact*, never from the fp16-rounded value stored there.
+static void MNNNormPackedFp16(float* normOut_, float* sumOut_, const float* source_, const float* residual_,
+                              const float* gamma, const float* beta, float epsilon, size_t batch, size_t channels,
+                              bool RMSNorm, int tId, int threadNumber) {
+    MNN_ASSERT((residual_ == nullptr) == (sumOut_ == nullptr));
+    MNN_ASSERT(threadNumber > 0);
+    constexpr size_t kPack = 8;
+    constexpr size_t kTokenTile = 4;
+    auto normOut = reinterpret_cast<__fp16*>(normOut_);
+    auto sumOut = reinterpret_cast<__fp16*>(sumOut_);
+    auto source = reinterpret_cast<const __fp16*>(source_);
+    auto residual = reinterpret_cast<const __fp16*>(residual_);
+
+    const size_t fullBlocks = channels / kPack;
+    const size_t remain = channels - fullBlocks * kPack;
+    const size_t tileCount = UP_DIV(batch, kTokenTile);
+    const bool affine = gamma != nullptr && beta != nullptr;
+    const float invChannels = 1.0f / static_cast<float>(channels);
+    // RMSNorm needs no mean, so pass 1 can accumulate the squares itself and pass 2
+    // drops out; the fp32 recompute in pass 3 then costs no more loads than a
+    // read-back of sumOut would have.
+    const bool squaresFromPass1 = RMSNorm && residual != nullptr;
+
+    auto loadExactPair = [&](size_t offset) {
+        float32x4_t value = vcvt_f32_f16(vld1_f16(source + offset));
+        if (residual != nullptr) {
+            value = vaddq_f32(value, vcvt_f32_f16(vld1_f16(residual + offset)));
+        }
+        return value;
+    };
+    auto loadExactLane = [&](size_t index) {
+        float value = static_cast<float>(source[index]);
+        if (residual != nullptr) {
+            value += static_cast<float>(residual[index]);
+        }
+        return value;
+    };
+
+    for (size_t tile = static_cast<size_t>(tId); tile < tileCount; tile += static_cast<size_t>(threadNumber)) {
+        const size_t tokenBase = tile * kTokenTile;
+        const size_t tokenCount = ALIMIN(kTokenTile, batch - tokenBase);
+        float means[kTokenTile] = {0.0f, 0.0f, 0.0f, 0.0f};
+        float32x4_t squareAcc[kTokenTile] = {vdupq_n_f32(0.0f), vdupq_n_f32(0.0f), vdupq_n_f32(0.0f),
+                                            vdupq_n_f32(0.0f)};
+        float squareSums[kTokenTile] = {0.0f, 0.0f, 0.0f, 0.0f};
+
+        // ── Pass 1: store source + residual into `sumOut`, and accumulate either the
+        //    mean (LayerNorm) or the squares (RMSNorm).  Skipped entirely for the hot
+        //    RMSNorm-without-residual case.
+        if (residual != nullptr || !RMSNorm) {
+            float32x4_t meanAcc[kTokenTile] = {vdupq_n_f32(0.0f), vdupq_n_f32(0.0f), vdupq_n_f32(0.0f),
+                                              vdupq_n_f32(0.0f)};
+            for (size_t block = 0; block < fullBlocks; ++block) {
+                for (size_t token = 0; token < tokenCount; ++token) {
+                    const size_t offset = (block * batch + tokenBase + token) * kPack;
+                    float32x4_t lo = loadExactPair(offset);
+                    float32x4_t hi = loadExactPair(offset + 4);
+                    if (residual != nullptr) {
+                        vst1_f16(sumOut + offset, vcvt_f16_f32(lo));
+                        vst1_f16(sumOut + offset + 4, vcvt_f16_f32(hi));
+                    }
+                    if (squaresFromPass1) {
+                        squareAcc[token] = vfmaq_f32(squareAcc[token], lo, lo);
+                        squareAcc[token] = vfmaq_f32(squareAcc[token], hi, hi);
+                    } else if (!RMSNorm) {
+                        meanAcc[token] = vaddq_f32(meanAcc[token], vaddq_f32(lo, hi));
+                    }
+                }
+            }
+            for (size_t token = 0; token < tokenCount; ++token) {
+                means[token] = vaddvq_f32(meanAcc[token]);
+            }
+            if (remain > 0) {
+                for (size_t token = 0; token < tokenCount; ++token) {
+                    const size_t offset = (fullBlocks * batch + tokenBase + token) * kPack;
+                    for (size_t lane = 0; lane < remain; ++lane) {
+                        const float value = loadExactLane(offset + lane);
+                        if (residual != nullptr) {
+                            sumOut[offset + lane] = static_cast<__fp16>(value);
+                        }
+                        if (squaresFromPass1) {
+                            squareSums[token] += value * value;
+                        } else if (!RMSNorm) {
+                            means[token] += value;
+                        }
+                    }
+                    if (sumOut != nullptr) {
+                        for (size_t lane = remain; lane < kPack; ++lane) {
+                            sumOut[offset + lane] = static_cast<__fp16>(0.0f);
+                        }
+                    }
+                }
+            }
+            if (!RMSNorm) {
+                for (size_t token = 0; token < tokenCount; ++token) {
+                    means[token] *= invChannels;
+                }
+            }
+        }
+
+        float32x4_t meanVec[kTokenTile];
+        for (size_t token = 0; token < tokenCount; ++token) {
+            meanVec[token] = vdupq_n_f32(means[token]);
+        }
+
+        // ── Pass 2: sum of squared deviations, unless pass 1 already has them.
+        if (!squaresFromPass1) {
+            for (size_t block = 0; block < fullBlocks; ++block) {
+                for (size_t token = 0; token < tokenCount; ++token) {
+                    const size_t offset = (block * batch + tokenBase + token) * kPack;
+                    float32x4_t lo = vsubq_f32(loadExactPair(offset), meanVec[token]);
+                    float32x4_t hi = vsubq_f32(loadExactPair(offset + 4), meanVec[token]);
+                    squareAcc[token] = vfmaq_f32(squareAcc[token], lo, lo);
+                    squareAcc[token] = vfmaq_f32(squareAcc[token], hi, hi);
+                }
+            }
+            if (remain > 0) {
+                for (size_t token = 0; token < tokenCount; ++token) {
+                    const size_t offset = (fullBlocks * batch + tokenBase + token) * kPack;
+                    for (size_t lane = 0; lane < remain; ++lane) {
+                        const float diff = loadExactLane(offset + lane) - means[token];
+                        squareSums[token] += diff * diff;
+                    }
+                }
+            }
+        }
+        float invStds[kTokenTile] = {0.0f, 0.0f, 0.0f, 0.0f};
+        for (size_t token = 0; token < tokenCount; ++token) {
+            const float squareSum = squareSums[token] + vaddvq_f32(squareAcc[token]);
+            invStds[token] = 1.0f / std::sqrt(squareSum * invChannels + epsilon);
+        }
+
+        // ── Pass 3: scale, affine, store.
+        for (size_t block = 0; block < fullBlocks; ++block) {
+            float32x4_t gammaLo, gammaHi, betaLo, betaHi;
+            if (affine) {
+                gammaLo = vld1q_f32(gamma + block * kPack);
+                gammaHi = vld1q_f32(gamma + block * kPack + 4);
+                betaLo = vld1q_f32(beta + block * kPack);
+                betaHi = vld1q_f32(beta + block * kPack + 4);
+            }
+            for (size_t token = 0; token < tokenCount; ++token) {
+                const size_t offset = (block * batch + tokenBase + token) * kPack;
+                float32x4_t lo = vsubq_f32(loadExactPair(offset), meanVec[token]);
+                float32x4_t hi = vsubq_f32(loadExactPair(offset + 4), meanVec[token]);
+                lo = vmulq_n_f32(lo, invStds[token]);
+                hi = vmulq_n_f32(hi, invStds[token]);
+                if (affine) {
+                    lo = vfmaq_f32(betaLo, lo, gammaLo);
+                    hi = vfmaq_f32(betaHi, hi, gammaHi);
+                }
+                vst1_f16(normOut + offset, vcvt_f16_f32(lo));
+                vst1_f16(normOut + offset + 4, vcvt_f16_f32(hi));
+            }
+        }
+        if (remain > 0) {
+            const size_t channelBase = fullBlocks * kPack;
+            for (size_t token = 0; token < tokenCount; ++token) {
+                const size_t offset = (fullBlocks * batch + tokenBase + token) * kPack;
+                for (size_t lane = 0; lane < remain; ++lane) {
+                    float value = (loadExactLane(offset + lane) - means[token]) * invStds[token];
+                    if (affine) {
+                        value = value * gamma[channelBase + lane] + beta[channelBase + lane];
+                    }
+                    normOut[offset + lane] = static_cast<__fp16>(value);
+                }
+                for (size_t lane = remain; lane < kPack; ++lane) {
+                    normOut[offset + lane] = static_cast<__fp16>(0.0f);
+                }
+            }
+        }
+    }
+}
 #endif // __aarch64__ && MNN_USE_NEON
 
 namespace MNN {
@@ -3042,6 +3227,13 @@ bool Arm82Functions::init() {
     FUNC_PTR_ASSIGN(gInstance->MNNFusedGatedDelta, MNNFusedGatedDeltaFp16);
 #endif
 #endif // MNN_SUPPORT_TRANSFORMER_FUSE
+
+#if defined(__aarch64__) && defined(MNN_USE_NEON)
+    // Packed-layout norm. Cannot inherit the base table's entry: that one assumes pack=4
+    // fp32 storage. Guarded like the kernel body; where it stays null CPULayerNorm's C4
+    // path reports NOT_SUPPORT rather than reading a stale fp32 entry.
+    FUNC_PTR_ASSIGN(gInstance->MNNNormPacked, MNNNormPackedFp16);
+#endif
 
     gInstance->MNNComputeMatMulForH_1 = _MNNComputeMatMulForH_1_FP16;
     gInstance->MNNComputeMatMulForE_1 = _MNNComputeMatMulForE_1_FP16;

--- a/source/backend/cpu/CPULayerNorm.cpp
+++ b/source/backend/cpu/CPULayerNorm.cpp
@@ -83,7 +83,7 @@ ErrorCode CPULayerNorm::onExecute(const std::vector<Tensor*>& inputs, const std:
         bytes = 1;
     }
 
-    if (mNeedUnpackC4 && (bytes == 2 || bytes == 4)) {
+    if (mLayoutC4 && (bytes == 2 || bytes == 4)) {
         const int batch = inputs[0]->length(0);
         const int channel = inputs[0]->length(1);
         auto inputPtr = inputs[0]->host<uint8_t>();
@@ -131,66 +131,27 @@ ErrorCode CPULayerNorm::onExecute(const std::vector<Tensor*>& inputs, const std:
             }
             return NO_ERROR;
         }
-        if (bytes == 4) {
-            auto inputFloat = reinterpret_cast<const float*>(inputPtr);
-            auto outputFloat = reinterpret_cast<float*>(outputPtr);
-            auto input1Float = reinterpret_cast<const float*>(input1Ptr);
-            auto output1Float = reinterpret_cast<float*>(output1Ptr);
-            if (core->MNNNormPacked == nullptr) {
-                return NOT_SUPPORT;
-            }
-            constexpr int tokenTile = 4;
-            const int packedTaskCount = core->pack == 4 ? UP_DIV(batch, tokenTile) : batch;
-            const int packedThreadNumber = ALIMIN(threadNumber, packedTaskCount);
-            MNN_CONCURRENCY_BEGIN(tId, packedThreadNumber) {
-                core->MNNNormPacked(output1Float != nullptr ? output1Float : outputFloat,
-                                    output1Float != nullptr ? outputFloat : nullptr, inputFloat, input1Float, gamma,
-                                    beta, mResource->mEpsilon, batch, channel, mResource->mRMSNorm, tId,
-                                    packedThreadNumber);
-            }
-            MNN_CONCURRENCY_END();
-            return NO_ERROR;
+        if (core->MNNNormPacked == nullptr) {
+            return NOT_SUPPORT;
         }
-        auto unpackedInput = mTmpUnpackedInput.ptr();
-        auto unpackedOutput = mTmpUnpackedOutput.ptr();
-        int unpackOffset[2] = {batch, channel};
-        core->MNNUnpackCUnitTranspose(reinterpret_cast<float*>(unpackedInput), reinterpret_cast<const float*>(inputPtr),
-                                      batch, channel, unpackOffset);
-        if (input1Ptr != nullptr) {
-            core->MNNUnpackCUnitTranspose(reinterpret_cast<float*>(unpackedOutput),
-                                          reinterpret_cast<const float*>(input1Ptr), batch, channel, unpackOffset);
-        }
-        auto unpackedInputLowp = reinterpret_cast<int16_t*>(unpackedInput);
-        auto unpackedOutputLowp = reinterpret_cast<int16_t*>(unpackedOutput);
-        MNN_CONCURRENCY_BEGIN(ttId, threadNumber) {
-            auto tmpInput = reinterpret_cast<float*>(mTmpInputFloat.ptr() + ttId * channel * sizeof(float));
-            auto tmpOutput = reinterpret_cast<float*>(mTmpOutputFloat.ptr() + ttId * channel * sizeof(float));
-            for (int n = ttId; n < batch; n += threadNumber) {
-                auto inputRow = unpackedInputLowp + n * channel;
-                auto outputRow = unpackedOutputLowp + n * channel;
-                core->MNNLowpToFp32(inputRow, tmpInput, channel);
-                if (input1Ptr != nullptr) {
-                    core->MNNLowpToFp32(outputRow, tmpOutput, channel);
-                    for (int c = 0; c < channel; ++c) {
-                        tmpInput[c] += tmpOutput[c];
-                    }
-                    core->MNNFp32ToLowp(tmpInput, inputRow, channel);
-                }
-                MNNNorm(tmpOutput, tmpInput, gamma, beta, mResource->mEpsilon, channel, mResource->mRMSNorm);
-                core->MNNFp32ToLowp(tmpOutput, outputRow, channel);
-            }
+        // Packed-domain norm, fp32 and fp16 alike: no unpack/repack.
+        auto inputFloat = reinterpret_cast<const float*>(inputPtr);
+        auto outputFloat = reinterpret_cast<float*>(outputPtr);
+        auto input1Float = reinterpret_cast<const float*>(input1Ptr);
+        auto output1Float = reinterpret_cast<float*>(output1Ptr);
+        // Fused 2-out form: outputs[0] is the residual sum, outputs[1] the normalized
+        // result. Plain form: outputs[0] is the normalized result and there is no sum.
+        float* normOut = output1Float != nullptr ? output1Float : outputFloat;
+        float* sumOut = output1Float != nullptr ? outputFloat : nullptr;
+        // The fp16 kernel and the pack-4 fp32 kernel both walk 4-token tiles; the
+        // AVX2 / AVX512 fp32 kernels split per token.
+        const int tokenTile = (bytes == 4 && core->pack != 4) ? 1 : 4;
+        const int packedThreadNumber = ALIMIN(threadNumber, UP_DIV(batch, tokenTile));
+        MNN_CONCURRENCY_BEGIN(tId, packedThreadNumber) {
+            core->MNNNormPacked(normOut, sumOut, inputFloat, input1Float, gamma, beta, mResource->mEpsilon, batch,
+                                channel, mResource->mRMSNorm, tId, packedThreadNumber);
         }
         MNN_CONCURRENCY_END();
-        int packOffset[2] = {channel, batch};
-        if (output1Ptr != nullptr) {
-            core->MNNPackCUnitTranspose(reinterpret_cast<float*>(outputPtr),
-                                        reinterpret_cast<const float*>(unpackedInput), batch, channel, packOffset);
-            core->MNNPackCUnitTranspose(reinterpret_cast<float*>(output1Ptr),
-                                        reinterpret_cast<const float*>(unpackedOutput), batch, channel, packOffset);
-        } else {
-            core->MNNPackCUnitTranspose(reinterpret_cast<float*>(outputPtr),
-                                        reinterpret_cast<const float*>(unpackedOutput), batch, channel, packOffset);
-        }
         return NO_ERROR;
     }
 
@@ -229,7 +190,7 @@ ErrorCode CPULayerNorm::onResize(const std::vector<Tensor*>& inputs, const std::
     mOutterSize = 1;
     mInnerSize = 1;
     const auto layout = TensorUtils::getDescribe(inputs[0])->dimensionFormat;
-    mNeedUnpackC4 = (layout == MNN_DATA_FORMAT_NC4HW4);
+    mLayoutC4 = (layout == MNN_DATA_FORMAT_NC4HW4);
     do {
         // Compute outter and inner
         int rank = inputs.at(0)->dimensions();
@@ -250,7 +211,7 @@ ErrorCode CPULayerNorm::onResize(const std::vector<Tensor*>& inputs, const std::
         for (int i = rank - mResource->mAxis; i < rank; ++i) {
             mInnerSize *= inputs.at(0)->length(i);
         }
-        if (mResource->mIniGammaBeta && !mNeedUnpackC4) {
+        if (mResource->mIniGammaBeta && !mLayoutC4) {
             MNN_ASSERT(mResource->mGamma->size() == mInnerSize * sizeof(float));
         }
     } while (false);
@@ -260,25 +221,13 @@ ErrorCode CPULayerNorm::onResize(const std::vector<Tensor*>& inputs, const std::
 
     const bool needFloatTemp = CPUBackend::getDataType(inputs[0]) == DataType_DT_INT8 ||
                                inputs[0]->getType().bytes() == 1 || bn->functions()->bytes != 4;
-    const bool needUnpackTemp = mNeedUnpackC4 && bn->functions()->bytes == 2;
     if (needFloatTemp) {
-        int tmpSize = mNeedUnpackC4 ? inputs[0]->length(1) : mInnerSize;
-        int tmpThreadNumber = mNeedUnpackC4 ? bn->threadNumber() : threadNumber;
+        int tmpSize = mLayoutC4 ? inputs[0]->length(1) : mInnerSize;
+        int tmpThreadNumber = mLayoutC4 ? bn->threadNumber() : threadNumber;
         mTmpInputFloat = buf->alloc(tmpThreadNumber * tmpSize * sizeof(float));
         mTmpOutputFloat = buf->alloc(tmpThreadNumber * tmpSize * sizeof(float));
-    }
-    if (needUnpackTemp) {
-        const int elementCount = inputs[0]->length(0) * inputs[0]->length(1);
-        mTmpUnpackedInput = buf->alloc(elementCount * sizeof(int16_t));
-        mTmpUnpackedOutput = buf->alloc(elementCount * sizeof(int16_t));
-    }
-    if (needFloatTemp) {
         buf->free(mTmpInputFloat);
         buf->free(mTmpOutputFloat);
-    }
-    if (needUnpackTemp) {
-        buf->free(mTmpUnpackedInput);
-        buf->free(mTmpUnpackedOutput);
     }
     return NO_ERROR;
 }

--- a/source/backend/cpu/CPULayerNorm.hpp
+++ b/source/backend/cpu/CPULayerNorm.hpp
@@ -39,9 +39,7 @@ private:
     int mOutterSize = 1;
     MemChunk mTmpInputFloat;
     MemChunk mTmpOutputFloat;
-    MemChunk mTmpUnpackedInput;
-    MemChunk mTmpUnpackedOutput;
-    bool mNeedUnpackC4 = false;
+    bool mLayoutC4 = false;
 };
 } // namespace MNN
 #endif /* CPULayerNorm_hpp */

--- a/source/backend/cpu/compute/CommonOptFunction.cpp
+++ b/source/backend/cpu/compute/CommonOptFunction.cpp
@@ -4773,10 +4773,10 @@ static void MNNRoPEComputeBasic(void* dst, const void* src, const void* cosEven,
 }
 
 template <int Pack>
-static void MNNNormPackedFloat(float* dest, float* sum, const float* source, const float* residual,
+static void MNNNormPackedFloat(float* normOut, float* sumOut, const float* source, const float* residual,
                                const float* gamma, const float* beta, float epsilon, size_t batch, size_t channels,
                                bool RMSNorm, int tId, int threadNumber) {
-    MNN_ASSERT((residual == nullptr) == (sum == nullptr));
+    MNN_ASSERT((residual == nullptr) == (sumOut == nullptr));
     MNN_ASSERT(threadNumber > 0);
     constexpr int tokenTile = 4;
     const size_t channelUnit = UP_DIV(channels, Pack);
@@ -4816,7 +4816,7 @@ static void MNNNormPackedFloat(float* dest, float* sum, const float* source, con
                     if (affine) {
                         value = vmlaq_f32(betaValue, value, gammaValue);
                     }
-                    vst1q_f32(dest + offset, value);
+                    vst1q_f32(normOut + offset, value);
                 }
             }
         }
@@ -4836,15 +4836,15 @@ static void MNNNormPackedFloat(float* dest, float* sum, const float* source, con
                         float value = source[offset + lane];
                         if (residual != nullptr) {
                             value += residual[offset + lane];
-                            sum[offset + lane] = value;
+                            sumOut[offset + lane] = value;
                         }
                         if (!RMSNorm) {
                             means[token] += value;
                         }
                     }
-                    if (sum != nullptr) {
+                    if (sumOut != nullptr) {
                         for (size_t lane = valid; lane < Pack; ++lane) {
-                            sum[offset + lane] = 0.0f;
+                            sumOut[offset + lane] = 0.0f;
                         }
                     }
                 }
@@ -4855,7 +4855,7 @@ static void MNNNormPackedFloat(float* dest, float* sum, const float* source, con
                 }
             }
         }
-        const float* normSource = sum != nullptr ? sum : source;
+        const float* normSource = sumOut != nullptr ? sumOut : source;
         float squareSums[tokenTile] = {0.0f, 0.0f, 0.0f, 0.0f};
         for (size_t block = 0; block < channelUnit; ++block) {
             const size_t valid = ALIMIN(static_cast<size_t>(Pack), channels - block * Pack);
@@ -4882,10 +4882,10 @@ static void MNNNormPackedFloat(float* dest, float* sum, const float* source, con
                     if (gamma != nullptr && beta != nullptr) {
                         value = value * gamma[channel] + beta[channel];
                     }
-                    dest[offset + lane] = value;
+                    normOut[offset + lane] = value;
                 }
                 for (size_t lane = valid; lane < Pack; ++lane) {
-                    dest[offset + lane] = 0.0f;
+                    normOut[offset + lane] = 0.0f;
                 }
             }
         }

--- a/source/backend/cpu/compute/CommonOptFunction.h
+++ b/source/backend/cpu/compute/CommonOptFunction.h
@@ -377,10 +377,13 @@ struct CoreFunctions {
                                float beta, float kq, size_t dk, size_t dv);
     float (*MNNNormalizeQKAndDot)(float* q, float* k, float qScale, bool useL2Norm, size_t dk);
     void (*MNNCountMaxMinValue)(const float* source, float* minVal, float* maxVal, size_t size);
-    // Packed layout is [channelUnit, batch, pack]. residual and sum are an optional pair; threads split batch work.
-    void (*MNNNormPacked)(float* dest, float* sum, const float* source, const float* residual, const float* gamma,
-                          const float* beta, float epsilon, size_t batch, size_t channels, bool RMSNorm, int tId,
-                          int threadNumber);
+    // Packed layout [UP_DIV(channels, pack), batch, pack] for source/residual/sumOut/
+    // normOut; gamma/beta are [channels]. sumOut (outputs[0], the source+residual sum)
+    // and residual are an optional pair, null for the plain form. normOut is outputs[1]
+    // when a sum is produced, outputs[0] otherwise. Threads split batch work.
+    void (*MNNNormPacked)(float* normOut, float* sumOut, const float* source, const float* residual,
+                          const float* gamma, const float* beta, float epsilon, size_t batch, size_t channels,
+                          bool RMSNorm, int tId, int threadNumber) = nullptr;
     void (*MNNDynamicUpdateConvBiasScale)(float* newbias, float* oldbias, float* weightKernelSum, float* inputZero,
                                           size_t ocQuad);
     void (*MNNAsyQuantInfo)(float* scale, float* bias, float* qscale, float* qbias, float* dstMin, float* dstMax,

--- a/source/backend/cpu/x86_x64/AVX2Functions.cpp
+++ b/source/backend/cpu/x86_x64/AVX2Functions.cpp
@@ -24,10 +24,10 @@ static void _MNNGetMatMulPackMode(int* eP, int* lP, int* hP) {
 }
 
 template <int Pack>
-static void _MNNNormPacked_Float(float* dest, float* sum, const float* source, const float* residual,
+static void _MNNNormPacked_Float(float* normOut, float* sumOut, const float* source, const float* residual,
                                  const float* gamma, const float* beta, float epsilon, size_t batch, size_t channels,
                                  bool RMSNorm, int tId, int threadNumber) {
-    MNN_ASSERT((residual == nullptr) == (sum == nullptr));
+    MNN_ASSERT((residual == nullptr) == (sumOut == nullptr));
     MNN_ASSERT(threadNumber > 0);
     const size_t channelUnit = UP_DIV(channels, Pack);
     for (size_t n = tId; n < batch; n += threadNumber) {
@@ -37,14 +37,14 @@ static void _MNNNormPacked_Float(float* dest, float* sum, const float* source, c
                 const size_t cu = c / Pack;
                 const size_t cr = c - cu * Pack;
                 const size_t index = (cu * batch + n) * Pack + cr;
-                sum[index] = source[index] + residual[index];
+                sumOut[index] = source[index] + residual[index];
             }
             for (size_t c = channels; c < channelUnit * Pack; ++c) {
                 const size_t cu = c / Pack;
                 const size_t cr = c - cu * Pack;
-                sum[(cu * batch + n) * Pack + cr] = 0.0f;
+                sumOut[(cu * batch + n) * Pack + cr] = 0.0f;
             }
-            normSource = sum;
+            normSource = sumOut;
         }
         float mean = 0.0f;
         if (!RMSNorm) {
@@ -76,12 +76,12 @@ static void _MNNNormPacked_Float(float* dest, float* sum, const float* source, c
             if (gamma && beta) {
                 norm = norm * gamma[c] + beta[c];
             }
-            dest[index] = norm;
+            normOut[index] = norm;
         }
         for (size_t c = channels; c < channelUnit * Pack; ++c) {
             const size_t cu = c / Pack;
             const size_t cr = c - cu * Pack;
-            dest[(cu * batch + n) * Pack + cr] = 0.0f;
+            normOut[(cu * batch + n) * Pack + cr] = 0.0f;
         }
     }
 }

--- a/test/op/LayerNormTest.cpp
+++ b/test/op/LayerNormTest.cpp
@@ -320,8 +320,13 @@ public:
     }
 
     virtual bool run(int precision) {
-        return runOne(2, 8, false) && runOne(3, 5, false) && runOne(13, 1024, false) && runOne(2, 8, true) &&
-               runOne(3, 5, true) && runOne(13, 1024, true) && runOne(22, 128, true, true);
+        // batch == 1 takes the flat fast path instead of the packed kernel: at one token
+        // the packed offset degenerates to the channel index.
+        return runOne(1, 8, false) && runOne(1, 5, false) && runOne(1, 1024, false) && runOne(1, 12, true) &&
+               runOne(1, 1024, true) && runOne(1, 1020, true) && runOne(1, 128, true, true) &&
+               runOne(2, 8, false) && runOne(3, 5, false) && runOne(13, 1024, false) && runOne(5, 12, false) &&
+               runOne(2, 8, true) && runOne(3, 5, true) && runOne(13, 1024, true) && runOne(5, 12, true) &&
+               runOne(7, 1020, true) && runOne(22, 128, true, true);
     }
 };
 
@@ -371,8 +376,13 @@ public:
     }
 
     virtual bool run(int precision) {
-        return runOne(2, 8, false) && runOne(3, 5, false) && runOne(13, 1024, false) && runOne(2, 8, true) &&
-               runOne(3, 5, true) && runOne(13, 1024, true);
+        // batch == 1 is the decode shape: the fused 2-in/2-out op on a single token,
+        // which takes the flat fast path rather than the packed kernel.
+        return runOne(1, 8, false) && runOne(1, 5, false) && runOne(1, 1024, false) && runOne(1, 12, true) &&
+               runOne(1, 1024, true) && runOne(1, 1020, true) &&
+               runOne(2, 8, false) && runOne(3, 5, false) && runOne(13, 1024, false) && runOne(5, 12, false) &&
+               runOne(2, 8, true) && runOne(3, 5, true) && runOne(13, 1024, true) && runOne(5, 12, true) &&
+               runOne(7, 1020, true);
     }
 };
 

--- a/transformers/llm/benchmark/llm_nightly.sh
+++ b/transformers/llm/benchmark/llm_nightly.sh
@@ -53,7 +53,7 @@ python transformers/llm/eval/evaluate_perplexity.py -m ./model/config.json | tee
 
 # 7. Eval Test
 echo ">>> Running Eval Test for Qwen3-0.6B..."
-python transformers/llm/eval/llm_eval.py -m ./model/config.json -d arc_challenge,ceval-valid --limit 20
+python transformers/llm/eval/llm_eval.py -m ./model/config.json -d arc_challenge,ceval-valid
 
 # 8. Report Summary to Aone CI
 echo ">>> Nightly Test Report"

--- a/transformers/llm/eval/llm_eval.py
+++ b/transformers/llm/eval/llm_eval.py
@@ -27,6 +27,7 @@ class MNNLM(HFLM):
         self.delta = None
         self.peft = None
         self.softmax_dtype = torch.float32
+        self.enable_thinking = None
 
     def tok_encode(
         self, string: str, left_truncate_len=None, add_special_tokens=None
@@ -43,6 +44,7 @@ class MNNLM(HFLM):
         lm_logits_list = []
         for ids in inps:
             ids_list = ids.tolist()
+            self._model.reset()
             logits = self._model.forward(ids_list)
             npy_logits = copy.deepcopy(logits.read())
             torch_logits = torch.from_numpy(npy_logits)


### PR DESCRIPTION
Automated sync from the internal MNN development repository.

- Pending commits: 1
- Head branch: `sync/ali-to-github`
- Commit authors are preserved from the source commits.

### Commits

- `f230f1586d` [CPU:Perf] Normalize fp16 C4 LayerNorm in the packed domain instead of transposing — jingbang.yjb <jingbang.yjb@alibaba-inc.com>