### PR TITLE
[Converter:Bugfix] Fail fast on invalid TFLite model and propagate optimizer failures

### DIFF
--- a/tools/converter/source/common/cli.cpp
+++ b/tools/converter/source/common/cli.cpp
@@ -700,6 +700,10 @@ bool Cli::convertModel(modelConfig& modelPath) {
     if (needOptimize) {
         std::cout << "Start to Optimize the MNN Net..." << std::endl;
         finalNet = optimizeNet(netT, modelPath.forTraining, modelPath, expectedPass);
+        if (nullptr == finalNet) {
+            MNN_ERROR("[ERROR] Optimize failed.\n");
+            return false;
+        }
         if (finalNet->extraTensorDescribe.size()>0 && expectedPass.empty()) {
             MNN_PRINT("MNN net has tensor quant info\n");
             computeUnaryBuffer(finalNet.get());

--- a/tools/converter/source/optimizer/PostConverter.cpp
+++ b/tools/converter/source/optimizer/PostConverter.cpp
@@ -599,6 +599,10 @@ bool fuseConstIntoSubgraph(MNN::NetT* net, const std::vector<MNN::SubGraphProtoT
         subnet->outputName = outputNames;
 
         std::unique_ptr<MNN::NetT> new_subnet = optimizeNetImpl(subnet, empty);
+        if (nullptr == new_subnet) {
+            MNN_ERROR("Optimize failed: subgraph %s has no op\n", mutable_subgraph->name.c_str());
+            return false;
+        }
         mutable_subgraph->nodes               = std::move(subnet->oplists);
 
         MNN::SubGraphProtoT* new_subgraph = mutable_subgraph;
@@ -672,7 +676,15 @@ std::unique_ptr<MNN::NetT> optimizeNet(std::unique_ptr<MNN::NetT>& originNet, bo
     // then subgraph depend on it may convert failed (nullptr) or wrong (error shape)
     // RunOptimize won't use subgraph, so we can do it before other subgraph optimize safely
     std::unique_ptr<MNN::NetT> net = ctx.RunOptimize(originNet, empty);
+    if (nullptr == net) {
+        MNN_ERROR("Optimize failed: the model has no op\n");
+        return nullptr;
+    }
     auto program = Program::create(net.get(), true, true);
+    if (nullptr == program) {
+        MNN_ERROR("Optimize failed: cannot create program\n");
+        return nullptr;
+    }
     auto addVars = [&](std::shared_ptr<Program> program, const std::vector<std::string>& tensorName) {
         for (const auto& iter : program->vars()) {
             if (iter.first < tensorName.size() && iter.first >= 0) {
@@ -691,6 +703,10 @@ std::unique_ptr<MNN::NetT> optimizeNet(std::unique_ptr<MNN::NetT>& originNet, bo
         CompleteSubGraph(inputs, ctx.subgraphs[idx]);
         auto new_graph = ctx.completed_subgraphs[idx];
         auto subProgram = Program::create(new_graph, true, true);
+        if (nullptr == subProgram) {
+            MNN_ERROR("Optimize failed: cannot create subgraph program\n");
+            return nullptr;
+        }
         subProgram->input(inputs, true);
         // add vars of subgraph, so inner subgraph can use them
         addVars(subProgram, new_graph->tensors);
@@ -703,6 +719,10 @@ std::unique_ptr<MNN::NetT> optimizeNet(std::unique_ptr<MNN::NetT>& originNet, bo
         CompleteSubGraph(inputs, subgraph);
     }
     net = ctx.RunOptimize(net, empty);
+    if (nullptr == net) {
+        MNN_ERROR("Optimize failed: the model has no op\n");
+        return nullptr;
+    }
 
     fuseConstIntoSubgraph(net.get(), ctx.completed_subgraphs);
     for (auto* subgraph : ctx.completed_subgraphs) {

--- a/tools/converter/source/optimizer/Program.cpp
+++ b/tools/converter/source/optimizer/Program.cpp
@@ -19,21 +19,21 @@ using namespace MNN;
 namespace MNN {
 namespace Express {
 
-void Program::createUnit(std::map<int, VARP>& varMap, std::vector<int>& inputIndexes, const std::vector<std::unique_ptr<OpT>>& oplists, MNN::OpT* op, const MNN::NetT* net, std::set<OpT*>& invalidSet, std::set<int>& extraInputIndexes) {
-    createUnit(varMap, inputIndexes, oplists, op, net->tensorName, invalidSet, extraInputIndexes, net);
+bool Program::createUnit(std::map<int, VARP>& varMap, std::vector<int>& inputIndexes, const std::vector<std::unique_ptr<OpT>>& oplists, MNN::OpT* op, const MNN::NetT* net, std::set<OpT*>& invalidSet, std::set<int>& extraInputIndexes) {
+    return createUnit(varMap, inputIndexes, oplists, op, net->tensorName, invalidSet, extraInputIndexes, net);
 }
 
-void Program::createUnit(std::map<int, VARP>& varMap, std::vector<int>& inputIndexes, const std::vector<std::unique_ptr<OpT>>& oplists,
+bool Program::createUnit(std::map<int, VARP>& varMap, std::vector<int>& inputIndexes, const std::vector<std::unique_ptr<OpT>>& oplists,
                     MNN::OpT* op, const std::vector<std::string>& tensorName, std::set<OpT*>& invalidSet, std::set<int>& extraInputIndexes, const MNN::NetT* net, std::map<std::string, int> TensorDescribeName) {
     if (invalidSet.find(op) != invalidSet.end()) {
-        return;
+        return true;
     }
     std::vector<VARP> inputVars;
     auto outputIndexes = op->outputIndexes;
     for (int j = 0; j < outputIndexes.size(); ++j) {
         if (varMap.find(outputIndexes[j]) != varMap.end()) {
             // Don't support multi op output to one index
-            return;
+            return false;
         }
     }
     invalidSet.insert(op);
@@ -46,7 +46,9 @@ void Program::createUnit(std::map<int, VARP>& varMap, std::vector<int>& inputInd
             for (int j = 0; j < oplists.size(); ++j) {
                 for (auto outputIndex : oplists[j]->outputIndexes) {
                     if (outputIndex == input) {
-                        createUnit(varMap, inputIndexes, oplists, oplists[j].get(), tensorName, invalidSet, extraInputIndexes, net, TensorDescribeName);
+                        if (!createUnit(varMap, inputIndexes, oplists, oplists[j].get(), tensorName, invalidSet, extraInputIndexes, net, TensorDescribeName)) {
+                            return false;
+                        }
                     }
                 }
             }
@@ -62,6 +64,10 @@ void Program::createUnit(std::map<int, VARP>& varMap, std::vector<int>& inputInd
         inputVars.emplace_back(varMap[input]);
     }
     auto expr = Expr::create(op, inputVars, outputIndexes.size());
+    if (nullptr == expr) {
+        MNN_ERROR("Create expr for op %s failed\n", op->name.c_str());
+        return false;
+    }
     expr->setName(op->name);
     for (int j = 0; j < outputIndexes.size(); ++j) {
         if (op->type == OpType_Input) {
@@ -74,13 +80,16 @@ void Program::createUnit(std::map<int, VARP>& varMap, std::vector<int>& inputInd
 //            int idx = outputIndexes[j];
             if (TensorDescribeName.find(newVar->name()) != TensorDescribeName.end()) {
                 int idx = TensorDescribeName[newVar->name()];
-                float scale = extraDescribes[idx]->quantInfo->scale;
-                float zero = extraDescribes[idx]->quantInfo->zero;
-                newVar->writeScaleMap(scale, zero);
+                if (idx >= 0 && idx < (int)extraDescribes.size() && extraDescribes[idx] && extraDescribes[idx]->quantInfo) {
+                    float scale = extraDescribes[idx]->quantInfo->scale;
+                    float zero = extraDescribes[idx]->quantInfo->zero;
+                    newVar->writeScaleMap(scale, zero);
+                }
             }
         }
         varMap[outputIndexes[j]] = newVar;
     }
+    return true;
 }
 
 VARPS Program::input(const std::unordered_map<std::string, VARP>& inputs, bool lazy) {
@@ -98,6 +107,10 @@ void Program::save(MNN::NetT* net) {
 }
 
 std::shared_ptr<Program> Program::create(const MNN::NetT* net, bool supportExtra, bool saveAllVars) {
+    if (nullptr == net) {
+        MNN_ERROR("Program::create: net is null\n");
+        return nullptr;
+    }
     return create(net->oplists, net->tensorName, net->outputName, supportExtra, saveAllVars, net);
 }
 
@@ -121,7 +134,10 @@ std::shared_ptr<Program> Program::create(const std::vector<std::unique_ptr<OpT>>
     }
     for (int index = 0; index < oplists.size(); ++index) {
         std::set<OpT*> invalidSet;
-        createUnit(varMap, inputIndexes, oplists, oplists[index].get(), tensorName, invalidSet, extraInputIndexes, net, TensorDescribeName);
+        if (!createUnit(varMap, inputIndexes, oplists, oplists[index].get(), tensorName, invalidSet, extraInputIndexes, net, TensorDescribeName)) {
+            MNN_ERROR("Program::create: failed to create op %s\n", oplists[index]->name.c_str());
+            return nullptr;
+        }
     }
     std::map<std::string, VARP> outputs;
     if (outputName.empty()) {

--- a/tools/converter/source/optimizer/Program.cpp
+++ b/tools/converter/source/optimizer/Program.cpp
@@ -32,8 +32,9 @@ bool Program::createUnit(std::map<int, VARP>& varMap, std::vector<int>& inputInd
     auto outputIndexes = op->outputIndexes;
     for (int j = 0; j < outputIndexes.size(); ++j) {
         if (varMap.find(outputIndexes[j]) != varMap.end()) {
-            // Don't support multi op output to one index
-            return false;
+            // Output may already exist when a dependency was created recursively while
+            // visiting an earlier op in oplists (graph is not necessarily topologically sorted).
+            return true;
         }
     }
     invalidSet.insert(op);

--- a/tools/converter/source/optimizer/Program.hpp
+++ b/tools/converter/source/optimizer/Program.hpp
@@ -27,7 +27,7 @@ public:
         return mOutputs;
     }
     VARPS input(const std::unordered_map<std::string, VARP>& inputs, bool lazy = false);
-    static void createUnit(std::map<int, VARP>& varMap, std::vector<int>& inputIndexes, const std::vector<std::unique_ptr<OpT>>& oplists, MNN::OpT* op, const MNN::NetT* net, std::set<OpT*>& invalidSet, std::set<int>& extraInputIndexes);
+    static bool createUnit(std::map<int, VARP>& varMap, std::vector<int>& inputIndexes, const std::vector<std::unique_ptr<OpT>>& oplists, MNN::OpT* op, const MNN::NetT* net, std::set<OpT*>& invalidSet, std::set<int>& extraInputIndexes);
 
     const std::map<int, VARP>& vars() const {
         return mVars;
@@ -36,7 +36,7 @@ public:
     void save(MNN::NetT* net);
 private:
     static std::shared_ptr<Program> create(const std::vector<std::unique_ptr<OpT>>& oplists, const std::vector<std::string>& tensorName, const std::vector<std::string>& outputName, bool supportExtra, bool saveAllVars, const MNN::NetT* net=nullptr);
-    static void createUnit(std::map<int, VARP>& varMap, std::vector<int>& inputIndexes, const std::vector<std::unique_ptr<OpT>>& oplists, MNN::OpT* op, const std::vector<std::string>& tensorName, std::set<OpT*>& invalidSet, std::set<int>& extraInputIndexes, const MNN::NetT* net=nullptr, std::map<std::string, int> TensorDescribeName = {});
+    static bool createUnit(std::map<int, VARP>& varMap, std::vector<int>& inputIndexes, const std::vector<std::unique_ptr<OpT>>& oplists, MNN::OpT* op, const std::vector<std::string>& tensorName, std::set<OpT*>& invalidSet, std::set<int>& extraInputIndexes, const MNN::NetT* net=nullptr, std::map<std::string, int> TensorDescribeName = {});
     Program() {
     }
     std::map<int, VARP> mVars;

--- a/tools/converter/source/tflite/liteConverter.cpp
+++ b/tools/converter/source/tflite/liteConverter.cpp
@@ -8,6 +8,7 @@
 
 #include <iostream>
 #include <functional>
+#include <stdint.h>
 #include "logkit.h"
 #include "flatbuffers/idl.h"
 #include "flatbuffers/minireflect.h"
@@ -23,6 +24,28 @@ static bool invalidTfliteIndex(const char* what, int index, int size) {
         return true;
     }
     return false;
+}
+
+// Keep in sync with MNN_MAX_TENSOR_DIM in source/core/TensorUtils.hpp
+static const int kMaxTfliteTensorDim = 9;
+static bool validTfliteShape(const std::vector<int>& shape) {
+    if ((int)shape.size() > kMaxTfliteTensorDim) {
+        return false;
+    }
+    int64_t prod = 1;
+    for (size_t i = 0; i < shape.size(); ++i) {
+        int d = shape[i];
+        if (d < -1) {
+            return false;
+        }
+        if (d > 0) {
+            if (prod > (int64_t)INT32_MAX / d) {
+                return false;
+            }
+            prod *= d;
+        }
+    }
+    return true;
 }
 
 class TfliteModel {
@@ -210,6 +233,11 @@ int tflite2MNNNet(const std::string inputModel, const std::string bizCode,
     auto model                   = std::shared_ptr<TfliteModel>(new TfliteModel(model_name));
     model->readModel();
     auto& tfliteModel = model->get();
+    if (nullptr == tfliteModel) {
+        MNN_ERROR("[ERROR] Invalid TFLite Model:%s\n", inputModel.c_str());
+        MNNNetT.reset();
+        return 1;
+    }
 
     const auto& tfliteOpSet = tfliteModel->operator_codes;
     // const auto operatorCodesSize = tfliteOpSet.size();
@@ -220,10 +248,20 @@ int tflite2MNNNet(const std::string inputModel, const std::string bizCode,
     // use the weight's data type of Conv2D|DepthwiseConv2D to decide quantizedModel mode
     int quantizedModel = 0;
     for (int i = 0; i < subGraphsSize; ++i) {
+        if (nullptr == tfliteModel->subgraphs[i]) {
+            MNN_ERROR("[ERROR] Invalid TFLite Model: null subgraph\n");
+            MNNNetT.reset();
+            return 1;
+        }
         const auto& ops     = tfliteModel->subgraphs[i]->operators;
         const auto& tensors = tfliteModel->subgraphs[i]->tensors;
         const int opNums    = static_cast<int>(ops.size());
         for (int j = 0; j < opNums; ++j) {
+            if (nullptr == ops[j]) {
+                MNN_ERROR("[ERROR] Invalid TFLite Model: null operator\n");
+                MNNNetT.reset();
+                return 1;
+            }
             const int opcodeIndex = ops[j]->opcode_index;
             if (invalidTfliteIndex("opcode", opcodeIndex, static_cast<int>(tfliteOpSet.size()))) {
                 MNNNetT.reset();
@@ -255,8 +293,21 @@ int tflite2MNNNet(const std::string inputModel, const std::string bizCode,
     auto& buffers = tfliteModel->buffers;
 
     for (int i = 0; i < subGraphsSize; ++i) {
+        if (nullptr == tfliteModel->subgraphs[i]) {
+            MNN_ERROR("[ERROR] Invalid TFLite Model: null subgraph\n");
+            MNNNetT.reset();
+            return 1;
+        }
         const auto& ops     = tfliteModel->subgraphs[i]->operators;
         const auto& tensors = tfliteModel->subgraphs[i]->tensors;
+        for (size_t t = 0; t < tensors.size(); ++t) {
+            const auto* tensor = tfliteAt(tensors, static_cast<int>(t), "tensor");
+            if (nullptr == tensor || !validTfliteShape(tensor->shape)) {
+                MNN_ERROR("[ERROR] Invalid TFLite Model: tensor %zu has invalid shape\n", t);
+                MNNNetT.reset();
+                return 1;
+            }
+        }
 
         // set const
         std::vector<bool> extractedTensors(tfliteModel->subgraphs[i]->tensors.size(), false);
@@ -293,12 +344,22 @@ int tflite2MNNNet(const std::string inputModel, const std::string bizCode,
             MNNNetT->outputName.push_back(outputTensor->name);
         }
         // tensor names
-        for (const auto& tensor : tensors) {
+        for (size_t t = 0; t < tensors.size(); ++t) {
+            const auto* tensor = tfliteAt(tensors, static_cast<int>(t), "tensor");
+            if (nullptr == tensor) {
+                MNNNetT.reset();
+                return 1;
+            }
             MNNNetT->tensorName.push_back(tensor->name);
         }
 
         const int opNums = ops.size();
         for (int j = 0; j < opNums; ++j) {
+            if (nullptr == ops[j]) {
+                MNN_ERROR("[ERROR] Invalid TFLite Model: null operator\n");
+                MNNNetT.reset();
+                return 1;
+            }
             const int opcodeIndex = ops[j]->opcode_index;
             if (invalidTfliteIndex("opcode", opcodeIndex, static_cast<int>(tfliteOpSet.size()))) {
                 MNNNetT.reset();
@@ -427,7 +488,7 @@ int tflite2MNNNet(const std::string inputModel, const std::string bizCode,
                     return;
                 }
                 auto quant = tensor->quantization.get();
-                if (!quant) {
+                if (!quant || quant->scale.empty() || quant->zero_point.empty()) {
                     return;
                 }
                 std::unique_ptr<MNN::TensorDescribeT> tensorDescribe(new MNN::TensorDescribeT);
@@ -464,6 +525,11 @@ int tflite2MNNNet(const std::string inputModel, const std::string bizCode,
         }
     }
 
+    if (MNNNetT->oplists.empty()) {
+        MNN_ERROR("[ERROR] Invalid TFLite Model: no operator\n");
+        MNNNetT.reset();
+        return 1;
+    }
     MNNNetT->sourceType = MNN::NetSource_TFLITE;
     MNNNetT->bizCode    = bizCode;
 
@@ -478,18 +544,28 @@ TfliteModel::~TfliteModel() {
 
 void TfliteModel::readModel() {
     std::ifstream inputFile(_modelName, std::ios::binary);
+    if (!inputFile) {
+        MNN_ERROR("[ERROR] Cannot open TFLite model: %s\n", _modelName.c_str());
+        return;
+    }
     inputFile.seekg(0, std::ios::end);
     const auto size = inputFile.tellg();
+    if (size <= 0) {
+        MNN_ERROR("[ERROR] Invalid TFLite Model: empty file\n");
+        return;
+    }
     inputFile.seekg(0, std::ios::beg);
 
     char* buffer = new char[size];
     inputFile.read(buffer, size);
     inputFile.close();
 
-    // verify model
+    // verify model; do not UnPack a failed buffer (LOG(FATAL) does not abort)
     flatbuffers::Verifier verify((uint8_t*)buffer, size);
     if (!tflite::VerifyModelBuffer(verify)) {
-        LOG(FATAL) << "TFlite model version ERROR!";
+        MNN_ERROR("[ERROR] Invalid TFLite Model buffer\n");
+        delete[] buffer;
+        return;
     }
 
     _tfliteModel = tflite::UnPackModel(buffer);


### PR DESCRIPTION
## Summary

Narrowed per maintainer review on #4830 (rebased onto master after #4834).

**In scope (this PR):**
- `TfliteModel::readModel()` fail-fast: handle missing/empty files, reject unverified buffers without calling `UnPackModel` (root cause of #4798 SEGV when `LOG(FATAL)` does not abort).
- `tflite2MNNNet()` hard errors for null model, null subgraph/operator, invalid tensor shapes, empty `oplists` — reuses `tfliteAt<>()` from #4834 (no parallel index checks, no silent `continue`).
- `Program::createUnit` propagates `Expr::create` failure; `Program::create` returns `nullptr` so optimize/convert aborts cleanly instead of leaving holes in `varMap`.
- `optimizeNet` / `cli` null checks when program creation or optimization fails.

**Deferred to follow-up PRs (per review):**
- `express/Expr.cpp` null guards + `expr/create_guard` test
- `MNNMemoryUtils.cpp` overflow guard only (without `0 == size → NULL`)
- ONNX unresolved-input hard error (pending conversion regression)

## Test plan
- [ ] Malformed TFLite reproducers from #4798 fail with conversion errors (no SEGV)
- [ ] Converter build with `-DMNN_BUILD_CONVERTER=ON`

Fixes #4798 (converter path)