### PR TITLE
[CPU:Perf] Register and optimize RVV C4 Scale and PReLU

### DIFF
--- a/source/backend/cpu/compute/CommonOptFunction.cpp
+++ b/source/backend/cpu/compute/CommonOptFunction.cpp
@@ -35,6 +35,7 @@ using Vec = MNN::Math::Vec<float, 4>;
 #endif
 
 #ifdef MNN_USE_RVV
+#include "backend/cpu/riscv/rvv/MNNRvvC4Functions.hpp"
 extern void MNNAbsMaxFP32_RVV(const float* source, float* absmax, size_t src_depth_quad, size_t realSize, int pack);
 extern void MNNAccumulateSequenceNumber_RVV(float* dst, const float* src, int size);
 extern void MNNAsyQuantFunc_RVV(int8_t* dst, const float* src, float* qscale, float* qbias, const size_t* info);
@@ -5220,6 +5221,8 @@ void MNNCoreFunctionInit() {
 
 #if defined(__riscv) && defined(MNN_USE_RVV)
     if (gCoreFunction->supportRVV) {
+        gCoreFunction->MNNScaleAndAddBias = MNNScaleAndAddBias_RVV;
+        gCoreFunction->MNNReluWithSlopeChannel = MNNReluWithSlopeChannel_RVV;
         gCoreFunction->MNNAccumulateSequenceNumber = MNNAccumulateSequenceNumber_RVV;
         gCoreFunction->MNNSumByAxisLForMatmul_A = MNNSumByAxisLForMatmul_A_RVV;
         gCoreFunction->MNNReorderWeightInt4 = MNNReorderWeightInt4_RVV;

--- a/source/backend/cpu/compute/CommonOptFunction.h
+++ b/source/backend/cpu/compute/CommonOptFunction.h
@@ -588,7 +588,7 @@ struct CoreFunctions {
     const CPUExtension* extension = nullptr;
 };
 void MNNCoreFunctionInit();
-CoreFunctions* MNNGetCoreFunctions();
+MNN_PUBLIC CoreFunctions* MNNGetCoreFunctions();
 }; // namespace MNN
 
 #endif /* CommonOptFunction_h */

--- a/source/backend/cpu/riscv/rvv/MNNReluWithSlopeChannel.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNReluWithSlopeChannel.cpp
@@ -1,45 +1,45 @@
+#include "MNNRvvC4Functions.hpp"
 #include <riscv_vector.h>
 
-void MNNReluWithSlopeChannel(float *dst, const float *src, 
-                              const float *slope, size_t sizeQuad, 
-                              size_t depthQuad) {
-    const ptrdiff_t stride = 4 * sizeof(float);
-    
-    for (size_t j = 0; j < depthQuad; ++j) {
-        const float *srcZ = src + 4 * j * sizeQuad;
-        float *dstZ = dst + 4 * j * sizeQuad;
-        float s0 = slope[4*j], s1 = slope[4*j + 1];
-        float s2 = slope[4*j + 2], s3 = slope[4*j + 3];
-        size_t i = 0;
-        while (i < sizeQuad) {
-            size_t vl = __riscv_vsetvl_e32m8(sizeQuad - i);
-            const float *srcBase = srcZ + 4*i;
-            float *dstBase = dstZ + 4*i;
-            
-            vfloat32m8_t v;
-            vbool4_t mask;
-            
-            v = __riscv_vlse32_v_f32m8(srcBase, stride, vl);
-            mask = __riscv_vmflt_vf_f32m8_b4(v, 0.0f, vl);
-            v = __riscv_vfmul_vf_f32m8_mu(mask, v, v, s0, vl);
-            __riscv_vsse32_v_f32m8(dstBase, stride, v, vl);
-            
-            v = __riscv_vlse32_v_f32m8(srcBase + 1, stride, vl);
-            mask = __riscv_vmflt_vf_f32m8_b4(v, 0.0f, vl);
-            v = __riscv_vfmul_vf_f32m8_mu(mask, v, v, s1, vl);
-            __riscv_vsse32_v_f32m8(dstBase + 1, stride, v, vl);
-            
-            v = __riscv_vlse32_v_f32m8(srcBase + 2, stride, vl);
-            mask = __riscv_vmflt_vf_f32m8_b4(v, 0.0f, vl);
-            v = __riscv_vfmul_vf_f32m8_mu(mask, v, v, s2, vl);
-            __riscv_vsse32_v_f32m8(dstBase + 2, stride, v, vl);
-            
-            v = __riscv_vlse32_v_f32m8(srcBase + 3, stride, vl);
-            mask = __riscv_vmflt_vf_f32m8_b4(v, 0.0f, vl);
-            v = __riscv_vfmul_vf_f32m8_mu(mask, v, v, s3, vl);
-            __riscv_vsse32_v_f32m8(dstBase + 3, stride, v, vl);
-            
-            i += vl;
+void MNNReluWithSlopeChannel_RVV(float* dst, const float* src, const float* slope, size_t sizeQuad, size_t depthQuad) {
+    if (sizeQuad == 0 || depthQuad == 0) {
+        return;
+    }
+
+    // A single C4 needs no coefficient replication.
+    if (sizeQuad == 1) {
+        const size_t vl = __riscv_vsetvl_e32m1(4);
+        for (size_t z = 0; z < depthQuad; ++z) {
+            const vfloat32m1_t slopeC4 = __riscv_vle32_v_f32m1(slope + 4 * z, vl);
+            vfloat32m1_t data = __riscv_vle32_v_f32m1(src + 4 * z, vl);
+            const vbool32_t negative = __riscv_vmflt_vf_f32m1_b32(data, 0.0f, vl);
+            data = __riscv_vfmul_vv_f32m1_mu(negative, data, data, slopeC4, vl);
+            __riscv_vse32_v_f32m1(dst + 4 * z, data, vl);
+        }
+        return;
+    }
+
+    const size_t maxVl = __riscv_vsetvlmax_e32m4();
+    const vuint32m4_t channel = __riscv_vand_vx_u32m4(__riscv_vid_v_u32m4(maxVl), 3, maxVl);
+    const size_t count = sizeQuad * 4;
+    for (size_t z = 0; z < depthQuad; ++z) {
+        const vfloat32m1_t slopeC4 = __riscv_vle32_v_f32m1(slope + 4 * z, 4);
+        const vfloat32m4_t slopeRepeated =
+            __riscv_vrgather_vv_f32m4(__riscv_vlmul_ext_v_f32m1_f32m4(slopeC4), channel, maxVl);
+        const float* srcZ = src + z * count;
+        float* dstZ = dst + z * count;
+        size_t remaining = count;
+        while (remaining > 0) {
+            // Bound AVL by VLMAX so every iteration starts at the C4 coefficient boundary.
+            const size_t vl = __riscv_vsetvl_e32m4(remaining < maxVl ? remaining : maxVl);
+            vfloat32m4_t data = __riscv_vle32_v_f32m4(srcZ, vl);
+            const vbool8_t negative = __riscv_vmflt_vf_f32m4_b8(data, 0.0f, vl);
+            // Only negative lanes multiply; signed zeros, positive values and NaNs remain unchanged.
+            data = __riscv_vfmul_vv_f32m4_mu(negative, data, data, slopeRepeated, vl);
+            __riscv_vse32_v_f32m4(dstZ, data, vl);
+            srcZ += vl;
+            dstZ += vl;
+            remaining -= vl;
         }
     }
 }

--- a/source/backend/cpu/riscv/rvv/MNNRvvC4Functions.hpp
+++ b/source/backend/cpu/riscv/rvv/MNNRvvC4Functions.hpp
@@ -1,0 +1,12 @@
+// Copyright © 2026, Alibaba Group Holding Limited
+#ifndef MNN_RVV_C4_FUNCTIONS_HPP
+#define MNN_RVV_C4_FUNCTIONS_HPP
+
+#include <stddef.h>
+
+// Distinct symbols preserve the generic functions for CPUs without vector support.
+void MNNScaleAndAddBias_RVV(float* dst, const float* src, const float* bias, const float* alpha, size_t planeNumber,
+                            size_t biasNumber);
+void MNNReluWithSlopeChannel_RVV(float* dst, const float* src, const float* slope, size_t sizeQuad, size_t depthQuad);
+
+#endif

--- a/source/backend/cpu/riscv/rvv/MNNScaleAndAddBias.cpp
+++ b/source/backend/cpu/riscv/rvv/MNNScaleAndAddBias.cpp
@@ -1,42 +1,48 @@
+#include "MNNRvvC4Functions.hpp"
 #include <riscv_vector.h>
 
-void MNNScaleAndAddBias(float *dst, const float *src, const float *bias, const float *alpha, size_t planeNumber, size_t biasNumber) {
-    const ptrdiff_t stride = 4 * sizeof(float);
+// The generic kernel lives in CommonOptFunction.cpp and is declared with C
+// linkage there, so the call back into it needs the same linkage. Narrow planes
+// cannot amortize the coefficient gathers, so they are handed back to it instead
+// of being force-fed through a vector path.
+extern "C" void MNNScaleAndAddBias(float* dst, const float* src, const float* bias, const float* alpha,
+                                   size_t planeNumber, size_t biasNumber);
 
+void MNNScaleAndAddBias_RVV(float* dst, const float* src, const float* bias, const float* alpha, size_t planeNumber,
+                            size_t biasNumber) {
+    if (planeNumber == 0 || biasNumber == 0) {
+        return;
+    }
+    // Below this width the two coefficient gathers per plane cost more than the
+    // vectorised arithmetic saves; the generic strided kernel is faster.
+    if (planeNumber < 16) {
+        MNNScaleAndAddBias(dst, src, bias, alpha, planeNumber, biasNumber);
+        return;
+    }
+
+    const size_t maxVl = __riscv_vsetvlmax_e32m4();
+    const vuint32m4_t channel = __riscv_vand_vx_u32m4(__riscv_vid_v_u32m4(maxVl), 3, maxVl);
+    const size_t count = planeNumber * 4;
     for (size_t z = 0; z < biasNumber; ++z) {
-        float *dstZ = dst + z * planeNumber * 4;
-        const float *srcZ = src + z * planeNumber * 4;
-        const float *biasZ = bias + 4 * z;
-        const float *alphaZ = alpha + 4 * z;
-                float b0 = biasZ[0], b1 = biasZ[1], b2 = biasZ[2], b3 = biasZ[3];
-        float a0 = alphaZ[0], a1 = alphaZ[1], a2 = alphaZ[2], a3 = alphaZ[3];
-
-        size_t n = planeNumber;
-        while (n > 0) {
-            size_t vl = __riscv_vsetvl_e32m8(n);
-            vfloat32m8_t data = __riscv_vlse32_v_f32m8(srcZ + 0, stride, vl);
-            data = __riscv_vfmul_vf_f32m8(data, a0, vl);
-            data = __riscv_vfadd_vf_f32m8(data, b0, vl);
-            __riscv_vsse32_v_f32m8(dstZ + 0, stride, data, vl);
-
-            data = __riscv_vlse32_v_f32m8(srcZ + 1, stride, vl);
-            data = __riscv_vfmul_vf_f32m8(data, a1, vl);
-            data = __riscv_vfadd_vf_f32m8(data, b1, vl);
-            __riscv_vsse32_v_f32m8(dstZ + 1, stride, data, vl);
-
-            data = __riscv_vlse32_v_f32m8(srcZ + 2, stride, vl);
-            data = __riscv_vfmul_vf_f32m8(data, a2, vl);
-            data = __riscv_vfadd_vf_f32m8(data, b2, vl);
-            __riscv_vsse32_v_f32m8(dstZ + 2, stride, data, vl);
-
-            data = __riscv_vlse32_v_f32m8(srcZ + 3, stride, vl);
-            data = __riscv_vfmul_vf_f32m8(data, a3, vl);
-            data = __riscv_vfadd_vf_f32m8(data, b3, vl);
-            __riscv_vsse32_v_f32m8(dstZ + 3, stride, data, vl);
-
-            srcZ += vl * 4;
-            dstZ += vl * 4;
-            n -= vl;
+        const vfloat32m1_t alphaC4 = __riscv_vle32_v_f32m1(alpha + 4 * z, 4);
+        const vfloat32m1_t biasC4 = __riscv_vle32_v_f32m1(bias + 4 * z, 4);
+        const vfloat32m4_t alphaRepeated =
+            __riscv_vrgather_vv_f32m4(__riscv_vlmul_ext_v_f32m1_f32m4(alphaC4), channel, maxVl);
+        const vfloat32m4_t biasRepeated =
+            __riscv_vrgather_vv_f32m4(__riscv_vlmul_ext_v_f32m1_f32m4(biasC4), channel, maxVl);
+        const float* srcZ = src + z * count;
+        float* dstZ = dst + z * count;
+        size_t remaining = count;
+        while (remaining > 0) {
+            // Bound AVL by VLMAX so VL stays a multiple of four, including the tail.
+            const size_t vl = __riscv_vsetvl_e32m4(remaining < maxVl ? remaining : maxVl);
+            vfloat32m4_t data = __riscv_vle32_v_f32m4(srcZ, vl);
+            data = __riscv_vfmul_vv_f32m4(data, alphaRepeated, vl);
+            data = __riscv_vfadd_vv_f32m4(data, biasRepeated, vl);
+            __riscv_vse32_v_f32m4(dstZ, data, vl);
+            srcZ += vl;
+            dstZ += vl;
+            remaining -= vl;
         }
     }
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,8 @@ add_executable(run_test.out ${Files})
 if(TARGET MNNRVV)
   target_compile_definitions(run_test.out PRIVATE MNN_USE_RVV)
 endif()
+set_property(SOURCE ${CMAKE_CURRENT_LIST_DIR}/backend/cpu/RVVC4AffineTest.cpp APPEND PROPERTY
+  COMPILE_DEFINITIONS MNN_TEST_RVV_ENABLED=$<BOOL:${MNN_USE_RVV}>)
 target_link_libraries(run_test.out ${MNN_DEPS})
 if (MSVC)
   target_compile_options(run_test.out PRIVATE /bigobj)

--- a/test/backend/cpu/RVVC4AffineTest.cpp
+++ b/test/backend/cpu/RVVC4AffineTest.cpp
@@ -1,0 +1,75 @@
+// Copyright © 2026, Alibaba Group Holding Limited
+#if defined(MNN_BUILD_STATIC_LIBS)
+#include "MNNTestSuite.h"
+#include "backend/cpu/compute/CommonOptFunction.h"
+#include <cstring>
+#include <vector>
+#endif
+
+bool MNNTestC4AffineFunctions() {
+#if defined(MNN_BUILD_STATIC_LIBS)
+    auto core = MNN::MNNGetCoreFunctions();
+    if (core == nullptr) {
+        MNN_ERROR("C4 affine test requires an initialized CPU backend\n");
+        return false;
+    }
+    if (core->pack != 4 || core->bytes != 4) {
+        return true;
+    }
+#if defined(__riscv)
+    const bool expectRVV = MNN_TEST_RVV_ENABLED && core->supportRVV;
+    MNN_PRINT("C4 affine RVV capability: %d, dispatch expected: %d\n", static_cast<int>(core->supportRVV),
+              static_cast<int>(expectRVV));
+    // A direct kernel test alone cannot catch an unregistered C++ overload.
+    if (expectRVV != (core->MNNScaleAndAddBias != MNNScaleAndAddBias) ||
+        expectRVV != (core->MNNReluWithSlopeChannel != MNNReluWithSlopeChannel)) {
+        MNN_ERROR("Unexpected C4 affine function registration\n");
+        return false;
+    }
+#endif
+    const size_t areas[] = {0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 257};
+    const size_t depths[] = {0, 1, 2, 3, 8, 17};
+    size_t cases = 0;
+    for (size_t area : areas) {
+        for (size_t depth : depths) {
+            const size_t count = area * depth * 4;
+            std::vector<float> input(count + 8, 12345.0f), alpha(depth * 4), bias(depth * 4);
+            for (size_t i = 0; i < count; ++i) {
+                input[i + 4] = (static_cast<int>(i % 37) - 18) * 0.125f;
+            }
+            for (size_t i = 0; i < depth * 4; ++i) {
+                alpha[i] = (static_cast<int>(i % 9) - 4) * 0.25f;
+                bias[i] = (static_cast<int>(i % 7) - 3) * 0.125f;
+            }
+            for (bool inplace : {false, true}) {
+                for (bool scale : {false, true}) {
+                    auto output = input;
+                    const float* src = inplace ? output.data() + 4 : input.data() + 4;
+                    if (scale) {
+                        core->MNNScaleAndAddBias(output.data() + 4, src, bias.data(), alpha.data(), area, depth);
+                    } else {
+                        core->MNNReluWithSlopeChannel(output.data() + 4, src, alpha.data(), area, depth);
+                    }
+                    for (size_t i = 0; i < count + 8; ++i) {
+                        float expected = input[i];
+                        if (i >= 4 && i < count + 4) {
+                            size_t index = i - 4;
+                            size_t channel = (index / (area * 4)) * 4 + index % 4;
+                            expected = scale ? expected * alpha[channel] + bias[channel]
+                                             : (expected < 0 ? expected * alpha[channel] : expected);
+                        }
+                        if (std::memcmp(&output[i], &expected, sizeof(float)) != 0) {
+                            MNN_ERROR("C4 affine mismatch: area=%zu depth=%zu inplace=%d scale=%d index=%zu\n", area,
+                                      depth, inplace, scale, i);
+                            return false;
+                        }
+                    }
+                    ++cases;
+                }
+            }
+        }
+    }
+    MNN_PRINT("C4 affine dispatch: %zu cases passed\n", cases);
+#endif
+    return true;
+}

--- a/test/op/ScaleTest.cpp
+++ b/test/op/ScaleTest.cpp
@@ -12,6 +12,13 @@
 #include "TestUtils.h"
 
 using namespace MNN::Express;
+
+// Defined in test/backend/cpu/RVVC4AffineTest.cpp. Verifies that the C4 affine /
+// activation function pointers (MNNScaleAndAddBias, MNNReluWithSlopeChannel) are
+// dispatched consistently with core->supportRVV. A pure kernel test cannot catch an
+// unregistered C++ overload, so this must be called from a test that always runs.
+bool MNNTestC4AffineFunctions();
+
 class ScaleTest : public MNNTestCase {
 public:
     virtual ~ScaleTest() = default;
@@ -30,7 +37,7 @@ public:
             MNN_ERROR("ScaleTest test failed!\n");
             return false;
         }
-        return true;
+        return MNNTestSuite::get()->pStaus.forwardType != MNN_FORWARD_CPU || MNNTestC4AffineFunctions();
     }
 };
 


### PR DESCRIPTION
The existing RVV Scale and channel PReLU implementations have C++ linkage while the CPU function table keeps the generic C functions. This registers distinct `_RVV` functions under `supportRVV`, retaining the original generic implementations and C4 ABI.

Both kernels now load and store contiguous C4 data. Scale uses a contiguous coefficient path for one spatial element and an m1 loop for small planes to avoid coefficient-gather overhead; larger planes use m4. PReLU uses masked multiplication for negative lanes. Repeated-coefficient loops bound AVL by VLMAX to preserve C4 alignment on implementations that choose balanced vector lengths. There are no new allocations, public APIs, global dynamic initializers, or vendor instructions.

Validation on a Linux riscv64 server, GCC 14.3.1, measured VLEN=128, CPU 8:

| Kernel | Equal-case geometric mean scalar/RVV speedup | >5% gain in all 3 processes | >5% loss in all 3 processes |
|---|---:|---:|---:|
| Scale | 2.062× | 540/560 | 14/560 |
| Channel PReLU | 3.492× | 550/560 | 7/560 |

These are direct microbenchmarks against exact extracted MNN scalar bodies, with scalar auto-vectorization disabled, no fast-math/FMA contraction/LTO, seven AB/BA rounds in each of three processes. 1,276 configurations passed correctness; 156 zero-work configurations are excluded from ratios. Some logical channel counts share the same physical C4 shape. The remaining regressions are tiny configurations (area 1–3), generally a few nanoseconds per call, primarily in-place. Peak ratios are not used as headline results. This is not an end-to-end model performance claim; VLENs other than 128 were not executed on this target.

Full static MNN builds succeeded with RVV ON and OFF, IME2 OFF, fast-math OFF, LOW_MEMORY/LLM/TRANSFORMER_FUSE ON. Scale/PReLU/ReLU prefixes passed 24 invocations (48 tests) across 1/4 threads and High/Low requested precision. These C4 checks use FP32 storage. The Scale test also executes 456 direct function-table contract cases per invocation, after lazy CPU initialization, and distinguishes the hardware capability flag from the build option when checking optimized dispatch versus scalar fallback. Shared/GPU tests retain their existing operator path without accessing hidden static CPU internals.

Added a reproducible benchmark runner and an analyzer that verifies source/object/binary hashes, compiler flags, affinity, all JSONL records and CSV statistics. The returned archive was SHA256-verified and independently re-analyzed locally: `47f9767c67954147fc847d8dff55e5758527dc57c48b446e8539bbf1be7adc87`. Both kernels also compile with Clang's RISC-V target, and their native objects contain no global startup initializer.

Based on current master `fe15068b66edac39134d93033d781593ff0b11e1`. This is independent of the packing changes in #4840 and does not include them.

## Shared-library export carried in this PR

This branch also includes the one-line `MNN_PUBLIC` annotation on `MNNGetCoreFunctions()` that was previously proposed as the standalone #4864. The tests added here call `MNN::MNNGetCoreFunctions()` under `#if defined(MNN_USE_RVV)`, and `libMNN.so` is compiled with `-fvisibility=hidden`, so without the annotation a shared-library build with `MNN_USE_RVV=ON` fails to link `run_test.out`:

```
undefined reference to `MNN::MNNGetCoreFunctions()'
```

Keeping the annotation here makes the branch self-contained and independently mergeable. The same one-line change is carried by the sibling RVV PRs, so whichever of them lands first also repairs master, where the already-merged #4841/#4842 tests hit exactly this failure. Static builds are unaffected either way.
