### PR TITLE
[CPU:Bugfix] Export MNNGetCoreFunctions for shared-library RVV test builds

### DIFF
--- a/source/backend/cpu/compute/CommonOptFunction.h
+++ b/source/backend/cpu/compute/CommonOptFunction.h
@@ -588,7 +588,7 @@ struct CoreFunctions {
     const CPUExtension* extension = nullptr;
 };
 void MNNCoreFunctionInit();
-CoreFunctions* MNNGetCoreFunctions();
+MNN_PUBLIC CoreFunctions* MNNGetCoreFunctions();
 }; // namespace MNN
 
 #endif /* CommonOptFunction_h */


### PR DESCRIPTION
## Summary

This fixes a shared-library build regression that our merged PRs #4841 and #4842 introduced, for which we apologize. The regression breaks `run_test.out` linking when MNN is built as a shared library with `MNN_USE_RVV=ON`.

## Root cause

PRs #4842 and #4841 added `test/backend/cpu/RVVLinearAttentionTest.cpp` and `RVVAttentionMaskTest.cpp`, and #4842 also changed `test/CMakeLists.txt` to define `MNN_USE_RVV` on `run_test.out` when the `MNNRVV` target exists. With that macro active, both tests reference `MNN::MNNGetCoreFunctions()`. However, `libMNN.so` is compiled with `-fvisibility=hidden` and this symbol has no visibility annotation, so it is not exported from the shared library (`nm -D` confirms). The link therefore fails with `undefined reference to MNN::MNNGetCoreFunctions()` on any default shared-library build with RVV enabled. Static builds are unaffected, which is why this was not caught earlier. A pure master tree reproduces the failure independently of any other PR.

## Fix

A minimal one-line change: annotate the `MNNGetCoreFunctions()` declaration in `source/backend/cpu/compute/CommonOptFunction.h` with the existing `MNN_PUBLIC` macro (`__attribute__((visibility("default")))` on non-MSVC), so the symbol is exported from the shared library and the RVV tests can resolve it. No behavior change for static builds or for the library's internal callers.

## Verification

On a riscv64 board (openEuler 24.03, GCC 14.3.1, VLEN=128):

- Pure master `a03b005c`, shared library + `MNN_USE_RVV=ON`: `run_test.out` fails to link with `undefined reference to MNN::MNNGetCoreFunctions()` (reproduces the regression).
- With this fix applied, the same configuration builds successfully, and `backend/cpu/rvv/attention_mask` and `backend/cpu/rvv/linear_attention` tests run through the normal `run_test.out` path.
- Static builds with `MNN_USE_RVV=ON`/`OFF` remain unaffected.

## Module

CPU/Core

## Type

- [x] Bugfix
