### PR TITLE
[Converter:Bugfix] Fail fast on out-of-range TFLite tensor/buffer indices

### DIFF
--- a/tools/converter/source/tflite/ConvolutionTflite.cpp
+++ b/tools/converter/source/tflite/ConvolutionTflite.cpp
@@ -33,14 +33,27 @@ void Conv2DTflite::run(MNN::OpT* dstOp, const std::unique_ptr<tflite::OperatorT>
                        const std::vector<std::unique_ptr<tflite::OperatorCodeT>>& tfliteOpSet, int quantizedModel) {
     // 3|2 inputs: input tensor, weight, (bias)
     const int inputSize = tfliteOp->inputs.size();
-    DCHECK(inputSize == 2 || inputSize == 3) << "tflite Conv2D input ERROR! ";
+    if (inputSize < 2 || tfliteOp->outputs.empty()) {
+        MNN_ERROR("[ERROR] Invalid TFLite Model: Conv2D has invalid inputs or outputs\n");
+        dstOp->type = MNN::OpType_MAX;
+        return;
+    }
     const auto& tfliteConvOption = tfliteOp->builtin_options.AsConv2DOptions();
     const int inputIndex     = tfliteOp->inputs[0];
     const int weightIndex    = tfliteOp->inputs[1];
     const int outputIndex    = tfliteOp->outputs[0];
-    const auto& inputTensor  = tfliteTensors[inputIndex];
-    const auto& weightTensor = tfliteTensors[weightIndex];
-    const auto& outputTensor = tfliteTensors[outputIndex];
+    const auto* inputTensor  = tfliteAt(tfliteTensors, inputIndex, "tensor");
+    const auto* weightTensor = tfliteAt(tfliteTensors, weightIndex, "tensor");
+    const auto* outputTensor = tfliteAt(tfliteTensors, outputIndex, "tensor");
+    if (nullptr == inputTensor || nullptr == weightTensor || nullptr == outputTensor) {
+        dstOp->type = MNN::OpType_MAX;
+        return;
+    }
+    const auto* weightBuffer = tfliteAt(tfliteModelBuffer, static_cast<int>(weightTensor->buffer), "buffer");
+    if (nullptr == weightBuffer) {
+        dstOp->type = MNN::OpType_MAX;
+        return;
+    }
     if (weightTensor->type == tflite::TensorType_INT8 || weightTensor->type == tflite::TensorType_INT4) {
         quantizedModel = 2;
         dstOp->type = MNN::OpType_Convolution;
@@ -146,7 +159,7 @@ void Conv2DTflite::run(MNN::OpT* dstOp, const std::unique_ptr<tflite::OperatorT>
         filter_hwcn.resize(weightSize);
         for (int i = 0; i < out_size; i++) {
             for (int j = 0; j < in_size; j++) {
-                filter_hwcn[i * in_size + j] = tfliteModelBuffer[weightTensor->buffer]->data[i + j * out_size];
+                filter_hwcn[i * in_size + j] = weightBuffer->data[i + j * out_size];
             }
         }
         conv2dParamQuan->weight = filter_hwcn;
@@ -202,20 +215,20 @@ void Conv2DTflite::run(MNN::OpT* dstOp, const std::unique_ptr<tflite::OperatorT>
         }
 
         // weight
-        if (tfliteModelBuffer[weightTensor->buffer]->data.data() == nullptr) {
+        if (weightBuffer->data.data() == nullptr) {
             //MNN_ERROR("Has not const weight data for tflite convolution\n");
             dstOp->main.value = convolution2DQuant.release();
             return;
         }
         std::vector<int8_t> weightTmp;
-        auto weight = reinterpret_cast<const int8_t*>(tfliteModelBuffer[weightTensor->buffer]->data.data());
+        auto weight = reinterpret_cast<const int8_t*>(weightBuffer->data.data());
         if (weightTensor->type == tflite::TensorType_INT4) {
             // Add one to assume has enough memory
             weightTmp.resize(weightSize + 1);
-            auto originSize = tfliteModelBuffer[weightTensor->buffer]->data.size();
+            auto originSize = weightBuffer->data.size();
             // Int4 -> Int8
             int halfSize = (weightSize + 1) / 2;
-            auto srcInt4 = reinterpret_cast<const uint8_t*>(tfliteModelBuffer[weightTensor->buffer]->data.data());
+            auto srcInt4 = reinterpret_cast<const uint8_t*>(weightBuffer->data.data());
             for (int v=0; v<halfSize; ++v) {
                 int srcValue = srcInt4[v];
                 weightTmp[2 * v] = srcValue & 0x0F;
@@ -230,7 +243,7 @@ void Conv2DTflite::run(MNN::OpT* dstOp, const std::unique_ptr<tflite::OperatorT>
             weight = weightTmp.data();
         } else {
             MNN_ASSERT(weightTensor->type == tflite::TensorType_INT8);
-            MNN_ASSERT(tfliteModelBuffer[weightTensor->buffer]->data.size() == weightSize);
+            MNN_ASSERT(weightBuffer->data.size() == weightSize);
         }
 
         MNN_ASSERT(weightTensor->quantization->scale.size() == co);
@@ -295,7 +308,7 @@ void Conv2DTflite::run(MNN::OpT* dstOp, const std::unique_ptr<tflite::OperatorT>
         }
 
         // weight
-        if (tfliteModelBuffer[weightTensor->buffer]->data.data() == nullptr) {
+        if (weightBuffer->data.data() == nullptr) {
             //MNN_ERROR("Has not const weight data for tflite convolution\n");
             dstOp->main.value = convolution2DFloat.release();
             return;
@@ -305,13 +318,13 @@ void Conv2DTflite::run(MNN::OpT* dstOp, const std::unique_ptr<tflite::OperatorT>
         switch (weightTensor->type) {
             case tflite::TensorType_FLOAT32:
             {
-                auto originalWeightPtr = reinterpret_cast<const float*>(tfliteModelBuffer[weightTensor->buffer]->data.data());
+                auto originalWeightPtr = reinterpret_cast<const float*>(weightBuffer->data.data());
                 convertDataFormatTflite(originalWeightPtr, weightData.data(), kh, kw, ci, co);
                 break;
             }
             case tflite::TensorType_UINT8:
             {
-                auto originalWeightPtr = reinterpret_cast<const int8_t*>(tfliteModelBuffer[weightTensor->buffer]->data.data());
+                auto originalWeightPtr = reinterpret_cast<const int8_t*>(weightBuffer->data.data());
                 convertDataFormatTfliteDequant<int8_t>(originalWeightPtr, weightData.data(), kh, kw, ci, co, weightTensor->quantization.get());
                 break;
             }

--- a/tools/converter/source/tflite/ResizeBilinear.cpp
+++ b/tools/converter/source/tflite/ResizeBilinear.cpp
@@ -30,18 +30,44 @@ void ResizeBilinear::run(MNN::OpT *dstOp, const std::unique_ptr<tflite::Operator
                          const std::vector<std::unique_ptr<tflite::BufferT> > &tfliteModelBuffer,
                          const std::vector<std::unique_ptr<tflite::OperatorCodeT> > &tfliteOpSet, int quantizedModel) {
     DCHECK(!quantizedModel);
+    if (tfliteOp->inputs.size() < 2 || tfliteOp->outputs.empty()) {
+        MNN_ERROR("[ERROR] Invalid TFLite Model: Resize has invalid inputs or outputs\n");
+        dstOp->type = MNN::OpType_MAX;
+        return;
+    }
     auto resizeParam         = new MNN::InterpT;
-    const auto &scaleTensor  = tfliteTensors[tfliteOp->inputs[1]];
+    const auto* scaleTensor  = tfliteAt(tfliteTensors, tfliteOp->inputs[1], "tensor");
+    if (nullptr == scaleTensor) {
+        dstOp->type = MNN::OpType_MAX;
+        return;
+    }
+    if (tfliteOp->opcode_index < 0 || tfliteOp->opcode_index >= static_cast<int>(tfliteOpSet.size()) ||
+        tfliteOpSet[tfliteOp->opcode_index] == nullptr) {
+        MNN_ERROR("[ERROR] Invalid TFLite Model: opcode index %d out of range (size %zu)\n", tfliteOp->opcode_index,
+                  tfliteOpSet.size());
+        dstOp->type = MNN::OpType_MAX;
+        return;
+    }
     auto code = liteOpConverter::getOpCode(tfliteOpSet[tfliteOp->opcode_index].get());
     if (BuiltinOperator_RESIZE_NEAREST_NEIGHBOR == code) {
-        const auto& nearest = tfliteOp->builtin_options.AsResizeNearestNeighborOptions();
+        const auto* nearest = tfliteOp->builtin_options.AsResizeNearestNeighborOptions();
+        if (nullptr == nearest) {
+            MNN_ERROR("[ERROR] Invalid TFLite Model: Resize missing options\n");
+            dstOp->type = MNN::OpType_MAX;
+            return;
+        }
         resizeParam->resizeType   = 1;
         resizeParam->alignCorners = nearest->align_corners;
         if (nearest->half_pixel_centers) {
             resizeParam->ctm = MNN::CoordinateTransformationMode_HalfPixels;
         }
     } else if (BuiltinOperator_RESIZE_BILINEAR == code) {
-        const auto& resizeOption = tfliteOp->builtin_options.AsResizeBilinearOptions();
+        const auto* resizeOption = tfliteOp->builtin_options.AsResizeBilinearOptions();
+        if (nullptr == resizeOption) {
+            MNN_ERROR("[ERROR] Invalid TFLite Model: Resize missing options\n");
+            dstOp->type = MNN::OpType_MAX;
+            return;
+        }
         resizeParam->resizeType   = 2;
         resizeParam->alignCorners = resizeOption->align_corners;
         if (resizeOption->half_pixel_centers) {
@@ -50,7 +76,18 @@ void ResizeBilinear::run(MNN::OpT *dstOp, const std::unique_ptr<tflite::Operator
     } else {
         DCHECK(false);
     }
-    auto scaleDataPtr        = reinterpret_cast<const int *>(tfliteModelBuffer[scaleTensor->buffer]->data.data());
+    const auto* scaleBuffer = tfliteAt(tfliteModelBuffer, static_cast<int>(scaleTensor->buffer), "buffer");
+    if (nullptr == scaleBuffer || scaleBuffer->data.empty()) {
+        MNN_ERROR("[ERROR] Invalid TFLite Model: Resize scale buffer is empty\n");
+        dstOp->type = MNN::OpType_MAX;
+        return;
+    }
+    auto scaleDataPtr        = reinterpret_cast<const int *>(scaleBuffer->data.data());
+    if (scaleBuffer->data.size() < 2 * sizeof(int)) {
+        MNN_ERROR("[ERROR] Invalid TFLite Model: Resize scale buffer is too small\n");
+        dstOp->type = MNN::OpType_MAX;
+        return;
+    }
 
     resizeParam->outputHeight = scaleDataPtr[0];
     resizeParam->outputWidth  = scaleDataPtr[1];

--- a/tools/converter/source/tflite/TfliteUtils.hpp
+++ b/tools/converter/source/tflite/TfliteUtils.hpp
@@ -13,6 +13,7 @@
 
 #include "MNN_generated.h"
 #include "schema_generated.h"
+#include "MNN/MNNDefine.h"
 #include "logkit.h"
 
 typedef std::unique_ptr<tflite::QuantizationParametersT> tfliteQuanParam;
@@ -58,5 +59,14 @@ bool convertDataFormatTfliteDequant(const T* src, float* dst, int KH, int KW, in
 MNN::DataType TfliteDataTypeToMNN(tflite::TensorType type);
 
 MNN::DataType TfliteDequantDataTypeToMNN(tflite::TensorType type);
+
+template <typename T>
+inline const T* tfliteAt(const std::vector<std::unique_ptr<T>>& v, int i, const char* what) {
+    if (i < 0 || i >= static_cast<int>(v.size()) || v[i] == nullptr) {
+        MNN_ERROR("[ERROR] Invalid TFLite Model: %s index %d out of range (size %zu)\n", what, i, v.size());
+        return nullptr;
+    }
+    return v[i].get();
+}
 
 #endif /* TfliteUtils_hpp */

--- a/tools/converter/source/tflite/liteConverter.cpp
+++ b/tools/converter/source/tflite/liteConverter.cpp
@@ -15,6 +15,16 @@
 
 #include "liteConverter.hpp"
 #include "liteOpConverter.hpp"
+#include "TfliteUtils.hpp"
+
+static bool invalidTfliteIndex(const char* what, int index, int size) {
+    if (index < 0 || index >= size) {
+        MNN_ERROR("[ERROR] Invalid TFLite Model: %s index %d out of range (size %d)\n", what, index, size);
+        return true;
+    }
+    return false;
+}
+
 class TfliteModel {
 public:
     TfliteModel() = delete;
@@ -69,17 +79,25 @@ bool dumpTflite2Json(const char* modelFile, const char* jsonFile) {
     return true;
 }
 
-static void _converteConstantDataToMNNConstantNode(
+static bool _converteConstantDataToMNNConstantNode(
     int tensorIndex, const std::vector<std::unique_ptr<tflite::TensorT>>& tfliteTensors,
     const std::vector<std::unique_ptr<tflite::BufferT>>& tfliteModelBuffers, std::unique_ptr<MNN::NetT>& MNNNetT) {
+    const auto* tensor = tfliteAt(tfliteTensors, tensorIndex, "tensor");
+    if (nullptr == tensor) {
+        return false;
+    }
+    const int bufferIndex = static_cast<int>(tensor->buffer);
+    const auto* buffer = tfliteAt(tfliteModelBuffers, bufferIndex, "buffer");
+    if (nullptr == buffer) {
+        return false;
+    }
     // check whether buffer data size is greater than zero,
     // if size > 0, then this tensor is Constant, convete this tensor to be MNN Constant node
-    const auto& tensor         = tfliteTensors[tensorIndex];
-    const uint32_t bufferIndex = tensor->buffer;
-    const auto tensorBuffer    = tfliteModelBuffers[bufferIndex]->data;
-    const auto bufferSize      = tensorBuffer.size();
-    if (bufferSize == 0)
-        return;
+    const auto& tensorBuffer = buffer->data;
+    const auto bufferSize = tensorBuffer.size();
+    if (bufferSize == 0) {
+        return true;
+    }
 
     // this is Constant data
     std::unique_ptr<MNN::OpT> mnnConstantOp(new MNN::OpT);
@@ -107,6 +125,7 @@ static void _converteConstantDataToMNNConstantNode(
 
     MNNNetT->tensorName.emplace_back(mnnConstantOp->name);
     MNNNetT->oplists.emplace_back(std::move(mnnConstantOp));
+    return true;
 }
 template<typename SRC, typename DST>
 void convert(const SRC* s, DST* d, size_t sizeInBytes) {
@@ -206,11 +225,25 @@ int tflite2MNNNet(const std::string inputModel, const std::string bizCode,
         const int opNums    = static_cast<int>(ops.size());
         for (int j = 0; j < opNums; ++j) {
             const int opcodeIndex = ops[j]->opcode_index;
+            if (invalidTfliteIndex("opcode", opcodeIndex, static_cast<int>(tfliteOpSet.size()))) {
+                MNNNetT.reset();
+                return 1;
+            }
             auto opCode     = liteOpConverter:: getOpCode(tfliteOpSet[opcodeIndex].get());
             if (opCode == tflite::BuiltinOperator_CONV_2D || opCode == tflite::BuiltinOperator_DEPTHWISE_CONV_2D ||
                 opCode == tflite::BuiltinOperator_TRANSPOSE_CONV) {
-                const int weightIndex    = ops[j]->inputs[1];
-                const auto& weightTensor = tensors[weightIndex];
+                if (ops[j]->inputs.size() < 2) {
+                    MNN_ERROR("[ERROR] Invalid TFLite Model: conv op has %zu inputs, need at least 2\n",
+                              ops[j]->inputs.size());
+                    MNNNetT.reset();
+                    return 1;
+                }
+                const int weightIndex = ops[j]->inputs[1];
+                const auto* weightTensor = tfliteAt(tensors, weightIndex, "tensor");
+                if (nullptr == weightTensor) {
+                    MNNNetT.reset();
+                    return 1;
+                }
                 if (weightTensor->type == tflite::TensorType_UINT8) {
                     quantizedModel = 1;
                 } else if (weightTensor->type == tflite::TensorType_INT8) {
@@ -230,8 +263,12 @@ int tflite2MNNNet(const std::string inputModel, const std::string bizCode,
 
         // set input
         for (const auto index : tfliteModel->subgraphs[i]->inputs) {
+            const auto* inputTensor = tfliteAt(tensors, index, "tensor");
+            if (nullptr == inputTensor) {
+                MNNNetT.reset();
+                return 1;
+            }
             MNN::OpT* inputOp       = new MNN::OpT;
-            const auto& inputTensor = tensors[index];
             inputOp->name           = inputTensor->name;
             inputOp->type           = MNN::OpType_Input;
             inputOp->main.type      = MNN::OpParameter_Input;
@@ -247,7 +284,13 @@ int tflite2MNNNet(const std::string inputModel, const std::string bizCode,
 
         // set output names
         for (int k = 0; k < tfliteModel->subgraphs[i]->outputs.size(); ++k) {
-            MNNNetT->outputName.push_back(tensors[tfliteModel->subgraphs[i]->outputs[k]]->name);
+            int outIndex = tfliteModel->subgraphs[i]->outputs[k];
+            const auto* outputTensor = tfliteAt(tensors, outIndex, "tensor");
+            if (nullptr == outputTensor) {
+                MNNNetT.reset();
+                return 1;
+            }
+            MNNNetT->outputName.push_back(outputTensor->name);
         }
         // tensor names
         for (const auto& tensor : tensors) {
@@ -257,16 +300,28 @@ int tflite2MNNNet(const std::string inputModel, const std::string bizCode,
         const int opNums = ops.size();
         for (int j = 0; j < opNums; ++j) {
             const int opcodeIndex = ops[j]->opcode_index;
+            if (invalidTfliteIndex("opcode", opcodeIndex, static_cast<int>(tfliteOpSet.size()))) {
+                MNNNetT.reset();
+                return 1;
+            }
             auto opCode = liteOpConverter:: getOpCode(tfliteOpSet[opcodeIndex].get());
 
             if (needExtractInput(opCode)) {
                 for (auto input : ops[j]->inputs) {
-                    if (input < 0 || extractedTensors[input]) {
+                    if (input < 0 || input >= static_cast<int>(extractedTensors.size()) || extractedTensors[input]) {
                         continue;
                     }
                     extractedTensors[input] = true;
-                    auto& tensor = tfliteModel->subgraphs[i]->tensors[input];
-                    auto& buffer = buffers[tensor->buffer];
+                    const auto* tensor = tfliteAt(tfliteModel->subgraphs[i]->tensors, input, "tensor");
+                    if (nullptr == tensor) {
+                        MNNNetT.reset();
+                        return 1;
+                    }
+                    const auto* buffer = tfliteAt(buffers, static_cast<int>(tensor->buffer), "buffer");
+                    if (nullptr == buffer) {
+                        MNNNetT.reset();
+                        return 1;
+                    }
                     if (buffer->data.empty()) {
                         continue;
                     }
@@ -328,7 +383,13 @@ int tflite2MNNNet(const std::string inputModel, const std::string bizCode,
             if (opCode == tflite::BuiltinOperator_CUSTOM) {
                 const int inputSize = ops[j]->inputs.size();
                 for (int k = 0; k < inputSize; ++k) {
-                    _converteConstantDataToMNNConstantNode(ops[j]->inputs[k], tensors, tfliteModelBuffer, MNNNetT);
+                    if (ops[j]->inputs[k] < 0) {
+                        continue;
+                    }
+                    if (!_converteConstantDataToMNNConstantNode(ops[j]->inputs[k], tensors, tfliteModelBuffer, MNNNetT)) {
+                        MNNNetT.reset();
+                        return 1;
+                    }
                 }
             }
 
@@ -340,8 +401,20 @@ int tflite2MNNNet(const std::string inputModel, const std::string bizCode,
                 MNNNetT.reset();
                 return 0;
             }
+            if (ops[j]->outputs.empty()) {
+                MNN_ERROR("[ERROR] Invalid TFLite Model: op has no outputs\n");
+                delete op;
+                MNNNetT.reset();
+                return 1;
+            }
+            const auto* outputTensor = tfliteAt(tensors, ops[j]->outputs[0], "tensor");
+            if (nullptr == outputTensor) {
+                delete op;
+                MNNNetT.reset();
+                return 1;
+            }
             // tflite op to MNN op
-            op->name      = tensors[ops[j]->outputs[0]]->name;
+            op->name      = outputTensor->name;
             op->type      = creator->opType(quantizedModel);
             op->main.type = creator->type(quantizedModel);
             // set default input output index
@@ -349,10 +422,11 @@ int tflite2MNNNet(const std::string inputModel, const std::string bizCode,
                 if (quantizedModel != 2) {
                     return;
                 }
-                if (tensors[idx]->type != tflite::TensorType_INT8) {
+                const auto* tensor = tfliteAt(tensors, idx, "tensor");
+                if (nullptr == tensor || tensor->type != tflite::TensorType_INT8) {
                     return;
                 }
-                auto quant = tensors[idx]->quantization.get();
+                auto quant = tensor->quantization.get();
                 if (!quant) {
                     return;
                 }


### PR DESCRIPTION
Fail fast with a clear error when TFLite tensor/buffer/input/output indices are out of range, instead of crashing MNNConvert. Fixes #4795
